### PR TITLE
Increase Interpreting Performance by Decreasing dict Allocations

### DIFF
--- a/nodestream/interpreting/interpretations/extract_variables_interpretation.py
+++ b/nodestream/interpreting/interpretations/extract_variables_interpretation.py
@@ -44,4 +44,4 @@ class ExtractVariablesInterpretation(Interpretation, alias="variables"):
         self.norm_args = normalization or {}
 
     def interpret(self, context: ProviderContext):
-        context.variables.apply_providers(context, self.variables, **self.norm_args)
+        context.variables.apply_providers(context, self.variables, self.norm_args)

--- a/nodestream/interpreting/interpretations/properties_interpretation.py
+++ b/nodestream/interpreting/interpretations/properties_interpretation.py
@@ -29,7 +29,7 @@ class PropertiesInterpretation(Interpretation, alias="properties"):
 
     def interpret(self, context: ProviderContext):
         source = context.desired_ingest.source
-        source.properties.apply_providers(context, self.properties, **self.norm_args)
+        source.properties.apply_providers(context, self.properties, self.norm_args)
 
     def gather_object_shapes(self) -> Iterable[GraphObjectShape]:
         yield GraphObjectShape(

--- a/nodestream/interpreting/interpretations/relationship_interpretation.py
+++ b/nodestream/interpreting/interpretations/relationship_interpretation.py
@@ -54,7 +54,7 @@ class SingleNodeKeySearchAlgorithm(RelatedNodeKeySearchAlgorithm):
     ) -> Iterable[Dict[str, Any]]:
         return [
             {
-                k: v.normalize_single_value(context, **self.key_normalization)
+                k: v.normalize_single_value(context, self.key_normalization)
                 for k, v in self.node_key.items()
             }
         ]
@@ -65,7 +65,7 @@ class MultiNodeKeySearchAlgorithm(RelatedNodeKeySearchAlgorithm):
         # If we do not have the same length, then there is an error because
         # we do not have pairs to create keys for each node based off of.
         all_values_by_key_property = {
-            k: tuple(v.normalize_many_values(context, **self.key_normalization))
+            k: tuple(v.normalize_many_values(context, self.key_normalization))
             for k, v in self.node_key.items()
         }
         distinct_lengths = {len(vals) for vals in all_values_by_key_property.values()}
@@ -160,10 +160,10 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
     def find_relationship(self, context: ProviderContext) -> Relationship:
         rel = Relationship(type=self.relationship_type.single_value(context))
         rel.key_values.apply_providers(
-            context, self.relationship_key, **self.key_normalization
+            context, self.relationship_key, self.key_normalization
         )
         rel.properties.apply_providers(
-            context, self.relationship_properties, **self.properties_normalization
+            context, self.relationship_properties, self.properties_normalization
         )
         return rel
 
@@ -175,7 +175,7 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
             )
             if node.has_valid_id:
                 node.properties.apply_providers(
-                    context, self.node_properties, **self.properties_normalization
+                    context, self.node_properties, self.properties_normalization
                 )
                 yield node
 

--- a/nodestream/interpreting/interpretations/source_node_interpretation.py
+++ b/nodestream/interpreting/interpretations/source_node_interpretation.py
@@ -104,8 +104,8 @@ class SourceNodeInterpretation(Interpretation, alias="source_node"):
     def interpret(self, context: ProviderContext):
         source = context.desired_ingest.source
         source.type = self.node_type.single_value(context)
-        source.key_values.apply_providers(context, self.key, **self.norm_args)
-        source.properties.apply_providers(context, self.properties, **self.norm_args)
+        source.key_values.apply_providers(context, self.key, self.norm_args)
+        source.properties.apply_providers(context, self.properties, self.norm_args)
         source.additional_types = self.additional_types
 
     def gather_used_indexes(self) -> Iterable[Union[KeyIndex, FieldIndex]]:

