### PR TITLE
fix jsonl line parsing

### DIFF
--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -68,7 +68,7 @@ class LineSeperatedJsonFileFormat(SupportedFileFormat, alias=".jsonl"):
 
 class TextFileFormat(SupportedFileFormat, alias=".txt"):
     def read_file_from_handle(self, fp: IOBase) -> Iterable[JsonLikeDocument]:
-        return ({"line": line.decode("utf-8").strip()} for line in fp.readlines())
+        return ({"line": line.strip()} for line in fp.readlines())
 
 
 class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -6,7 +6,6 @@ from csv import DictReader
 from glob import glob
 from io import BufferedReader, IOBase, TextIOWrapper
 from pathlib import Path
-from tempfile import SpooledTemporaryFile
 from typing import Any, AsyncGenerator, Iterable, Union
 
 from httpx import AsyncClient

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -147,7 +147,9 @@ class RemoteFileExtractor(Extractor):
                 async for chunk in response.aiter_bytes():
                     fp.write(chunk)
             fp.seek(0)
-            yield SupportedFileFormat.from_file_pointer_and_format(fp, Path(url).suffix)
+            yield SupportedFileFormat.from_file_pointer_and_format(
+                BufferedReader(fp), Path(url).suffix
+            )
 
     async def extract_records(self) -> AsyncGenerator[Any, Any]:
         async with AsyncClient() as client:

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -37,7 +37,11 @@ class SupportedFileFormat(Pluggable, ABC):
     def read_file(self) -> Iterable[JsonLikeDocument]:
         with self.read_handle() as fp:
             if self.reader is not None:
-                reader = self.reader(fp)
+                if self.reader is TextIOWrapper:
+                    reader = self.reader(fp, encoding="utf-8")
+                else:
+                    reader = self.reader(fp)
+
             else:
                 reader = fp
             return self.read_file_from_handle(reader)
@@ -95,8 +99,6 @@ class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):
     def read_file_from_handle(
         self, reader: TextIOWrapper
     ) -> Iterable[JsonLikeDocument]:
-        if not isinstance(reader, TextIOWrapper):
-            return DictReader(TextIOWrapper(reader))
         return DictReader(reader)
 
 

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -63,12 +63,12 @@ class JsonFileFormat(SupportedFileFormat, alias=".json"):
 
 class LineSeperatedJsonFileFormat(SupportedFileFormat, alias=".jsonl"):
     def read_file_from_handle(self, fp: StringIO) -> Iterable[JsonLikeDocument]:
-        return (json.loads(line) for line in fp)
+        return (json.loads(line.strip()) for line in fp.readlines())
 
 
 class TextFileFormat(SupportedFileFormat, alias=".txt"):
     def read_file_from_handle(self, fp: StringIO) -> Iterable[JsonLikeDocument]:
-        return ({"line": line} for line in fp)
+        return ({"line": line} for line in fp.readlines())
 
 
 class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -63,12 +63,12 @@ class JsonFileFormat(SupportedFileFormat, alias=".json"):
 
 class LineSeperatedJsonFileFormat(SupportedFileFormat, alias=".jsonl"):
     def read_file_from_handle(self, fp: IOBase) -> Iterable[JsonLikeDocument]:
-        return (json.loads(line) for line in fp.readlines())
+        return (json.loads(line.strip()) for line in fp.readlines())
 
 
 class TextFileFormat(SupportedFileFormat, alias=".txt"):
     def read_file_from_handle(self, fp: IOBase) -> Iterable[JsonLikeDocument]:
-        return ({"line": line} for line in fp.readlines())
+        return ({"line": line.decode("utf-8").strip()} for line in fp.readlines())
 
 
 class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):

--- a/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
+++ b/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
@@ -81,7 +81,7 @@ def subject_with_populated_text_objects(subject, s3_client):
         s3_client.put_object(
             Bucket=BUCKET_NAME,
             Key=f"{PREFIX}/bar/{i}.txt",
-            Body="test\ntest2",
+            Body="test\ntest2\n",
         )
     return subject
 
