### PR TITLE
Correct batchsize to be batchSize

### DIFF
--- a/nodestream/databases/neo4j/query.py
+++ b/nodestream/databases/neo4j/query.py
@@ -6,7 +6,7 @@ COMMIT_QUERY = """
 CALL apoc.periodic.iterate(
     $iterable_query,
     $batched_query,
-    {batchsize: 1000, parallel: true, retries: 3, params: $iterate_params}
+    {batchSize: 1000, parallel: true, retries: 3, params: $iterate_params}
 )
 YIELD batches, committedOperations, failedOperations, errorMessages
 RETURN batches, committedOperations, failedOperations, errorMessages


### PR DESCRIPTION
This was a typo from the query. This value is being ignored because of casing. 

The reason this value should can be set is that large transactions can cause major turmoil when it its updating with large transactions of relationships (Especially against large data sets). 

See here in the docs:
https://neo4j.com/docs/apoc/current/overview/apoc.periodic/apoc.periodic.iterate/