### PR TITLE
Update README license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Fast, Declarative ETL for Graph Databases._
 
 [![Continuous Integration](https://github.com/nodestream-proj/nodestream/actions/workflows/ci.yaml/badge.svg)](https://github.com/nodestream-proj/nodestream/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/nodestream-proj/nodestream/branch/main/graph/badge.svg?token=HAPEVKQ6OQ)](https://codecov.io/gh/nodestream-proj/nodestream)
-[![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
+[![ApacheV2 License](https://img.shields.io/badge/License-Apache%202.0-yellow.svg)](https://opensource.org/license/apache-2-0/)
 [![PyPI version](https://badge.fury.io/py/nodestream.svg)](https://badge.fury.io/py/nodestream)
 
 ## Features


### PR DESCRIPTION
README license badge is showing GPL3, while the LICENSE in the repo is Apache 2.0. Updating the badge to reflect the license change.