### PR TITLE
Add an option to bound outbox size

### DIFF
--- a/nodestream/cli/commands/run.py
+++ b/nodestream/cli/commands/run.py
@@ -26,6 +26,13 @@ class Run(NodestreamCommand):
             default=1000,
             flag=False,
         ),
+        option(
+            "step-outbox-size",
+            "s",
+            "How many records to buffer in each step's outbox before blocking",
+            default=1000,
+            flag=False,
+        ),
     ]
 
     async def handle_async(self):

--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -19,6 +19,7 @@ class RunPipeline(Operation):
             pipeline_name=command.argument("pipeline"),
             initialization_arguments=PipelineInitializationArguments(
                 annotations=command.option("annotations"),
+                step_outbox_size=int(command.option("step-outbox-size")),
             ),
             progress_reporter=self.create_progress_reporter(command),
         )

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -47,6 +47,7 @@ class PipelineFileSafeLoader(SafeLoader):
 class PipelineInitializationArguments:
     """Arguments used to initialize a pipeline from a file."""
 
+    step_outbox_size: int = 1000
     annotations: Optional[List[str]] = None
 
     @classmethod
@@ -58,7 +59,10 @@ class PipelineInitializationArguments:
         return cls(annotations=["test"])
 
     def initialize_from_file_data(self, file_data: List[dict]):
-        return Pipeline(self.load_steps(ClassLoader(), file_data))
+        return Pipeline(
+            steps=self.load_steps(ClassLoader(), file_data),
+            step_outbox_size=self.step_outbox_size,
+        )
 
     def load_steps(self, class_loader, file_data):
         return [

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -22,14 +22,16 @@ async def test_run_pipeline_operation_perform(run_pipeline_operation, mocker):
 
 def test_make_run_request(run_pipeline_operation, mocker):
     command = mocker.Mock()
-    command.option.side_effect = [["annotation1", "annotation2"], "10000"]
+    command.option.side_effect = [["annotation1", "annotation2"], "10001", "10000"]
     command.argument.return_value = "my_pipeline"
     result = run_pipeline_operation.make_run_request(command)
     assert_that(result.pipeline_name, equal_to("my_pipeline"))
     assert_that(
         result.initialization_arguments,
         equal_to(
-            PipelineInitializationArguments(annotations=["annotation1", "annotation2"])
+            PipelineInitializationArguments(
+                annotations=["annotation1", "annotation2"], step_outbox_size=10001
+            )
         ),
     )
     assert_that(result.progress_reporter.reporting_frequency, equal_to(10000))

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -10,7 +10,7 @@ def pipeline(mocker):
     s1.handle_async_record_stream = mocker.Mock(return_value=empty_async_generator())
     s2.handle_async_record_stream = mocker.Mock(return_value=empty_async_generator())
     s1.finish, s2.finish = mocker.AsyncMock(), mocker.AsyncMock()
-    return Pipeline([s1, s2])
+    return Pipeline([s1, s2], 10)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipeline/test_pipeline_progress_reporter.py
+++ b/tests/unit/pipeline/test_pipeline_progress_reporter.py
@@ -6,7 +6,7 @@ from nodestream.pipeline import IterableExtractor, Pipeline, PipelineProgressRep
 
 @pytest.mark.asyncio
 async def test_pipeline_progress_reporter_calls_with_reporting_frequency(mocker):
-    pipeline = Pipeline([IterableExtractor(range(100))])
+    pipeline = Pipeline([IterableExtractor(range(100))], 10)
     reporter = PipelineProgressReporter(reporting_frequency=10, callback=mocker.Mock())
     await pipeline.run(reporter)
     assert_that(reporter.callback.call_count, equal_to(10))


### PR DESCRIPTION
The outbox size represents the upper-bound of how many items can be buffered from a step before the step is blocked from continuing.  This PR introduces an option to set this value for different performance environments. 