### PR TITLE
Make nodes with No ID invalid

### DIFF
--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -88,7 +88,10 @@ class Node(DeduplicatableObject):
     @property
     def has_valid_id(self) -> bool:
         # Return that some of the ID values are defined.
-        return all(value is not None for value in self.key_values.values())
+        all_key_parts_defined = all(
+            value is not None for value in self.key_values.values()
+        )
+        return len(self.key_values) > 0 and all_key_parts_defined
 
     @property
     def is_valid(self) -> bool:

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -10,6 +10,11 @@ from nodestream.model import (
 )
 
 
+def test_node_with_no_keys_is_invalid():
+    node = Node("Person", {})
+    assert_that(node.has_valid_id, equal_to(False))
+
+
 def test_node_into_ingest():
     node = Node("Person", {"name": "John"})
     ingest = node.into_ingest()


### PR DESCRIPTION
Much of the code base assumes that nodes with no key parts are not possible (which is by design). However, the logic to invalidate nodes that do not have a key defined is not present. note: `all` on an empty iterable returns `True`. 

This closes #248 