### PR TITLE
Fix: Handle Nulls for Multi-Key Relationships

### DIFF
--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -88,7 +88,7 @@ class Node(DeduplicatableObject):
     @property
     def has_valid_id(self) -> bool:
         # Return that some of the ID values are defined.
-        return not all(value is None for value in self.key_values.values())
+        return all(value is not None for value in self.key_values.values())
 
     @property
     def is_valid(self) -> bool:

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -1,3 +1,4 @@
+import pytest
 from hamcrest import assert_that, equal_to
 
 from nodestream.model import (
@@ -40,3 +41,18 @@ def test_relationship_into_ingest():
             ]
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        ({"name": "John"}, True),
+        ({"name": None}, False),
+        ({"name": "John", "age": 30}, True),
+        ({"name": "John", "age": None}, False),
+        ({"name": None, "age": None}, False),
+    ],
+)
+def test_node_key_validity(keys, expected):
+    node = Node("Person", keys)
+    assert_that(node.has_valid_id, equal_to(expected))


### PR DESCRIPTION
We need all parts of the key to be defined. If we cannot, then we cannot ingest the record. 