@@ -113,11 +113,12 @@ async def test_s3_extractor_properly_loads_csv_files(
 
 @pytest.mark.asyncio
 async def test_s3_extractor_properly_loads_jsonl_files(
-    subject_with_populated_text_objects,
+    subject_with_populated_jsonl_objects,
 ):
     expected_results = [{"test": "test"}, {"test2": "test2"}]
     results = [
-        result async for result in subject_with_populated_text_objects.extract_records()
+        result
+        async for result in subject_with_populated_jsonl_objects.extract_records()
     ]
     assert_that(results, has_length(2))
     assert_that(results, has_items(*expected_results))
@@ -127,7 +128,7 @@ async def test_s3_extractor_properly_loads_jsonl_files(
 async def test_s3_extractor_properly_loads_text_files(
     subject_with_populated_text_objects,
 ):
-    expected_results = [{"line": "test"}, {"line": "test2"}]
+    expected_results = [{"line": b"test"}, {"line": b"test2"}]
     results = [
         result async for result in subject_with_populated_text_objects.extract_records()
     ]

--- a/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
+++ b/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
@@ -59,6 +59,7 @@ def subject_with_populated_csv_objects(subject, s3_client):
         )
     return subject
 
+
 @pytest.fixture
 def subject_with_populated_jsonl_objects(subject, s3_client):
     subject.s3_client = s3_client
@@ -70,6 +71,7 @@ def subject_with_populated_jsonl_objects(subject, s3_client):
             Body='{"test":"test"}\n{"test2":"test2"}',
         )
     return subject
+
 
 @pytest.fixture
 def subject_with_archieved_objects(subject_with_archiving_enabled, s3_client):
@@ -95,15 +97,15 @@ async def test_s3_extractor_properly_loads_csv_files(
     assert_that(results, has_length(NUM_OBJECTS))
     assert_that(results, has_items(*expected_results))
 
+
 @pytest.mark.asyncio
 async def test_s3_extractor_properly_loads_jsonl_files(
     subject_with_populated_jsonl_objects,
 ):
-    expected_results = [
-        {"test": "test"}, {"test2": "test2"}
-    ]
+    expected_results = [{"test": "test"}, {"test2": "test2"}]
     results = [
-        result async for result in subject_with_populated_jsonl_objects.extract_records()
+        result
+        async for result in subject_with_populated_jsonl_objects.extract_records()
     ]
     assert_that(results, has_length(2))
     assert_that(results, has_items(*expected_results))

--- a/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
+++ b/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
@@ -128,7 +128,7 @@ async def test_s3_extractor_properly_loads_jsonl_files(
 async def test_s3_extractor_properly_loads_text_files(
     subject_with_populated_text_objects,
 ):
-    expected_results = [{"line": b"test"}, {"line": b"test2"}]
+    expected_results = [{"line": "test"}, {"line": "test2"}]
     results = [
         result async for result in subject_with_populated_text_objects.extract_records()
     ]

--- a/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
+++ b/tests/unit/pipeline/extractors/stores/aws/test_s3_extractor.py
@@ -59,6 +59,17 @@ def subject_with_populated_csv_objects(subject, s3_client):
         )
     return subject
 
+@pytest.fixture
+def subject_with_populated_jsonl_objects(subject, s3_client):
+    subject.s3_client = s3_client
+    s3_client.create_bucket(Bucket=BUCKET_NAME)
+    for i in range(1):
+        s3_client.put_object(
+            Bucket=BUCKET_NAME,
+            Key=f"{PREFIX}/bar/{i}.jsonl",
+            Body='{"test":"test"}\n{"test2":"test2"}',
+        )
+    return subject
 
 @pytest.fixture
 def subject_with_archieved_objects(subject_with_archiving_enabled, s3_client):
@@ -82,6 +93,19 @@ async def test_s3_extractor_properly_loads_csv_files(
         result async for result in subject_with_populated_csv_objects.extract_records()
     ]
     assert_that(results, has_length(NUM_OBJECTS))
+    assert_that(results, has_items(*expected_results))
+
+@pytest.mark.asyncio
+async def test_s3_extractor_properly_loads_jsonl_files(
+    subject_with_populated_jsonl_objects,
+):
+    expected_results = [
+        {"test": "test"}, {"test2": "test2"}
+    ]
+    results = [
+        result async for result in subject_with_populated_jsonl_objects.extract_records()
+    ]
+    assert_that(results, has_length(2))
     assert_that(results, has_items(*expected_results))
 
 


### PR DESCRIPTION
- Fix error when parsing jsonl documents from s3 extractor.
- iterator of `StringIO` type returns type `bytes`, using iterator of `StringIO.readlines()` returns type `str`
- File reader open as bytes and specify reader in file handlers