### PR TITLE
Ignore Flush operations in Pipeline#run()

### DIFF
--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -6,6 +6,7 @@ from ..schema.schema import (
     AggregatedIntrospectiveIngestionComponent,
     IntrospectiveIngestionComponent,
 )
+from .flush import Flush
 from .step import Step
 
 
@@ -29,7 +30,8 @@ class Pipeline(AggregatedIntrospectiveIngestionComponent):
             empty_async_generator(),
         )
         async for record in record_stream_over_all_steps:
-            yield record
+            if record is not Flush:
+                yield record
 
         await self.finish()
 


### PR DESCRIPTION
We need to ignore flushes when outputting the stream of resultant records from neo4j. 