### PR TITLE
Improve Neo4j Query Performance By Using MERGE

### DIFF
--- a/nodestream/databases/neo4j/database_connector.py
+++ b/nodestream/databases/neo4j/database_connector.py
@@ -21,7 +21,7 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         use_enterprise_features: bool = False,
         use_apoc: bool = True,
         chunk_size: int = 1000,
-        execute_chunks_in_paralell: bool = True,
+        execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
         **driver_kwargs
     ):
@@ -38,7 +38,7 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
             ingest_query_builder=Neo4jIngestQueryBuilder(use_apoc),
             database_name=database_name,
             chunk_size=chunk_size,
-            execute_chunks_in_paralell=execute_chunks_in_paralell,
+            execute_chunks_in_parallel=execute_chunks_in_parallel,
             retries_per_chunk=retries_per_chunk,
         )
 
@@ -49,7 +49,7 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         ingest_query_builder: Neo4jIngestQueryBuilder,
         database_name: str,
         chunk_size: int = 1000,
-        execute_chunks_in_paralell: bool = True,
+        execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
     ) -> None:
         self.driver = driver
@@ -57,7 +57,7 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         self.ingest_query_builder = ingest_query_builder
         self.database_name = database_name
         self.chunk_size = chunk_size
-        self.execute_chunks_in_paralell = execute_chunks_in_paralell
+        self.execute_chunks_in_parallel = execute_chunks_in_parallel
         self.retries_per_chunk = retries_per_chunk
 
     def make_query_executor(self) -> QueryExecutor:
@@ -69,7 +69,7 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
             self.index_query_builder,
             self.database_name,
             chunk_size=self.chunk_size,
-            execute_chunks_in_paralell=self.execute_chunks_in_paralell,
+            execute_chunks_in_parallel=self.execute_chunks_in_parallel,
             retries_per_chunk=self.retries_per_chunk,
         )
 

--- a/nodestream/databases/neo4j/database_connector.py
+++ b/nodestream/databases/neo4j/database_connector.py
@@ -20,6 +20,9 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         database_name: str = "neo4j",
         use_enterprise_features: bool = False,
         use_apoc: bool = True,
+        chunk_size: int = 1000,
+        execute_chunks_in_paralell: bool = True,
+        retries_per_chunk: int = 3,
         **driver_kwargs
     ):
         driver = AsyncGraphDatabase.driver(
@@ -34,6 +37,9 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
             index_query_builder=index_query_builder,
             ingest_query_builder=Neo4jIngestQueryBuilder(use_apoc),
             database_name=database_name,
+            chunk_size=chunk_size,
+            execute_chunks_in_paralell=execute_chunks_in_paralell,
+            retries_per_chunk=retries_per_chunk,
         )
 
     def __init__(
@@ -42,11 +48,17 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         index_query_builder: Neo4jIndexQueryBuilder,
         ingest_query_builder: Neo4jIngestQueryBuilder,
         database_name: str,
+        chunk_size: int = 1000,
+        execute_chunks_in_paralell: bool = True,
+        retries_per_chunk: int = 3,
     ) -> None:
         self.driver = driver
         self.index_query_builder = index_query_builder
         self.ingest_query_builder = ingest_query_builder
         self.database_name = database_name
+        self.chunk_size = chunk_size
+        self.execute_chunks_in_paralell = execute_chunks_in_paralell
+        self.retries_per_chunk = retries_per_chunk
 
     def make_query_executor(self) -> QueryExecutor:
         from .query_executor import Neo4jQueryExecutor
@@ -56,6 +68,9 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
             self.ingest_query_builder,
             self.index_query_builder,
             self.database_name,
+            chunk_size=self.chunk_size,
+            execute_chunks_in_paralell=self.execute_chunks_in_paralell,
+            retries_per_chunk=self.retries_per_chunk,
         )
 
     def make_type_retriever(self) -> TypeRetriever:

--- a/nodestream/databases/neo4j/ingest_query_builder.py
+++ b/nodestream/databases/neo4j/ingest_query_builder.py
@@ -94,9 +94,9 @@ def _make_relationship(
     rel_identity: RelationshipIdentityShape, creation_rule: RelationshipCreationRule
 ):
     keys = generate_properties_set_with_prefix(rel_identity.keys, RELATIONSHIP_REF_NAME)