--- a/nodestream/interpreting/interpretations/switch_interpretation.py
+++ b/nodestream/interpreting/interpretations/switch_interpretation.py
@@ -69,7 +69,7 @@ class SwitchInterpretation(
             yield from self.default
 
     def interpret(self, context: ProviderContext):
-        key = self.switch_on.normalize_single_value(context, **self.normalization)
+        key = self.switch_on.normalize_single_value(context, self.normalization)
         interpretations = self.interpretations.get(key, self.default)
 
         if interpretations is None:

--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -51,7 +51,7 @@ class PropertySet(dict):
         self,
         context: "ProviderContext",
         provider_map: "Dict[str, ValueProvider]",
-        **norm_args,
+        norm_args,
     ):
         """For every `(key, provider)` pair provided, sets the property to the values provided.
 
@@ -59,7 +59,7 @@ class PropertySet(dict):
         arguments for value normalization.
         """
         for key, provider in provider_map.items():
-            v = provider.normalize_single_value(context, **norm_args)
+            v = provider.normalize_single_value(context, norm_args)
             self.set_property(key, v)
 
 

--- a/nodestream/pipeline/filters.py
+++ b/nodestream/pipeline/filters.py
@@ -52,11 +52,11 @@ class ValueMatcher:
 
     def does_match(self, context: ProviderContext):
         actual_value = self.value_provider.normalize_single_value(
-            context, **self.normalization
+            context, self.normalization
         )
 
         return any(
-            possibility_provider.normalize_single_value(context, **self.normalization)
+            possibility_provider.normalize_single_value(context, self.normalization)
             == actual_value
             for possibility_provider in self.possibilities
         )
@@ -123,7 +123,7 @@ class RegexMatcher:
 
     def should_include(self, context: ProviderContext) -> bool:
         actual_value = self.value_provider.normalize_single_value(
-            context, **self.normalization
+            context, self.normalization
         )
         match = self.regex.match(actual_value) is not None
         return not match if self.include else match

--- a/nodestream/pipeline/normalizers/normalizer.py
+++ b/nodestream/pipeline/normalizers/normalizer.py
@@ -33,10 +33,11 @@ class Normalizer(Pluggable, ABC):
         pass
 
     @classmethod
-    def normalize_by_args(cls, value: Any, **normalizer_args) -> Any:
-        for flag_name, enabled in normalizer_args.items():
-            if enabled:
-                value = cls.by_flag_name(flag_name).normalize_value(value)
+    def normalize_by_args(cls, value: Any, normalizer_args) -> Any:
+        if normalizer_args:
+            for flag_name, enabled in normalizer_args.items():
+                if enabled:
+                    value = cls.by_flag_name(flag_name).normalize_value(value)
 
         return value
 

--- a/nodestream/pipeline/value_providers/value_provider.py
+++ b/nodestream/pipeline/value_providers/value_provider.py
@@ -56,19 +56,19 @@ class ValueProvider(Pluggable, ABC):
     def many_values(self, context: ProviderContext) -> Iterable[Any]:
         raise NotImplementedError
 
-    def normalize(self, value, **args):
-        return Normalizer.normalize_by_args(value, **args)
+    def normalize(self, value, args):
+        return Normalizer.normalize_by_args(value, args)
 
     def normalize_single_value(
-        self, context: ProviderContext, **normalization_args
+        self, context: ProviderContext, normalization_args
     ) -> Any:
-        return self.normalize(self.single_value(context), **normalization_args)
+        return self.normalize(self.single_value(context), normalization_args)
 
     def normalize_many_values(
-        self, context: ProviderContext, **normalization_args
+        self, context: ProviderContext, normalization_args
     ) -> Iterable[Any]:
         for value in self.many_values(context):
-            yield self.normalize(value, **normalization_args)
+            yield self.normalize(value, normalization_args)
 
     @property
     def is_static(self) -> bool:


### PR DESCRIPTION
Instead of passing `kwargs` from function to function in the normalization pipeline, this passes the dictionary around removing duplicate dictionaries from being created. 