### PR TITLE
Add `unit` test harness for argument resolvers

### DIFF
--- a/tests/unit/pipeline/argument_resolvers/conftest.py
+++ b/tests/unit/pipeline/argument_resolvers/conftest.py
@@ -1,0 +1,27 @@
+from typing import Type
+
+import pytest
+from yaml import SafeLoader, load
+
+from nodestream.pipeline.argument_resolvers import ArgumentResolver
+
+
+@pytest.fixture
+def yaml_loader_with_argument_resolver():
+    def _yaml_loader_with_argument_resolver(resolver: Type[ArgumentResolver]):
+        class ArgumentResolverLoader(SafeLoader):
+            pass
+
+        resolver.install_yaml_tag(ArgumentResolverLoader)
+        return ArgumentResolverLoader
+
+    return _yaml_loader_with_argument_resolver
+
+
+@pytest.fixture
+def load_file_with_resolver(yaml_loader_with_argument_resolver):
+    def _load_file_with_resolver(file_path: str, resolver: Type[ArgumentResolver]):
+        with open(file_path, "r") as f:
+            return load(f, Loader=yaml_loader_with_argument_resolver(resolver))
+
+    return _load_file_with_resolver

--- a/tests/unit/pipeline/argument_resolvers/fixtures/with_env.yaml
+++ b/tests/unit/pipeline/argument_resolvers/fixtures/with_env.yaml
@@ -1,0 +1,3 @@
+test:
+  env: !env TEST_ENV
+  not_env: 123

--- a/tests/unit/pipeline/argument_resolvers/test_environment_variable_resolver.py
+++ b/tests/unit/pipeline/argument_resolvers/test_environment_variable_resolver.py
@@ -1,0 +1,10 @@
+from hamcrest import assert_that, equal_to
+
+from nodestream.pipeline.argument_resolvers import EnvironmentResolver
+
+
+def test_resolve_argument_value_resolution(load_file_with_resolver, mocker):
+    mocker.patch.dict("os.environ", {"TEST_ENV": "SET_FROM_ENV"})
+    file = "tests/unit/pipeline/argument_resolvers/fixtures/with_env.yaml"
+    result = load_file_with_resolver(file, EnvironmentResolver)
+    assert_that(result, equal_to({"test": {"env": "SET_FROM_ENV", "not_env": 123}}))


### PR DESCRIPTION
Add a pattern for testing argument resolvers. The pattern relies on creating a file loader that respects a provided argument resolver and loading a test file. Preconditions can be met in the test case. For instance, what this PR does to add a test value to the environment. 