### PR TITLE
Support Multiple Databases On `nodestream new` 

### DIFF
--- a/nodestream/cli/operations/run_project_cookiecutter.py
+++ b/nodestream/cli/operations/run_project_cookiecutter.py
@@ -15,6 +15,9 @@ class RunProjectCookiecutter(Operation):
     async def perform(self, _: NodestreamCommand):
         from ..application import get_version
 
+        version = get_version()
+        semver_non_patch_version = ".".join(version.split(".")[:2])
+
         cookiecutter(
             PROJECT_COOKIECUTTER_URL,
             no_input=True,
@@ -22,6 +25,7 @@ class RunProjectCookiecutter(Operation):
             extra_context={
                 "project_name": self.project_name,
                 "database": self.database,
-                "nodestream_version": get_version(),
+                "nodestream_version": version,
+                "nodestream_semver_non_patch_version": semver_non_patch_version,
             },
         )

--- a/tests/unit/cli/operations/test_run_project_cookiecutter.py
+++ b/tests/unit/cli/operations/test_run_project_cookiecutter.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.mark.asyncio
 async def test_perform(mocker, project_dir):
     from nodestream.cli.operations.run_project_cookiecutter import (
-        RunProjectCookiecutter,
         PROJECT_COOKIECUTTER_URL,
+        RunProjectCookiecutter,
     )
 
     mocked_cookiecutter = mocker.patch(

--- a/tests/unit/cli/operations/test_run_project_cookiecutter.py
+++ b/tests/unit/cli/operations/test_run_project_cookiecutter.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_perform(mocker, project_dir):
+    from nodestream.cli.operations.run_project_cookiecutter import (
+        RunProjectCookiecutter,
+        PROJECT_COOKIECUTTER_URL,
+    )
+
+    mocked_cookiecutter = mocker.patch(
+        "nodestream.cli.operations.run_project_cookiecutter.cookiecutter"
+    )
+    mocker.patch("nodestream.cli.application.get_version", return_value="0.12.0")
+    subject = RunProjectCookiecutter("project_name", str(project_dir), "neo4j")
+    await subject.perform(mocker.Mock())
+    mocked_cookiecutter.assert_called_once_with(
+        PROJECT_COOKIECUTTER_URL,
+        no_input=True,
+        output_dir=str(project_dir),
+        extra_context={
+            "project_name": "project_name",
+            "database": "neo4j",
+            "nodestream_version": "0.12.0",
+            "nodestream_semver_non_patch_version": "0.12",
+        },
+    )


### PR DESCRIPTION
Compliments changes from this PR: 

https://github.com/nodestream-proj/nodestream-project-cookiecutter/pull/1