### PR TITLE
Redesign Project Load Behavior for Delayed Evaluation

### DIFF
--- a/docs/docs/guides/creating-your-own-argument-resolver.md
+++ b/docs/docs/guides/creating-your-own-argument-resolver.md
@@ -9,23 +9,14 @@ AWS secrets manager.
 ## Defining your ArgumentResolver Class
 
 ```python
-from typing import Any
-
 import boto3
 
 from nodestream.pipeline.argument_resolvers import ArgumentResolver
 
 
 class EnvironmentResolver(ArgumentResolver):
-    @classmethod
-    def install_yaml_tag(cls, loader: Type[SafeLoader]):
-        loader.add_constructor(
-            "!secrets_manager",
-            lambda loader, node: cls.get_from_secrets_manager(loader.construct_scalar(node)),
-        )
-
     @staticmethod
-    def get_from_secrets_manager(variable_name):
+    def resolve_argument(variable_name):
         client = boto3.client("secretsmanager")
         return client.get_secret_value(SecretId=variable_name)["SecretString"]
 
@@ -33,8 +24,8 @@ class EnvironmentResolver(ArgumentResolver):
 
 Note that this implementation is pretty naive. But it's the simplest we need to demonstrate the point.
 
-In this example, we register with a yaml loader that can load a tag in
-yaml to utilize our new `ArgumentResolver`. Nodestream uses [`pyyaml`](https://pyyaml.org/) to load our pipelines.
+In this example, we assume that the `variable_name` is the name of the secret in AWS Secrets Manager. 
+We then use the AWS SDK to retrieve the secret value and return it.
 
 ## Registering your ArgumentResolver
 

--- a/docs/docs/guides/project-plugins.md
+++ b/docs/docs/guides/project-plugins.md
@@ -15,6 +15,20 @@ class MyProjectPlugin(ProjectPlugin):
         pass
 ```
 
+
+### Additional Lifecycle Methods
+
+In addition to the `activate` method, project plugins can optionally implement the following lifecycle methods: 
+
+#### `def before_project_load(self, file_path: Path) -> None`
+
+Called before a project is loaded. The `file_path` argument is the path to the project file.
+
+#### `def after_project_load(self, project: Project) -> None`
+
+Called after the project is loaded and all project plugins have been activated. 
+
+
 ### Use Case: Adding Custom Metadata to Project Pipelines
 
 Project plugins can be used to add custom metadata to project pipelines. This metadata can be used for a variety of purposes specific to your 
