### PR TITLE
Fix incorrect call to Ingest Strategy in Hooks

### DIFF
--- a/nodestream/model/desired_ingestion.py
+++ b/nodestream/model/desired_ingestion.py
@@ -37,10 +37,7 @@ class DesiredIngestion:
 
     async def run_ingest_hooks(self, strategy: "IngestionStrategy"):
         await asyncio.gather(
-            *(
-                strategy.run_hook(hook_req.hook, hook_req.before_ingest)
-                for hook_req in self.hook_requests
-            )
+            *(strategy.run_hook(hook_req) for hook_req in self.hook_requests)
         )
 
     def can_perform_ingest(self):


### PR DESCRIPTION
The call to `run_hook` in `IngestionStrategy` was not correctly made according to the signature. This fixes that and adds an appropriate test. 