### PR TITLE
Run Command Improvements

### DIFF
--- a/nodestream/cli/commands/run.py
+++ b/nodestream/cli/commands/run.py
@@ -2,13 +2,13 @@ from cleo.helpers import option
 
 from ..operations import InitializeLogger, InitializeProject, RunPipeline
 from .nodestream_command import NodestreamCommand
-from .shared_options import JSON_OPTION, PIPELINE_ARGUMENT, PROJECT_FILE_OPTION
+from .shared_options import JSON_OPTION, MANY_PIPELINES_ARGUMENT, PROJECT_FILE_OPTION
 
 
 class Run(NodestreamCommand):
     name = "run"
     description = "run a pipeline in the current project"
-    arguments = [PIPELINE_ARGUMENT]
+    arguments = [MANY_PIPELINES_ARGUMENT]
     options = [
         PROJECT_FILE_OPTION,
         JSON_OPTION,

--- a/nodestream/cli/commands/shared_options.py
+++ b/nodestream/cli/commands/shared_options.py
@@ -17,5 +17,5 @@ JSON_OPTION = option("json", "j", "Log output in JSON", flag=True)
 
 PIPELINE_ARGUMENT = argument("pipeline", "the name of the pipeline")
 MANY_PIPELINES_ARGUMENT = argument(
-    "pipelines", "the names of the pipelines", multiple=True
+    "pipelines", "the names of the pipelines", multiple=True, optional=True
 )

--- a/nodestream/cli/commands/shared_options.py
+++ b/nodestream/cli/commands/shared_options.py
@@ -16,3 +16,6 @@ JSON_OPTION = option("json", "j", "Log output in JSON", flag=True)
 
 
 PIPELINE_ARGUMENT = argument("pipeline", "the name of the pipeline")
+MANY_PIPELINES_ARGUMENT = argument(
+    "pipelines", "the names of the pipelines", multiple=True
+)

--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from cleo.io.outputs.output import Verbosity
 from yaml import safe_dump
 
@@ -14,8 +16,12 @@ class RunPipeline(Operation):
     def __init__(self, project: Project) -> None:
         self.project = project
 
+    def get_pipelines_to_run(self, command: NodestreamCommand) -> Iterable[str]:
+        supplied_commands = command.argument("pipelines")
+        return supplied_commands or self.project.get_all_pipeline_names()
+
     async def perform(self, command: NodestreamCommand):
-        for pipeline_name in command.argument("pipelines"):
+        for pipeline_name in self.get_pipelines_to_run(command):
             await self.project.run(self.make_run_request(command, pipeline_name))
 
     def make_run_request(

--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -1,3 +1,6 @@
+from cleo.io.outputs.output import Verbosity
+from yaml import safe_dump
+
 from ...pipeline import PipelineInitializationArguments, PipelineProgressReporter
 from ...pipeline.meta import PipelineContext
 from ...project import Project, RunRequest
@@ -15,11 +18,21 @@ class RunPipeline(Operation):
         await self.project.run(self.make_run_request(command))
 
     def make_run_request(self, command: NodestreamCommand) -> RunRequest:
+        def print_effective_config(config):
+            command.line(
+                "<info>Effective configuration:</info>",
+                verbosity=Verbosity.VERY_VERBOSE,
+            )
+            command.line(
+                f"<info>{safe_dump(config)}</info>", verbosity=Verbosity.VERY_VERBOSE
+            )
+
         return RunRequest(
             pipeline_name=command.argument("pipeline"),
             initialization_arguments=PipelineInitializationArguments(
                 annotations=command.option("annotations"),
                 step_outbox_size=int(command.option("step-outbox-size")),
+                on_effective_configuration_resolved=print_effective_config,
             ),
             progress_reporter=self.create_progress_reporter(command),
         )

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Callable, Dict
+from typing import Callable, Dict, List, Optional
 
 from yaml import SafeLoader, load
 

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Callable, Dict
 
 from yaml import SafeLoader, load
 
@@ -58,6 +58,7 @@ class PipelineInitializationArguments:
 
     step_outbox_size: int = 1000
     annotations: Optional[List[str]] = None
+    on_effective_configuration_resolved: Optional[Callable[[List[Dict]], None]] = None
 
     @classmethod
     def for_introspection(cls):
@@ -74,10 +75,14 @@ class PipelineInitializationArguments:
         )
 
     def load_steps(self, class_loader, file_data):
+        effective = self.get_effective_configuration(file_data)
+        if self.on_effective_configuration_resolved:
+            self.on_effective_configuration_resolved(file_data)
+        return [class_loader.load_class(**step_data) for step_data in effective]
+
+    def get_effective_configuration(self, file_data):
         return [
-            class_loader.load_class(**step_data)
-            for step_data in file_data
-            if self.should_load_step(step_data)
+            step_data for step_data in file_data if self.should_load_step(step_data)
         ]
 
     def should_load_step(self, step):

--- a/nodestream/project/project.py
+++ b/nodestream/project/project.py
@@ -160,6 +160,12 @@ class Project(
 
         return [self.scopes_by_name[scope_name]]
 
+    def get_all_pipeline_names(self) -> Iterable[str]:
+        """Returns all pipeline names in the project."""
+        for scope in self.scopes_by_name.values():
+            for pipeline in scope.pipelines_by_name.values():
+                yield pipeline.name
+
     def delete_pipeline(
         self,
         scope_name: Optional[str],

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -2,7 +2,6 @@ import pytest
 from hamcrest import assert_that, equal_to
 
 from nodestream.cli.operations.run_pipeline import RunPipeline, SpinnerProgressIndicator
-from nodestream.pipeline import PipelineInitializationArguments
 from nodestream.pipeline.meta import PipelineContext
 from nodestream.project import Project
 

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -15,39 +15,42 @@ def run_pipeline_operation(mocker):
 @pytest.mark.asyncio
 async def test_run_pipeline_operation_perform(run_pipeline_operation, mocker):
     run_req = "run"
+    cmd = mocker.Mock()
+    cmd.argument.return_value = ["pipeline_name"]
     run_pipeline_operation.make_run_request = mocker.Mock(return_value=run_req)
-    await run_pipeline_operation.perform(mocker.Mock())
+    await run_pipeline_operation.perform(cmd)
     run_pipeline_operation.project.run.assert_awaited_once_with(run_req)
 
 
 def test_make_run_request(run_pipeline_operation, mocker):
     annotations = ["annotation1", "annotation2"]
+    pipeline_name = "my_pipeline"
     command = mocker.Mock()
     command.option.side_effect = [annotations, "10001", "10000"]
-    command.argument.return_value = "my_pipeline"
-    result = run_pipeline_operation.make_run_request(command)
-    assert_that(result.pipeline_name, equal_to("my_pipeline"))
+    command.argument.return_value = [pipeline_name]
+    result = run_pipeline_operation.make_run_request(command, pipeline_name)
+    assert_that(result.pipeline_name, equal_to(pipeline_name))
     assert_that(result.initialization_arguments.annotations, equal_to(annotations))
     assert_that(result.initialization_arguments.step_outbox_size, equal_to(10001))
     assert_that(result.progress_reporter.reporting_frequency, equal_to(10000))
 
 
 def test_spinner_on_start(mocker):
-    spinner = SpinnerProgressIndicator(mocker.Mock())
+    spinner = SpinnerProgressIndicator(mocker.Mock(), "pipeline_name")
     spinner.on_start()
     spinner.command.progress_indicator.assert_called_once()
     spinner.progress.start.assert_called_once()
 
 
 def test_spinner_on_finish(mocker):
-    spinner = SpinnerProgressIndicator(mocker.Mock())
+    spinner = SpinnerProgressIndicator(mocker.Mock(), "pipeline_name")
     spinner.on_start()
     spinner.on_finish(PipelineContext())
     spinner.progress.finish.assert_called_once()
 
 
 def test_spinner_progress_callback(mocker):
-    spinner = SpinnerProgressIndicator(mocker.Mock())
+    spinner = SpinnerProgressIndicator(mocker.Mock(), "pipeline_name")
     spinner.on_start()
     spinner.progress_callback(1000, None)
     spinner.progress.set_message.assert_called_once()

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -21,19 +21,14 @@ async def test_run_pipeline_operation_perform(run_pipeline_operation, mocker):
 
 
 def test_make_run_request(run_pipeline_operation, mocker):
+    annotations = ["annotation1", "annotation2"]
     command = mocker.Mock()
-    command.option.side_effect = [["annotation1", "annotation2"], "10001", "10000"]
+    command.option.side_effect = [annotations, "10001", "10000"]
     command.argument.return_value = "my_pipeline"
     result = run_pipeline_operation.make_run_request(command)
     assert_that(result.pipeline_name, equal_to("my_pipeline"))
-    assert_that(
-        result.initialization_arguments,
-        equal_to(
-            PipelineInitializationArguments(
-                annotations=["annotation1", "annotation2"], step_outbox_size=10001
-            )
-        ),
-    )
+    assert_that(result.initialization_arguments.annotations, equal_to(annotations))
+    assert_that(result.initialization_arguments.step_outbox_size, equal_to(10001))
     assert_that(result.progress_reporter.reporting_frequency, equal_to(10000))
 
 

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -17,7 +17,9 @@ from nodestream.schema.schema import GraphSchema
 def scopes():
     return [
         PipelineScope("scope1", [PipelineDefinition("test", Path("path/to/pipeline"))]),
-        PipelineScope("scope2", []),
+        PipelineScope(
+            "scope2", [PipelineDefinition("test2", Path("path/to/pipeline"))]
+        ),
     ]
 
 
@@ -145,3 +147,7 @@ async def test_get_snapshot_for(project, mocker):
     project.run = mocker.AsyncMock()
     await project.get_snapshot_for("pipeline")
     project.run.assert_awaited_once()
+
+
+def test_all_pipeline_names(project):
+    assert_that(list(project.get_all_pipeline_names()), equal_to(["test", "test2"]))


### PR DESCRIPTION
- [When you do `-vv` on `nodestream run` the effective configuration is printed](https://github.com/nodestream-proj/nodestream/commit/d1dd28b61efcb7691471d6055fc532517cf06e59)
- [You can now pass multiple pipeline names to `nodestream run`](https://github.com/nodestream-proj/nodestream/commit/193df10bf1c2090ede6c1e6600456577439446d5)
- [If you pass no pipelines to `nodestream run`, all pipelines are run](https://github.com/nodestream-proj/nodestream/commit/193df10bf1c2090ede6c1e6600456577439446d5)