### PR TITLE
Fix Ingest Hooks and Writers

### DIFF
--- a/nodestream/databases/debounced_ingest_strategy.py
+++ b/nodestream/databases/debounced_ingest_strategy.py
@@ -84,3 +84,4 @@ class DebouncedIngestStrategy(IngestionStrategy, alias="debounced"):
         # a time.
         for hook in self.hooks_saved_for_after_ingest:
             await self.executor.execute_hook(hook)
+        self.hooks_saved_for_after_ingest.clear()

--- a/nodestream/databases/writer.py
+++ b/nodestream/databases/writer.py
@@ -1,4 +1,4 @@
-from ..pipeline import Flush, Writer
+from ..pipeline import Writer
 from .database_connector import DatabaseConnector
 from .debounced_ingest_strategy import DebouncedIngestStrategy
 from .ingest_strategy import INGESTION_STRATEGY_REGISTRY, IngestionStrategy
@@ -38,14 +38,7 @@ class GraphDatabaseWriter(Writer):
         self.pending_records = 0
 
     async def write_record(self, ingestible):
-        if ingestible is Flush:
-            await self.flush()
-            return
-
         await ingestible.ingest(self.ingest_strategy)
         self.pending_records += 1
         if self.pending_records >= self.batch_size:
             await self.flush()
-
-    async def finish(self):
-        await self.flush()

--- a/nodestream/pipeline/writers.py
+++ b/nodestream/pipeline/writers.py
@@ -2,8 +2,8 @@ from abc import abstractmethod
 from logging import INFO, getLevelName, getLogger
 from typing import Any, AsyncGenerator
 
-from .step import Step
 from .flush import Flush
+from .step import Step
 
 
 class Writer(Step):

--- a/nodestream/pipeline/writers.py
+++ b/nodestream/pipeline/writers.py
@@ -3,6 +3,7 @@ from logging import INFO, getLevelName, getLogger
 from typing import Any, AsyncGenerator
 
 from .step import Step
+from .flush import Flush
 
 
 class Writer(Step):
@@ -17,12 +18,21 @@ class Writer(Step):
         self, record_stream: AsyncGenerator[Any, Any]
     ) -> AsyncGenerator[Any, Any]:
         async for record in record_stream:
-            await self.write_record(record)
+            if record is Flush:
+                await self.flush()
+            else:
+                await self.write_record(record)
             yield record
 
     @abstractmethod
     async def write_record(self, record: Any):
         raise NotImplementedError
+
+    async def flush(self):
+        pass
+
+    async def finish(self):
+        await self.flush()
 
 
 class LoggerWriter(Writer):

--- a/tests/unit/databases/test_debounced_ingest_strategy.py
+++ b/tests/unit/databases/test_debounced_ingest_strategy.py
@@ -1,5 +1,5 @@
 import pytest
-from hamcrest import assert_that, equal_to, empty
+from hamcrest import assert_that, empty, equal_to
 
 from nodestream.databases import DebouncedIngestStrategy
 from nodestream.databases.query_executor import OperationOnNodeIdentity

--- a/tests/unit/databases/test_debounced_ingest_strategy.py
+++ b/tests/unit/databases/test_debounced_ingest_strategy.py
@@ -1,5 +1,5 @@
 import pytest
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, empty
 
 from nodestream.databases import DebouncedIngestStrategy
 from nodestream.databases.query_executor import OperationOnNodeIdentity
@@ -116,8 +116,7 @@ async def test_flush_relationships(ingest_strategy):
 async def test_flush_hooks_after_ingest_calls_executor(ingest_strategy, mocker):
     ingest_strategy.debouncer.drain_node_groups.return_value = []
     ingest_strategy.debouncer.drain_relationship_groups.return_value = []
-    ingest_strategy.hooks_saved_for_after_ingest = [mocker.AsyncMock()]
+    ingest_strategy.hooks_saved_for_after_ingest = [hook := mocker.AsyncMock()]
     await ingest_strategy.flush()
-    ingest_strategy.executor.execute_hook.assert_awaited_once_with(
-        ingest_strategy.hooks_saved_for_after_ingest[0]
-    )
+    ingest_strategy.executor.execute_hook.assert_awaited_once_with(hook)
+    assert_that(ingest_strategy.hooks_saved_for_after_ingest, empty())

--- a/tests/unit/databases/test_graph_database_writer.py
+++ b/tests/unit/databases/test_graph_database_writer.py
@@ -3,7 +3,6 @@ from hamcrest import assert_that, equal_to
 
 from nodestream.databases import GraphDatabaseWriter
 from nodestream.model import DesiredIngestion
-from nodestream.pipeline import Flush
 
 
 @pytest.fixture

--- a/tests/unit/databases/test_graph_database_writer.py
+++ b/tests/unit/databases/test_graph_database_writer.py
@@ -12,14 +12,6 @@ def stubbed_writer(mocker):
 
 
 @pytest.mark.asyncio
-async def test_graph_database_writer_flushes_when_recieving_a_flush(stubbed_writer):
-    await stubbed_writer.write_record(DesiredIngestion())
-    await stubbed_writer.write_record(DesiredIngestion())
-    await stubbed_writer.write_record(Flush)
-    stubbed_writer.ingest_strategy.flush.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_graph_database_writer_batches_appropriately(mocker):
     stubbed_writer = GraphDatabaseWriter(10, mocker.AsyncMock())
     for _ in range(100):

--- a/tests/unit/pipeline/test_writers.py
+++ b/tests/unit/pipeline/test_writers.py
@@ -1,6 +1,7 @@
 import pytest
+from hamcrest import assert_that, equal_to
 
-from nodestream.pipeline.writers import LoggerWriter
+from nodestream.pipeline.writers import LoggerWriter, Flush
 
 
 @pytest.mark.asyncio
@@ -10,3 +11,20 @@ async def test_write_item(mocker):
     item = "test"
     await writer.write_record(item)
     writer.logger.log.assert_called_once_with(writer.level, item)
+
+
+@pytest.mark.asyncio
+async def test_writers_flush_on_write(mocker):
+    writer = LoggerWriter()
+    writer.flush = mocker.AsyncMock()
+    writer.write_record = mocker.AsyncMock()
+
+    async def input():
+        yield 1
+        yield Flush
+        yield 2
+
+    results = [r async for r in writer.handle_async_record_stream(input())]
+    assert_that(results, equal_to([1, Flush, 2]))
+    assert_that(writer.write_record.await_count, equal_to(2))
+    assert_that(writer.flush.await_count, equal_to(1))

--- a/tests/unit/pipeline/test_writers.py
+++ b/tests/unit/pipeline/test_writers.py
@@ -1,7 +1,7 @@
 import pytest
 from hamcrest import assert_that, equal_to
 
-from nodestream.pipeline.writers import LoggerWriter, Flush
+from nodestream.pipeline.writers import Flush, LoggerWriter
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR introduces two fixes in `Writer` Logic:

- `Writers` did not handle flush globally, but rather required it to be handled locally. This pulls additional handling to the `Writer` base class. 
- Hooks were re-executed between batches. 