### PR TITLE
Respect the cardinality of `before_iteration` clauses in the interpreter

### DIFF
--- a/docs/docs/reference/interpreter.md
+++ b/docs/docs/reference/interpreter.md
@@ -110,3 +110,52 @@ We can use the following YAML definition to instruct the interpreter on how to p
           relationship_type: IN_CITY
           search: !jmespath city
 ```
+
+
+Mutliple interpretation passes are also allowed for the `before_iteration` block. 
+In this case, the `iterate_on` and `iterpretation` blocks are applied on the result of each pass pass of the `before_iteration` block.
+
+For example, imagine we have data like this:
+
+```json
+{
+  "site": "github.com",
+  "other_site": "another-git-host.com",
+  "people": [
+    {"name": "John", "address": "123 Test St"},
+    {"name": "Jane", "address": "456 Test St"}
+  ]
+}
+```
+
+We can use the following YAML definition to instruct the interpreter on how to parse this data:
+
+```yaml
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    before_iteration:
+      - - type: variables
+          site: !jmespath site
+      - - type: variables
+          site: !jmespath other_site
+    iterate_on: !jmespath people[*]
+    interpretations:
+      - type: source_node
+        name: !jmespath name
+        node_type: AwesomePerson
+      - type: relationship
+        node_type: Website
+        relationship_type: VISITS
+        node_key:
+          site: !variable site
+```
+
+This would result in the following graph:
+
+```mermaid
+graph LR
+  A[John] -->|VISITS| B[github.com];
+  C[Jane] -->|VISITS| B[github.com];
+  D[John] -->|VISITS| E[another-git-host.com];
+  F[Jane] -->|VISITS| E[another-git-host.com];
+```

--- a/nodestream/interpreting/interpreter.py
+++ b/nodestream/interpreting/interpreter.py
@@ -131,9 +131,9 @@ class Interpreter(Step, AggregatedIntrospectiveIngestionComponent):
 
     def interpret_record(self, record):
         context = ProviderContext.fresh(record)
-        self.before_iteration.apply_interpretations(context)
-        for sub_context in self.decomposer.decompose_record(context):
-            yield from self.interpretations.apply_interpretations(sub_context)
+        for base_context in self.before_iteration.apply_interpretations(context):
+            for sub_context in self.decomposer.decompose_record(base_context):
+                yield from self.interpretations.apply_interpretations(sub_context)
 
     def all_subordinate_components(self) -> Iterable[IntrospectiveIngestionComponent]:
         yield self.before_iteration


### PR DESCRIPTION
In the interpreter component, you can specify two different blocks of interpretations. `interpretations` and `before_iteration`. The `before_iteration` block is applied for a record is broken down into sub-records and applied to the `interpretations` block. 

Users can also specify `lists` of `lists` of  interpretations in the `interpretations` block. Because both the `interpreations` block and `before_iteration` block are parsed and loaded the same way, its possible to supply a list of lists to the `before_iteration` block.  However that is not respected in anyway. This provides a confusing experience to users that try and use this. 

To resolve this, this PR iterates over each sublist in `before_iteration` If provided, and performs the iteration and interpretation based on the output of each sublist provided. This creates an experience consistent with the use of the `interpretation` block. 