@@ -50,6 +64,7 @@ class MyProjectPlugin(ProjectPlugin):
         scope = PipelineScope.from_resources(name="my_plugin", package="my_plugin.pipelines")
         project.add_scope(scope)
 ```
+
 
 ### Registering the Project Plugin
 

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -163,15 +163,9 @@ class LazyLoadedTagSafeLoader(SafeLoader):
     pass
 
 
-def construct_undefined(self, node):
-    if isinstance(node, ScalarNode):
-        value = self.construct_scalar(node)
-    elif isinstance(node, SequenceNode):
-        value = self.construct_sequence(node)
-    elif isinstance(node, MappingNode):
-        value = self.construct_mapping(node)
-    print(node.tag)
+def wrap_unloaded_tag(self, node):
+    value = self.construct_scalar(node)
     return LazyLoadedArgument(node.tag[1:], value)
 
 
-LazyLoadedTagSafeLoader.add_constructor(None, construct_undefined)
+LazyLoadedTagSafeLoader.add_constructor(None, wrap_unloaded_tag)

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -4,11 +4,8 @@ from typing import Type
 
 from schema import Schema
 from yaml import (
-    MappingNode,
     SafeDumper,
     SafeLoader,
-    ScalarNode,
-    SequenceNode,
     dump,
     load,
 )

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -142,7 +142,7 @@ class LazyLoadedArgument:
         self.value = value
 
     def get_value(self):
-        return ArgumentResolver.resolve_arugment_with_alias(self.tag, self.value)
+        return ArgumentResolver.resolve_argument_with_alias(self.tag, self.value)
 
     @staticmethod
     def resolve_if_needed(value):

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -3,12 +3,7 @@ from pathlib import Path
 from typing import Type
 
 from schema import Schema
-from yaml import (
-    SafeDumper,
-    SafeLoader,
-    dump,
-    load,
-)
+from yaml import SafeDumper, SafeLoader, dump, load
 
 from .pipeline.argument_resolvers import ArgumentResolver
 

--- a/nodestream/pipeline/argument_resolvers/argument_resolver.py
+++ b/nodestream/pipeline/argument_resolvers/argument_resolver.py
@@ -20,7 +20,7 @@ class ArgumentResolver(Pluggable, ABC):
         return value
 
     @classmethod
-    def resolve_arugment_with_alias(cls, tag, value):
+    def resolve_argument_with_alias(cls, tag, value):
         ArgumentResolver.import_all()
         resolver = ARGUMENT_RESOLVER_REGISTRY.get(tag)
         return resolver.resolve_argument(value)

--- a/nodestream/pipeline/argument_resolvers/argument_resolver.py
+++ b/nodestream/pipeline/argument_resolvers/argument_resolver.py
@@ -15,6 +15,20 @@ class ArgumentResolver(Pluggable, ABC):
 
     entrypoint_name = "argument_resolvers"
 
+    @staticmethod
+    def resolve_argument(value):
+        return value
+
+    @classmethod
+    def resolve_arugment_with_alias(cls, tag, value):
+        ArgumentResolver.import_all()
+        resolver = ARGUMENT_RESOLVER_REGISTRY.get(tag)
+        return resolver.resolve_argument(value)
+
     @classmethod
     def install_yaml_tag(cls, loader: Type[SafeLoader]):
-        pass
+        def construct_argument(loader, node):
+            return cls.resolve_argument(loader.construct_scalar(node))
+
+        yaml_tag = f"!{ARGUMENT_RESOLVER_REGISTRY.name_for(cls)}"
+        loader.add_constructor(yaml_tag, construct_argument)

--- a/nodestream/pipeline/argument_resolvers/environment_variable_resolver.py
+++ b/nodestream/pipeline/argument_resolvers/environment_variable_resolver.py
@@ -1,20 +1,10 @@
 import os
-from typing import Type
-
-from yaml import SafeLoader
 
 from .argument_resolver import ArgumentResolver
 
 
-class EnvironmentResolver(ArgumentResolver):
+class EnvironmentResolver(ArgumentResolver, alias="env"):
     """An `EnvironmentResolver` is an `ArgumentResolver` that can resolve an environment variable into its value."""
-
-    @classmethod
-    def install_yaml_tag(cls, loader: Type[SafeLoader]):
-        loader.add_constructor(
-            "!env",
-            lambda loader, node: cls.resolve_argument(loader.construct_scalar(node)),
-        )
 
     @staticmethod
     def resolve_argument(variable_name):

--- a/nodestream/pipeline/argument_resolvers/include_file_resolver.py
+++ b/nodestream/pipeline/argument_resolvers/include_file_resolver.py
@@ -1,22 +1,11 @@
-from typing import Type
-
-from yaml import SafeLoader
-
 from .argument_resolver import ArgumentResolver
 
 
-class IncludeFileResolver(ArgumentResolver):
+class IncludeFileResolver(ArgumentResolver, alias="include"):
     """An `IncludeFileResolver` is an `ArgumentResolver` that can resolve a file path into a file's contents."""
 
-    @classmethod
-    def install_yaml_tag(cls, loader: Type[SafeLoader]):
-        loader.add_constructor(
-            "!include",
-            lambda loader, node: cls.include_file(loader.construct_scalar(node)),
-        )
-
     @staticmethod
-    def include_file(file_path: str):
+    def resolve_argument(file_path: str):
         from ..pipeline_file_loader import PipelineFileSafeLoader
 
         return PipelineFileSafeLoader.load_file_by_path(file_path)

--- a/nodestream/pipeline/scope_config.py
+++ b/nodestream/pipeline/scope_config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from ..file_io import LoadsFromYamlFile
+from ..file_io import LazyLoadedArgument, LoadsFromYamlFile
 
 
 @dataclass
@@ -39,4 +39,4 @@ class ScopeConfig(LoadsFromYamlFile):
         return cls(data)
 
     def get_config_value(self, key):
-        return self.config.get(key)
+        return LazyLoadedArgument.resolve_if_needed(self.config.get(key))

--- a/nodestream/project/target.py
+++ b/nodestream/project/target.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from ..file_io import LazyLoadedArgument
+
 
 @dataclass(slots=True, frozen=True)
 class Target:
@@ -8,16 +10,23 @@ class Target:
     connector_config: Dict[str, Any]
 
     @property
+    def resolved_connector_config(self):
+        return {
+            key: LazyLoadedArgument.resolve_if_needed(value)
+            for key, value in self.connector_config.items()
+        }
+
+    @property
     def connector(self):
         from ..databases import DatabaseConnector
 
-        return DatabaseConnector.from_database_args(**self.connector_config)
+        return DatabaseConnector.from_database_args(**self.resolved_connector_config)
 
     def make_writer(self, **writer_args):
         from ..databases import GraphDatabaseWriter
 
         return GraphDatabaseWriter.from_file_data(
-            **writer_args, **self.connector_config
+            **writer_args, **self.resolved_connector_config
         )
 
     def make_type_retriever(self):

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -15,7 +15,6 @@ from nodestream.project import (
     Project,
     RunRequest,
     Target,
-    ProjectPlugin,
 )
 from nodestream.schema.schema import GraphSchema
 

--- a/tests/unit/project/test_scope_config.py
+++ b/tests/unit/project/test_scope_config.py
@@ -1,8 +1,17 @@
 from hamcrest import assert_that, equal_to
 
+from nodestream.file_io import LazyLoadedArgument
 from nodestream.pipeline.scope_config import ScopeConfig
 
 
 def test_from_file_data_string_input():
     result = ScopeConfig.from_file_data({"TestKey": "TestValue"})
     assert_that(result.config, equal_to({"TestKey": "TestValue"}))
+
+
+def test_target_resolves_lazy_tags(mocker):
+    scope = ScopeConfig.from_file_data(
+        {"user": LazyLoadedArgument("env", "USERNAME_ENV")}
+    )
+    mocker.patch("os.environ", {"USERNAME_ENV": "bob"})
+    assert_that(scope.get_config_value("user"), equal_to("bob"))

--- a/tests/unit/project/test_target.py
+++ b/tests/unit/project/test_target.py
@@ -1,3 +1,6 @@
+from hamcrest import assert_that, equal_to
+
+from nodestream.file_io import LazyLoadedArgument
 from nodestream.project import Target
 
 
@@ -13,3 +16,9 @@ def test_target_make_type_retriever(mocker):
     mock_retriever = mocker.patch("nodestream.databases.DatabaseConnector")
     target.make_type_retriever()
     mock_retriever.from_database_args.assert_called_once_with(a="b")
+
+
+def test_target_resolves_lazy_tags(mocker):
+    target = Target("test", {"a": LazyLoadedArgument("env", "USERNAME_ENV")})
+    mocker.patch("os.environ", {"USERNAME_ENV": "bob"})
+    assert_that(target.resolved_connector_config, equal_to({"a": "bob"}))


### PR DESCRIPTION
This PR introduces two related changes to improve the  approach taken to load the project file:

- It allows `ProjectPlugins` to implement a `before_project_loaded` and `after_project_loaded` hooks to better time changes to the project that the plugin may wish to make. 
- Introduce a delayed loading methodology that allows tags that are used for resolvers to be loaded after the fact for targets and scopes. This allows one to introspect the project without loading all required configuration.