### PR TITLE
Concurrent Transfomers

### DIFF
--- a/nodestream/pipeline/transformers/__init__.py
+++ b/nodestream/pipeline/transformers/__init__.py
@@ -1,5 +1,5 @@
 from .expand_json_field import ExpandJsonField
-from .transformer import Transformer, ConcurrentTransformer
+from .transformer import ConcurrentTransformer, Transformer
 from .value_projection import ValueProjection
 
 __all__ = ("ExpandJsonField", "ValueProjection", "Transformer", "ConcurrentTransformer")

--- a/nodestream/pipeline/transformers/__init__.py
+++ b/nodestream/pipeline/transformers/__init__.py
@@ -1,5 +1,5 @@
 from .expand_json_field import ExpandJsonField
-from .transformer import Transformer
+from .transformer import Transformer, ConcurrentTransformer
 from .value_projection import ValueProjection
 
-__all__ = ("ExpandJsonField", "ValueProjection", "Transformer")
+__all__ = ("ExpandJsonField", "ValueProjection", "Transformer", "ConcurrentTransformer")

--- a/nodestream/pipeline/transformers/transformer.py
+++ b/nodestream/pipeline/transformers/transformer.py
@@ -1,5 +1,8 @@
+import asyncio
 from abc import abstractmethod
-from typing import Any, AsyncGenerator
+from concurrent.futures import ThreadPoolExecutor
+from logging import getLogger
+from typing import Any, AsyncGenerator, Optional
 
 from ..flush import Flush
 from ..step import Step
@@ -25,6 +28,82 @@ class Transformer(Step):
                         yield result
                 else:
                     yield await val_or_gen
+
+    @abstractmethod
+    async def transform_record(self, record: Any) -> Any:
+        raise NotImplementedError
+
+
+class ConcurrentTransformer(Transformer):
+    """A `ConcurrentTransformer` takes a given record and mutates into a new record while managing a pool of concurrent workers.
+
+    `ConcurrentTransformer`s are useful when the transformation work is IO bound and can be parallelized across multiple threads.
+    `ConcurrentTransformer`s are not useful when the transformation work is CPU bound as the GIL will prevent useful parallelization.
+    Additionally, `ConcurrentTransformer`s do not guarantee the order of the output stream will match the input stream.
+    """
+
+    def __init__(
+        self, thread_pool_size: Optional[int] = None, maximum_pending_tasks: int = 1000
+    ) -> None:
+        self.logger = getLogger(self.__class__.__name__)
+        self.maximum_pending_tasks = maximum_pending_tasks
+        self.thread_pool = ThreadPoolExecutor(
+            max_workers=thread_pool_size,
+            thread_name_prefix=self.__class__.__name__,
+            initializer=self.on_worker_thread_start,
+        )
+
+    def on_worker_thread_start(self):
+        pass
+
+    async def handle_async_record_stream(
+        self, record_stream: AsyncGenerator[Any, Any]
+    ) -> AsyncGenerator[Any, Any]:
+        pending_tasks = []
+
+        def drain_completed_tasks():
+            tasks_drained = 0
+            remaining_pending_tasks = []
+            for task in pending_tasks:
+                if task.done():
+                    yield task.result()
+                    tasks_drained += 1
+                else:
+                    remaining_pending_tasks.append(task)
+
+            pending_tasks[:] = remaining_pending_tasks
+            if tasks_drained:
+                self.logger.debug(
+                    "Drained %s completed tasks, %s pending tasks remain",
+                    tasks_drained,
+                    len(pending_tasks),
+                )
+
+        async for record in record_stream:
+            if record is Flush:
+                for result in drain_completed_tasks():
+                    yield result
+                yield record
+            else:
+                submitted = False
+                while not submitted:
+                    if len(pending_tasks) < self.maximum_pending_tasks:
+                        task = self.thread_pool.submit(self.do_work_on_record, record)
+                        pending_tasks.append(task)
+                        submitted = True
+                    for result in drain_completed_tasks():
+                        yield result
+
+        self.logger.debug("Finished enqueuing records, draining pending tasks")
+        while pending_tasks:
+            for result in drain_completed_tasks():
+                yield result
+
+    async def finish(self):
+        self.thread_pool.shutdown(wait=True)
+
+    def do_work_on_record(self, record: Any) -> Any:
+        return asyncio.run(self.transform_record(record))
 
     @abstractmethod
     async def transform_record(self, record: Any) -> Any:

--- a/tests/unit/pipeline/transformers/test_transformer.py
+++ b/tests/unit/pipeline/transformers/test_transformer.py
@@ -1,8 +1,7 @@
 import pytest
+from hamcrest import assert_that, contains_inanyorder, has_length
 
 from nodestream.pipeline.transformers import ConcurrentTransformer
-
-from hamcrest import assert_that, contains_inanyorder, has_length
 
 
 class AddOneConcurrently(ConcurrentTransformer):

--- a/tests/unit/pipeline/transformers/test_transformer.py
+++ b/tests/unit/pipeline/transformers/test_transformer.py
@@ -1,0 +1,32 @@
+import pytest
+
+from nodestream.pipeline.transformers import ConcurrentTransformer
+
+from hamcrest import assert_that, contains_inanyorder, has_length
+
+
+class AddOneConcurrently(ConcurrentTransformer):
+    async def transform_record(self, record):
+        return record + 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transformer_alL_items_collect():
+    items = list(range(100))
+
+    async def input_record_stream():
+        for i in items:
+            yield i
+
+    add = AddOneConcurrently()
+    result = [r async for r in add.handle_async_record_stream(input_record_stream())]
+    assert_that(result, contains_inanyorder(*[i + 1 for i in items]))
+    assert_that(result, has_length(len(items)))
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transformer_worker_cleanup(mocker):
+    add = AddOneConcurrently()
+    add.thread_pool = mocker.Mock()
+    await add.finish()
+    add.thread_pool.shutdown.assert_called_once_with(wait=True)


### PR DESCRIPTION
Currently,  when pipelines are bound by IO in Transformers, we are bottlenecked behind the performance of that IO since the pipeline cannot be faster than its slowest part in terms of actual throughput. This implements a `ConcurrentTransformer` that is capable of managing a thread pool of workers that are able to perform multiple operations in parallel. 