### PR TITLE
Refactor: Introduce Database Connectors Concept

### DIFF
--- a/nodestream/databases/database_connector.py
+++ b/nodestream/databases/database_connector.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+from ..pluggable import Pluggable
+from ..subclass_registry import SubclassRegistry
+from .query_executor import QueryExecutor
+from .query_executor_with_statistics import QueryExecutorWithStatistics
+
+DATABASE_CONNECTOR_SUBCLASS_REGISTRY = SubclassRegistry()
+
+
+@DATABASE_CONNECTOR_SUBCLASS_REGISTRY.connect_baseclass
+class DatabaseConnector(ABC, Pluggable):
+    entrypoint_name = "databases"
+
+    @classmethod
+    def from_database_args(
+        cls, database: str = "neo4j", **database_args
+    ) -> "DatabaseConnector":
+        return DATABASE_CONNECTOR_SUBCLASS_REGISTRY.get(database).from_file_data(
+            **database_args
+        )
+
+    @classmethod
+    def from_file_data(cls, **kwargs):
+        return cls(**kwargs)
+
+    @abstractmethod
+    def make_query_executor(self) -> QueryExecutor:
+        raise NotImplementedError
+
+    def get_query_executor(self, collect_stats: bool = True):
+        connector = self.make_query_executor()
+        if collect_stats:
+            connector = QueryExecutorWithStatistics(connector)
+        return connector

--- a/nodestream/databases/neo4j/__init__.py
+++ b/nodestream/databases/neo4j/__init__.py
@@ -1,4 +1,3 @@
-from .ingest_query_builder import Neo4jIngestQueryBuilder
-from .query_executor import Neo4jQueryExecutor
+from .database_connector import Neo4jDatabaseConnector
 
-__all__ = ("Neo4jQueryExecutor", "Neo4jIngestQueryBuilder")
+__all__ = ("Neo4jDatabaseConnector",)

--- a/nodestream/databases/neo4j/database_connector.py
+++ b/nodestream/databases/neo4j/database_connector.py
@@ -1,0 +1,53 @@
+from neo4j import AsyncDriver, AsyncGraphDatabase
+
+from ..database_connector import DatabaseConnector
+from ..query_executor import QueryExecutor
+from .index_query_builder import (
+    Neo4jEnterpriseIndexQueryBuilder,
+    Neo4jIndexQueryBuilder,
+)
+from .ingest_query_builder import Neo4jIngestQueryBuilder
+from .query_executor import Neo4jQueryExecutor
+
+
+class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
+    @classmethod
+    def from_file_data(
+        cls,
+        uri: str,
+        username: str,
+        password: str,
+        database_name: str = "neo4j",
+        use_enterprise_features: bool = False,
+    ):
+        driver = AsyncGraphDatabase.driver(uri, auth=(username, password))
+        if use_enterprise_features:
+            index_query_builder = Neo4jEnterpriseIndexQueryBuilder()
+        else:
+            index_query_builder = Neo4jIndexQueryBuilder()
+        return cls(
+            driver=driver,
+            index_query_builder=index_query_builder,
+            ingest_query_builder=Neo4jIngestQueryBuilder(),
+            database_name=database_name,
+        )
+
+    def __init__(
+        self,
+        driver: AsyncDriver,
+        index_query_builder: Neo4jIndexQueryBuilder,
+        ingest_query_builder: Neo4jIngestQueryBuilder,
+        database_name: str,
+    ) -> None:
+        self.driver = driver
+        self.index_query_builder = index_query_builder
+        self.ingest_query_builder = ingest_query_builder
+        self.database_name = database_name
+
+    def make_query_executor(self) -> QueryExecutor:
+        return Neo4jQueryExecutor(
+            self.driver,
+            self.ingest_query_builder,
+            self.index_query_builder,
+            self.database_name,
+        )

--- a/nodestream/databases/query_executor.py
+++ b/nodestream/databases/query_executor.py
@@ -11,11 +11,7 @@ from ..model import (
     RelationshipWithNodes,
     TimeToLiveConfiguration,
 )
-from ..pluggable import Pluggable
 from ..schema.indexes import FieldIndex, KeyIndex
-from ..subclass_registry import SubclassRegistry
-
-QUERY_EXECUTOR_SUBCLASS_REGISTRY = SubclassRegistry()
 
 
 @dataclass(slots=True, frozen=True)
@@ -31,20 +27,7 @@ class OperationOnRelationshipIdentity:
     relationship_identity: RelationshipIdentityShape
 
 