-    match_rel_query = (
+    merge_rel_query = (
         QueryBuilder()
-        .match_optional()
+        .merge()
         .node(ref_name=FROM_NODE_REF_NAME)
         .related_to(
             ref_name=RELATIONSHIP_REF_NAME,
@@ -106,18 +106,12 @@ def _make_relationship(
         .node(ref_name=TO_NODE_REF_NAME)
     )
 
-    create_rel_query = str(match_rel_query).replace("OPTIONAL MATCH ", "CREATE")
     set_properties_query = f"SET {RELATIONSHIP_REF_NAME} += params.{generate_prefixed_param_name(PROPERTIES_PARAM_NAME, RELATIONSHIP_REF_NAME)}"
     if creation_rule == RelationshipCreationRule.CREATE:
+        create_rel_query = str(merge_rel_query).replace("MERGE", "CREATE")
         return f"{create_rel_query} {set_properties_query}"
 
-    return f"""
-    {match_rel_query}
-    FOREACH (x IN CASE WHEN {RELATIONSHIP_REF_NAME} IS NULL THEN [1] ELSE [] END |
-        {create_rel_query} {set_properties_query})
-    FOREACH (i in CASE WHEN {RELATIONSHIP_REF_NAME} IS NOT NULL THEN [1] ELSE [] END |
-        {set_properties_query})
-    """
+    return f"{merge_rel_query} {set_properties_query}"
 
 
 class Neo4jIngestQueryBuilder:

--- a/nodestream/databases/neo4j/query.py
+++ b/nodestream/databases/neo4j/query.py
@@ -6,7 +6,7 @@ COMMIT_QUERY = """
 CALL apoc.periodic.iterate(
     $iterable_query,
     $batched_query,
-    {batchSize: $chunk_size, parallel: $execute_chunks_in_paralell, retries: $retries_per_chunk, params: $iterate_params}
+    {batchSize: $chunk_size, parallel: $execute_chunks_in_parallel, retries: $retries_per_chunk, params: $iterate_params}
 )
 YIELD batches, committedOperations, failedOperations, errorMessages
 RETURN batches, committedOperations, failedOperations, errorMessages
@@ -50,7 +50,7 @@ class QueryBatch:
         self,
         apoc_iterate: bool,
         chunk_size: int = 1000,
-        execute_chunks_in_paralell: bool = True,
+        execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
     ) -> Query:
         return Query(
@@ -61,7 +61,7 @@ class QueryBatch:
                 },
                 "batched_query": self.query_statement,
                 "iterable_query": UNWIND_QUERY,
-                "execute_chunks_in_paralell": execute_chunks_in_paralell,
+                "execute_chunks_in_parallel": execute_chunks_in_parallel,
                 "chunk_size": chunk_size,
                 "retries_per_chunk": retries_per_chunk,
             },

--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -12,7 +12,7 @@ from ..query_executor import (
 )
 from .index_query_builder import Neo4jIndexQueryBuilder
 from .ingest_query_builder import Neo4jIngestQueryBuilder
-from .query import Query
+from .query import Query, QueryBatch
 
 
 class Neo4jQueryExecutor(QueryExecutor):
@@ -22,12 +22,29 @@ class Neo4jQueryExecutor(QueryExecutor):
         ingest_query_builder: Neo4jIngestQueryBuilder,
         index_query_builder: Neo4jIndexQueryBuilder,
         database_name: str,
+        chunk_size: int = 1000,
+        execute_chunks_in_paralell: bool = True,
+        retries_per_chunk: int = 3,
     ) -> None:
         self.driver = driver
         self.ingest_query_builder = ingest_query_builder
         self.index_query_builder = index_query_builder
         self.logger = getLogger(self.__class__.__name__)
         self.database_name = database_name
+        self.chunk_size = chunk_size
+        self.execute_chunks_in_paralell = execute_chunks_in_paralell
+        self.retries_per_chunk = retries_per_chunk
+
+    async def execute_query_batch(self, batch: QueryBatch):
+        await self.execute(
+            batch.as_query(
+                self.ingest_query_builder.apoc_iterate,
+                chunk_size=self.chunk_size,
+                execute_chunks_in_paralell=self.execute_chunks_in_paralell,
+                retries_per_chunk=self.retries_per_chunk,
+            ),
+            log_result=True,
+        )
 
     async def upsert_nodes_in_bulk_with_same_operation(
         self, operation: OperationOnNodeIdentity, nodes: Iterable[Node]
@@ -37,10 +54,7 @@ class Neo4jQueryExecutor(QueryExecutor):
                 operation, nodes
             )
         )
-        await self.execute(
-            batched_query.as_query(self.ingest_query_builder.apoc_iterate),
-            log_result=True,
-        )
+        await self.execute_query_batch(batched_query)
 
     async def upsert_relationships_in_bulk_of_same_operation(
         self,
@@ -52,10 +66,7 @@ class Neo4jQueryExecutor(QueryExecutor):
                 shape, relationships
             )
         )
-        await self.execute(
-            batched_query.as_query(self.ingest_query_builder.apoc_iterate),
-            log_result=True,
-        )
+        await self.execute_query_batch(batched_query)
 
     async def upsert_key_index(self, index: KeyIndex):
         query = self.index_query_builder.create_key_index_query(index)

--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -23,7 +23,7 @@ class Neo4jQueryExecutor(QueryExecutor):
         index_query_builder: Neo4jIndexQueryBuilder,
         database_name: str,
         chunk_size: int = 1000,
-        execute_chunks_in_paralell: bool = True,
+        execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
     ) -> None:
         self.driver = driver
@@ -32,7 +32,7 @@ class Neo4jQueryExecutor(QueryExecutor):
         self.logger = getLogger(self.__class__.__name__)
         self.database_name = database_name
         self.chunk_size = chunk_size
-        self.execute_chunks_in_paralell = execute_chunks_in_paralell
+        self.execute_chunks_in_parallel = execute_chunks_in_parallel
         self.retries_per_chunk = retries_per_chunk
 
     async def execute_query_batch(self, batch: QueryBatch):
@@ -40,7 +40,7 @@ class Neo4jQueryExecutor(QueryExecutor):
             batch.as_query(
                 self.ingest_query_builder.apoc_iterate,
                 chunk_size=self.chunk_size,
-                execute_chunks_in_paralell=self.execute_chunks_in_paralell,
+                execute_chunks_in_parallel=self.execute_chunks_in_parallel,
                 retries_per_chunk=self.retries_per_chunk,
             ),
             log_result=True,

--- a/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
+++ b/tests/unit/databases/neo4j/test_ingest_query_buiilder.py
@@ -194,11 +194,7 @@ RELATIONSHIP_BETWEEN_TWO_NODES = RelationshipWithNodes(
 
 RELATIONSHIP_BETWEEN_TWO_NODES_EXPECTED_QUERY = QueryBatch(
     """MATCH (from_node: TestType) WHERE from_node.id = params.__from_node_id MATCH (to_node: ComplexType) WHERE to_node.id = params.__to_node_id
-    OPTIONAL MATCH  (from_node)-[rel: RELATED_TO]->(to_node)
-    FOREACH (x IN CASE WHEN rel IS NULL THEN [1] ELSE [] END |
-        CREATE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties)
-    FOREACH (i in CASE WHEN rel IS NOT NULL THEN [1] ELSE [] END |
-        SET rel += params.__rel_properties)
+    MERGE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties
     """,
     [
         {
@@ -217,12 +213,7 @@ RELATIONSHIP_BETWEEN_TWO_NODES_WITH_MULTI_KEY = RelationshipWithNodes(
 
 RELATIONSHIP_BETWEEN_TWO_NODES_EXPECTED_QUERY_WITH_MULTI_KEY = QueryBatch(
     """MATCH (from_node: TestType) WHERE from_node.id = params.__from_node_id MATCH (to_node: ComplexType) WHERE to_node.id_part1 = params.__to_node_id_part1 AND to_node.id_part2 = params.__to_node_id_part2
-    OPTIONAL MATCH  (from_node)-[rel: RELATED_TO]->(to_node)
-    FOREACH (x IN CASE WHEN rel IS NULL THEN [1] ELSE [] END |
-        CREATE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties)
-    FOREACH (i in CASE WHEN rel IS NOT NULL THEN [1] ELSE [] END |
-        SET rel += params.__rel_properties)
-    """,
+    MERGE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties""",
     [
         {
             "__from_node_id": "foo",

--- a/tests/unit/databases/neo4j/test_query_executor.py
+++ b/tests/unit/databases/neo4j/test_query_executor.py
@@ -26,6 +26,22 @@ def query_executor(mocker):
 
 
 @pytest.mark.asyncio
+async def test_execute_query_batch(query_executor, some_query_batch, mocker):
+    query_executor.execute = mocker.AsyncMock()
+    await query_executor.execute_query_batch(some_query_batch)
+    query_executor.execute.assert_called_once_with(
+        some_query_batch.as_query(
+            query_executor.ingest_query_builder.apoc_iterate,
+            chunk_size=query_executor.chunk_size,
+            execute_chunks_in_parallel=query_executor.execute_chunks_in_parallel,
+            retries_per_chunk=query_executor.retries_per_chunk,
+        ),
+        log_result=True,
+    )
+    query_executor.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_upsert_nodes_in_bulk_of_same_operation(
     mocker, query_executor, some_query_batch
 ):


### PR DESCRIPTION
Due to some internal analysis done by intuit, while this query does perform better is certain situations, in others it can cause memory consumption spikes in the 10s of GBs on the cluster and can cause stability and consistency issues. This PR approaches using the more obvious MERGE path and leaving it to the database to execute this more in a stable manor. This PR also adds several settings (currently undocumented) that allow for some tweaking of the underlying batch performance. 


NOTE: Docs excluded from this PR pending the docs revamp. 