### PR TITLE
Add a New Release Script for 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.9.5"
+version = "0.10.0"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/scripts/rev-official-plugins.sh
+++ b/scripts/rev-official-plugins.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+CURRENT_VERSION=#(poetry version -s)
+
+# Move up to the directory for the organization.
+cd .. 
+
+for plugin in $(ls | grep nodestream-plugin); do
+    cd $plugin
+
+    # Validate that the working directory is clean.
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Working directory is not clean."
+        exit 1
+    fi
+
+    # Validate that we are on the main branch.
+    if [ "$(git branch --show-current)" != "main" ]; then
+        echo "Not on main branch."
+        exit 1
+    fi
+
+    # Create a branch for the release.
+    git checkout -b "release-$CURRENT_VERSION"
+    echo "Updating $plugin"
+
+    # Update the version number in the pyproject.toml file.
+    poetry version "$CURRENT_VERSION"
+    poetry add nodestream@^$CURRENT_VERSION
+
+    # Commit the changes to the branch.
+    git add pyproject.toml
+    git commit -m "Release $CURRENT_VERSION"
+    
+    # Tag the commit with the version number.
+    git tag "$CURRENT_VERSION"
+    
+    # Push the branch and tag to the remote repository.
+    git push origin "release-$CURRENT_VERSION"
+    git push origin "$CURRENT_VERSION"
+
+    # Reset our state.
+    git checkout main
+    cd ..
+done


### PR DESCRIPTION
This script revs the versions of `nodestream` in all the core packages and prepares them for release. This is a side step on the goal to document and automate the release process. 