-@QUERY_EXECUTOR_SUBCLASS_REGISTRY.connect_baseclass
-class QueryExecutor(ABC, Pluggable):
-    entrypoint_name = "databases"
-
-    @classmethod
-    def from_database_args(cls, database: str = "neo4j", **database_args):
-        return QUERY_EXECUTOR_SUBCLASS_REGISTRY.get(database).from_file_data(
-            **database_args
-        )
-
-    @classmethod
-    def from_file_data(cls, **kwargs):
-        return cls(**kwargs)
-
+class QueryExecutor(ABC):
     @abstractmethod
     async def upsert_nodes_in_bulk_with_same_operation(
         self, operation: OperationOnNodeIdentity, nodes: Iterable[Node]

--- a/nodestream/databases/writer.py
+++ b/nodestream/databases/writer.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ..pipeline import Flush, Writer
 from .database_connector import DatabaseConnector
 from .debounced_ingest_strategy import DebouncedIngestStrategy

--- a/nodestream/databases/writer.py
+++ b/nodestream/databases/writer.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
 from ..pipeline import Flush, Writer
+from .database_connector import DatabaseConnector
 from .debounced_ingest_strategy import DebouncedIngestStrategy
 from .ingest_strategy import INGESTION_STRATEGY_REGISTRY, IngestionStrategy
-from .query_executor import QUERY_EXECUTOR_SUBCLASS_REGISTRY, QueryExecutor
-from .query_executor_with_statistics import QueryExecutorWithStatistics
 
 
 class GraphDatabaseWriter(Writer):
@@ -13,22 +12,18 @@ class GraphDatabaseWriter(Writer):
         cls,
         batch_size: int,
         database: str,
-        ingest_strategy_name: Optional[str] = None,
+        ingest_strategy_name: str = INGESTION_STRATEGY_REGISTRY.name_for(
+            DebouncedIngestStrategy
+        ),
         collect_stats: bool = True,
         **database_args
     ):
         # Import all query executors so that they can register themselves
-        QueryExecutor.import_all()
-
-        executor_class = QUERY_EXECUTOR_SUBCLASS_REGISTRY.get(database)
-        executor = executor_class.from_file_data(**database_args)
-        if collect_stats:
-            executor = QueryExecutorWithStatistics(executor)
-
-        ingest_strategy_name = (
-            ingest_strategy_name
-            or INGESTION_STRATEGY_REGISTRY.name_for(DebouncedIngestStrategy)
+        DatabaseConnector.import_all()
+        connector = DatabaseConnector.from_database_args(
+            database=database, **database_args
         )
+        executor = connector.get_query_executor(collect_stats=collect_stats)
         ingest_strategy_cls = INGESTION_STRATEGY_REGISTRY.get(ingest_strategy_name)
         ingest_strategy = ingest_strategy_cls(executor)
 

--- a/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
+++ b/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
@@ -4,7 +4,7 @@ import pytest
 from freezegun import freeze_time
 from hamcrest import assert_that, equal_to, equal_to_ignoring_whitespace
 
-from nodestream.databases.neo4j import Neo4jIngestQueryBuilder
+from nodestream.databases.neo4j.ingest_query_builder import Neo4jIngestQueryBuilder
 from nodestream.databases.neo4j.query import Query, QueryBatch
 from nodestream.databases.query_executor import (
     OperationOnNodeIdentity,

--- a/tests/unit/databases/neo4j/test_query_executor.py
+++ b/tests/unit/databases/neo4j/test_query_executor.py
@@ -1,7 +1,7 @@
 import pytest
 
-from nodestream.databases.neo4j import Neo4jQueryExecutor
 from nodestream.databases.neo4j.query import Query, QueryBatch
+from nodestream.databases.neo4j.query_executor import Neo4jQueryExecutor
 from nodestream.model import TimeToLiveConfiguration
 from nodestream.schema.schema import GraphObjectType
 


### PR DESCRIPTION
Due to our future plans of having migrations and other deeper integrations with internals of the database, this PR introduces a `DatabaseConnector` class that represents the integration point between a database and nodestream. With features like the migrations and more advanced indexing support, we are likely going to need to grow the interface beyond what the `QueryExecutor` is designed to do. The new `DatabaseConnector` class can act as the top level interface a database implementation needs to implement.

In short, instead of the `GraphDatabaseWriter` creating a `QueryExecutor` directly, it creates a `DatabaseConnector` and asks the `DatabaseConnector` to create a `QueryExecutor`.  