### PR TITLE
use consistent timestamp types betwean ingested_at and ttl timestamp …

### DIFF
--- a/nodestream/databases/neo4j/ingest_query_builder.py
+++ b/nodestream/databases/neo4j/ingest_query_builder.py
@@ -1,7 +1,7 @@
 import re
-from datetime import datetime, timedelta
 from functools import cache, wraps
 from typing import Iterable
+from pandas import Timedelta, Timestamp
 
 from cymple.builder import NodeAfterMergeAvailable, NodeAvailable, QueryBuilder
 
@@ -228,7 +228,7 @@ class Neo4jIngestQueryBuilder:
         return QueryBatch(query, params)
 
     def generate_ttl_match_query(self, config: TimeToLiveConfiguration) -> Query:
-        earliest_allowed_time = datetime.utcnow() - timedelta(
+        earliest_allowed_time = Timestamp.utcnow() - Timedelta(
             hours=config.expiry_in_hours
         )
         params = {"earliest_allowed_time": earliest_allowed_time}

--- a/nodestream/databases/neo4j/ingest_query_builder.py
+++ b/nodestream/databases/neo4j/ingest_query_builder.py
@@ -1,9 +1,9 @@
 import re
 from functools import cache, wraps
 from typing import Iterable
-from pandas import Timedelta, Timestamp
 
 from cymple.builder import NodeAfterMergeAvailable, NodeAvailable, QueryBuilder
+from pandas import Timedelta, Timestamp
 
 from ...model import (
     Node,

--- a/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
+++ b/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from unittest.mock import patch
 
+from pandas import Timestamp
 import pytest
-from freezegun import freeze_time
 from hamcrest import assert_that, equal_to, equal_to_ignoring_whitespace
 
 from nodestream.databases.neo4j.ingest_query_builder import (
@@ -30,7 +30,7 @@ def query_builder():
     return Neo4jIngestQueryBuilder(True)
 
 
-GREATEST_DAY = datetime(1998, 3, 25, 2, 0, 1)
+GREATEST_DAY = Timestamp(1998, 3, 25, 2, 0, 1)
 
 BASIC_NODE_TTL = TimeToLiveConfiguration(
     graph_object_type=GraphObjectType.NODE,
@@ -91,6 +91,7 @@ REL_TTL_WITH_CUSTOM_QUERY_EXPECTED_QUERY = Query(
 )
 
 
+@patch("pandas.Timestamp.utcnow")
 @pytest.mark.parametrize(
     "ttl,expected_query",
     [
@@ -100,8 +101,8 @@ REL_TTL_WITH_CUSTOM_QUERY_EXPECTED_QUERY = Query(
         (REL_TTL_WITH_CUSTOM_QUERY, REL_TTL_WITH_CUSTOM_QUERY_EXPECTED_QUERY),
     ],
 )
-@freeze_time("1998-03-25 12:00:01")
-def test_generates_expected_queries(query_builder, ttl, expected_query):
+def test_generates_expected_queries(mocked_utcnow, query_builder, ttl, expected_query):
+    mocked_utcnow.return_value = Timestamp(1998, 3, 25, 12, 0, 1)
     resultant_query = query_builder.generate_ttl_query_from_configuration(ttl)
     assert_that(resultant_query, equal_to(expected_query))
 

--- a/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
+++ b/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch
 
-from pandas import Timestamp
 import pytest
 from hamcrest import assert_that, equal_to, equal_to_ignoring_whitespace
+from pandas import Timestamp
 
 from nodestream.databases.neo4j.ingest_query_builder import (
     DELETE_NODE_QUERY,


### PR DESCRIPTION
## Bugfix

- TTL's were not matching in the ttl match query due to a different format being used in the `ingested_at` time value causing ttls to never delete objects.
- Switched the ttl match query to use pandas Timestamp since it is the more efficient time lib.