### PR TITLE
Yield files in order in `FileExtractor`

### DIFF
--- a/docs/docs/reference/extractors.md
+++ b/docs/docs/reference/extractors.md
@@ -116,7 +116,8 @@ With the previous minimal configuration, it will use your currently active aws c
 
 The `FileExtractor` class represents an extractor that reads records from files specified by glob patterns.
 It takes a collection of file paths as input and yields the records read from each file using the
-[appropriate file format parser](./file-formats.md).
+[appropriate file format parser](./file-formats.md). The files are read and yield in sorted order by file name so that
+the records are always yielded in the same order. 
 
 ```yaml
 - implementation: nodestream.pipeline.extractors:FileExtractor

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -84,8 +84,11 @@ class FileExtractor(Extractor):
     def __init__(self, paths: Iterable[Path]) -> None:
         self.paths = paths
 
+    def _ordered_paths(self) -> Iterable[Path]:
+        return sorted(self.paths)
+
     async def extract_records(self) -> AsyncGenerator[Any, Any]:
-        for path in self.paths:
+        for path in self._ordered_paths():
             with SupportedFileFormat.open(path) as file:
                 for record in file.read_file():
                     yield record

--- a/tests/unit/pipeline/extractors/test_files.py
+++ b/tests/unit/pipeline/extractors/test_files.py
@@ -1,4 +1,5 @@
 import csv
+import itertools
 import json
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -81,3 +82,10 @@ async def test_remote_file_extractor_extract_records(mocker, httpx_mock):
     subject = RemoteFileExtractor(files)
     results = [r async for r in subject.extract_records()]
     assert_that(results, equal_to([SIMPLE_RECORD, SIMPLE_RECORD]))
+
+
+def test_file_ordereing():
+    files_in_order = [Path(f"file{i}.json") for i in range(1, 4)]
+    for permutation in itertools.permutations(files_in_order):
+        subject = FileExtractor(permutation)
+        assert_that(list(subject._ordered_paths()), equal_to(files_in_order))


### PR DESCRIPTION
In the case where you have a series of files, each file should be loaded and yielded in a predictable order so that an appropriate snapshot is able to be created. If objects are continuously yielded in various orders, it means that one can not rely on the ordering. While, for most extractors, this isn't a big deal as you are not likely to snapshot them or the extractor has an obvious ordering. However in the case of the file extractor which takes a series of globs, its not obvious the ordering. This makes it so that is the case. 