### PR TITLE
Stream poll message format

### DIFF
--- a/nodestream/pipeline/extractors/streams/kafka.py
+++ b/nodestream/pipeline/extractors/streams/kafka.py
@@ -71,6 +71,5 @@ class KafkaStreamConnector(StreamConnector, alias="kafka"):
                 "Recived Kafka Messages",
                 extra={"topic": tp.topic, "partition": tp.partition},
             )
-            for message in messages:
-                entries.append(message.value)
+            entries.extend(messages)
         return entries

--- a/tests/unit/pipeline/extractors/streams/test_kafka.py
+++ b/tests/unit/pipeline/extractors/streams/test_kafka.py
@@ -33,6 +33,7 @@ async def test_poll(connector, mocker):
     connector.consumer.getmany.return_value = {
         mocker.Mock(topic="test-topic", partition=0): [mocker.Mock(value="test-value")]
     }
-    result = [record for record in await connector.poll()]
-    assert_that(result, equal_to(["test-value"]))
+    results = [record for record in await connector.poll()]
+    print(results)
+    assert_that([res.value for res in results], equal_to(["test-value"]))
     connector.consumer.getmany.assert_called_once_with(timeout_ms=10000)

--- a/tests/unit/pipeline/extractors/streams/test_kafka.py
+++ b/tests/unit/pipeline/extractors/streams/test_kafka.py
@@ -34,6 +34,5 @@ async def test_poll(connector, mocker):
         mocker.Mock(topic="test-topic", partition=0): [mocker.Mock(value="test-value")]
     }
     results = [record for record in await connector.poll()]
-    print(results)
     assert_that([res.value for res in results], equal_to(["test-value"]))
     connector.consumer.getmany.assert_called_once_with(timeout_ms=10000)


### PR DESCRIPTION
- return full message instead of only returning message.value in kafka streams