### PR TITLE
Move stream poll values into stream declaration

### DIFF
--- a/nodestream/pipeline/extractors/streams/extractor.py
+++ b/nodestream/pipeline/extractors/streams/extractor.py
@@ -11,9 +11,6 @@ from ..extractor import Extractor
 STREAM_CONNECTOR_SUBCLASS_REGISTRY = SubclassRegistry()
 STREAM_OBJECT_FORMAT_SUBCLASS_REGISTRY = SubclassRegistry()
 
-DEFAULT_TIMEOUT = 60
-DEFAULT_MAX_RECORDS = 100
-
 
 @STREAM_CONNECTOR_SUBCLASS_REGISTRY.connect_baseclass
 class StreamConnector(Pluggable, ABC):
@@ -28,7 +25,7 @@ class StreamConnector(Pluggable, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def poll(self, timeout: int, max_records: int) -> Iterable[Any]:
+    async def poll(self) -> Iterable[Any]:
         raise NotImplementedError
 
 
@@ -54,14 +51,7 @@ class StreamExtractor(Extractor):
     """
 
     @classmethod
-    def from_file_data(
-        cls,
-        connector: str,
-        record_format: str,
-        timeout: int = DEFAULT_TIMEOUT,
-        max_records: int = DEFAULT_MAX_RECORDS,
-        **connector_args
-    ):
+    def from_file_data(cls, connector: str, record_format: str, **connector_args):
         # Import all plugins so that they can register themselves
         StreamRecordFormat.import_all()
         StreamConnector.import_all()
@@ -69,8 +59,6 @@ class StreamExtractor(Extractor):
         object_format_cls = STREAM_OBJECT_FORMAT_SUBCLASS_REGISTRY.get(record_format)
         connector_cls = STREAM_CONNECTOR_SUBCLASS_REGISTRY.get(connector)
         return cls(
-            timeout=timeout,
-            max_records=max_records,
             record_format=object_format_cls(),
             connector=connector_cls(**connector_args),
         )
@@ -79,16 +67,12 @@ class StreamExtractor(Extractor):
         self,
         connector: StreamConnector,
         record_format: StreamRecordFormat,
-        timeout: int,
-        max_records: int,
     ):
         self.connector = connector
         self.record_format = record_format
-        self.timeout = timeout
-        self.max_records = max_records
 
     def poll(self):
-        return self.connector.poll(timeout=self.timeout, max_records=self.max_records)
+        return self.connector.poll()
 
     async def extract_records(self):
         await self.connector.connect()

--- a/tests/unit/pipeline/extractors/streams/test_extractor.py
+++ b/tests/unit/pipeline/extractors/streams/test_extractor.py
@@ -10,8 +10,6 @@ from nodestream.pipeline.extractors.streams.extractor import (
 @pytest.fixture
 def extractor(mocker):
     return StreamExtractor(
-        timeout=1,
-        max_records=1,
         record_format=JsonStreamRecordFormat(),
         connector=mocker.AsyncMock(),
     )
@@ -22,6 +20,6 @@ async def test_extract(extractor):
     extractor.connector.poll.side_effect = [['{"key": "test-value"}'], ValueError]
     result = [record async for record in extractor.extract_records()]
     assert_that(result, equal_to([{"key": "test-value"}]))
-    extractor.connector.poll.assert_called_once_with(timeout=1, max_records=1)
+    extractor.connector.poll.assert_called_once_with()
     extractor.connector.connect.assert_called_once()
     extractor.connector.disconnect.assert_called_once()

--- a/tests/unit/pipeline/extractors/streams/test_kafka.py
+++ b/tests/unit/pipeline/extractors/streams/test_kafka.py
@@ -6,7 +6,7 @@ from nodestream.pipeline.extractors.streams import KafkaStreamConnector
 
 @pytest.fixture
 def connector():
-    return KafkaStreamConnector("localhost:9092", "test-topic")
+    return KafkaStreamConnector("localhost:9092", "test-topic", max_records=1, poll_timeout_ms=10000)
 
 
 @pytest.mark.asyncio
@@ -31,6 +31,6 @@ async def test_poll(connector, mocker):
     connector.consumer.getmany.return_value = {
         mocker.Mock(topic="test-topic", partition=0): [mocker.Mock(value="test-value")]
     }
-    result = [record for record in await connector.poll(1, 1)]
+    result = [record for record in await connector.poll()]
     assert_that(result, equal_to(["test-value"]))
-    connector.consumer.getmany.assert_called_once_with(max_records=1, timeout_ms=1000)
+    connector.consumer.getmany.assert_called_once_with(timeout_ms=10000)

--- a/tests/unit/pipeline/extractors/streams/test_kafka.py
+++ b/tests/unit/pipeline/extractors/streams/test_kafka.py
@@ -6,7 +6,9 @@ from nodestream.pipeline.extractors.streams import KafkaStreamConnector
 
 @pytest.fixture
 def connector():
-    return KafkaStreamConnector("localhost:9092", "test-topic", max_records=1, poll_timeout_ms=10000)
+    return KafkaStreamConnector(
+        "localhost:9092", "test-topic", max_records=1, poll_timeout_ms=10000
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- The timeout and polling values are now provided to stream connectors instead of setting defaults for all extractors. This allows the ability to have multiple types of StreamConnectors with different polling and timeout settings.