### PR TITLE
Improve Plugin Docs

### DIFF
--- a/docs/docs/guides/creating-your-own-argument-resolver.md
+++ b/docs/docs/guides/creating-your-own-argument-resolver.md
@@ -50,6 +50,12 @@ Depending on how you are building your package, you can register your Argument R
     argument_resolvers = "nodestream_plugin_cool.argument_resolvers"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    argument_resolvers = "nodestream_plugin_cool.argument_resolvers"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/creating-your-own-audits.md
+++ b/docs/docs/guides/creating-your-own-audits.md
@@ -62,7 +62,7 @@ Depending on how you are building your package, you can register your audit plug
     ```ini
     [options.entry_points]
     nodestream.plugins =
-        project = nodestream_plugin_cool.audits
+        audits = nodestream_plugin_cool.audits
     ```
 
 === "setup.py"
@@ -73,7 +73,7 @@ Depending on how you are building your package, you can register your audit plug
         # ...,
         entry_points = {
             'nodestream.plugins': [
-                'project = nodestream_plugin_cool.audits',
+                'audits = nodestream_plugin_cool.audits',
             ]
         }
     )

--- a/docs/docs/guides/creating-your-own-audits.md
+++ b/docs/docs/guides/creating-your-own-audits.md
@@ -52,6 +52,12 @@ Depending on how you are building your package, you can register your audit plug
     audits = "nodestream_plugin_cool.audits"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    audits = "nodestream_plugin_cool.audits"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/creating-your-own-commands.md
+++ b/docs/docs/guides/creating-your-own-commands.md
@@ -97,7 +97,7 @@ Depending on how you are building your package, you can register your command pl
     ```ini
     [options.entry_points]
     nodestream.plugins =
-        project = nodestream_plugin_cool.audits
+        commands = nodestream_plugin_cool.audits
     ```
 
 === "setup.py"
@@ -108,7 +108,7 @@ Depending on how you are building your package, you can register your command pl
         # ...,
         entry_points = {
             'nodestream.plugins': [
-                'project = nodestream_plugin_cool.audits',
+                'commands = nodestream_plugin_cool.audits',
             ]
         }
     )

--- a/docs/docs/guides/creating-your-own-commands.md
+++ b/docs/docs/guides/creating-your-own-commands.md
@@ -84,7 +84,13 @@ Depending on how you are building your package, you can register your command pl
 === "pyproject.toml"
     ```toml
     [project.entry-points."nodestream.plugins"]
-    audits = "nodestream_plugin_cool.audits"
+    commands = "nodestream_plugin_cool.commands"
+    ```
+
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    commands = "nodestream_plugin_cool.commands"
     ```
 
 === "setup.cfg"

--- a/docs/docs/guides/creating-your-own-file-format-handler.md
+++ b/docs/docs/guides/creating-your-own-file-format-handler.md
@@ -48,6 +48,12 @@ Depending on how you are building your package, you can register your file forma
     file_formats = "nodestream_plugin_cool.file_formats"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    file_formats = "nodestream_plugin_cool.file_formats"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/creating-your-own-interpretation.md
+++ b/docs/docs/guides/creating-your-own-interpretation.md
@@ -76,6 +76,12 @@ Depending on how you are building your package, you can register your `Interpret
     interpretations = "nodestream_plugin_cool.interpretations"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    interpretations = "nodestream_plugin_cool.interpretations"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/creating-your-own-normalizer.md
+++ b/docs/docs/guides/creating-your-own-normalizer.md
@@ -32,6 +32,12 @@ Depending on how you are building your package, you can register your `Normalize
     normalizers = "nodestream_plugin_cool.normalizers"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    normalizers = "nodestream_plugin_cool.normalizers"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/creating-your-own-value-provider.md
+++ b/docs/docs/guides/creating-your-own-value-provider.md
@@ -84,6 +84,12 @@ Depending on how you are building your package, you can register your Value Prov
     value_providers = "nodestream_plugin_cool.value_providers"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    value_providers = "nodestream_plugin_cool.value_providers"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/customizing-the-stream-extractor.md
+++ b/docs/docs/guides/customizing-the-stream-extractor.md
@@ -43,6 +43,12 @@ Depending on how you are building your package, you can register your stream con
     stream_connectors = "nodestream_plugin_cool.stream_connectors"
     ```
 
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    stream_connectors = "nodestream_plugin_cool.stream_connectors"
+    ```
+
 === "setup.cfg"
     ```ini
     [options.entry_points]

--- a/docs/docs/guides/project-plugins.md
+++ b/docs/docs/guides/project-plugins.md
@@ -66,14 +66,20 @@ Depending on how you are building your package, you can register your project pl
 === "pyproject.toml"
     ```toml
     [project.entry-points."nodestream.plugins"]
-    project = "nodestream_plugin_cool:MyProjectPlugin"
+    projects = "nodestream_plugin_cool:plugin"
+    ```
+
+=== "pyproject.toml (poetry)"
+    ```toml
+    [tool.poetry.plugins."nodestream.plugins"]
+    projects = "nodestream_plugin_cool.plugin"
     ```
 
 === "setup.cfg"
     ```ini
     [options.entry_points]
     nodestream.plugins =
-        project = nodestream_plugin_cool:MyProjectPlugin
+        projects = nodestream_plugin_cool:MyProjectPlugin
     ```
 
 === "setup.py"
@@ -84,7 +90,7 @@ Depending on how you are building your package, you can register your project pl
         # ...,
         entry_points = {
             'nodestream.plugins': [
-                'project = nodestream_plugin_cool:MyProjectPlugin',
+                'projects = nodestream_plugin_cool:MyProjectPlugin',
             ]
         }
     )


### PR DESCRIPTION
There were a handful of copy-paste issues. Also, the documentation indicates pyproject.toml support, but does not consider the way that `poetry` does packaging (Where it does not respect the project details). So, this adds an additional component that indicates how the user can use poetry since it is the default. 