### PR TITLE
Use Multi-Part Copy when Archiving S3 Objects from Processing

### DIFF
--- a/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
+++ b/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
@@ -48,7 +48,7 @@ class S3Extractor(Extractor):
         if self.archive_dir:
             self.logger.info("Archiving S3 Object", extra=dict(key=key))
             filename = Path(key).name
-            self.s3_client.copy_object(
+            self.s3_client.copy(
                 Bucket=self.bucket,
                 Key=f"{self.archive_dir}/{filename}",
                 CopySource={"Bucket": self.bucket, "Key": key},


### PR DESCRIPTION
Some pipelines have been failing because of the following error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/nodestream/pipeline/extractors/stores/aws/s3_extractor.py", line 90, in extract_records
    self.archive_s3_object(key)
  File "/usr/local/lib/python3.11/site-packages/nodestream/pipeline/extractors/stores/aws/s3_extractor.py", line 51, in archive_s3_object
    self.s3_client.copy_object(
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 553, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 1009, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidRequest) when calling the CopyObject operation: The specified copy source is larger than the maximum allowable size for a copy source: 5368709120
```

Googled the error and this may be a fix:
https://stackoverflow.com/questions/52879356/boto3-copy-object-failing-on-size-5gb