### PR TITLE
Fix nodes with key properties of differing types crashing nodestream

### DIFF
--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -139,7 +139,7 @@ class Node(DeduplicatableObject):
         self.properties.update(other.properties)
 
     def get_dedup_key(self) -> tuple:
-        return tuple(sorted(self.key_values.values()))
+        return tuple(sorted(self.key_values.items()))
 
     def into_ingest(self) -> "DesiredIngestion":
         from .desired_ingestion import DesiredIngestion

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -76,3 +76,25 @@ def test_get_cached_timestamp():
 
     third = get_cached_timestamp(epoch=t + 2.1)
     assert_that(third, not_(same_instance(first)))
+
+
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        (
+            {"name": "John"},
+            (("name", "John"),),
+        ),
+        ({"name": "John", "age": 30}, (("age", 30), ("name", "John"))),
+        (
+            {"name": "John", "age": 30, "city": "New York"},
+            (("age", 30), ("city", "New York"), ("name", "John")),
+        ),
+    ],
+)
+def test_get_dedup_key(keys, expected):
+    node = Node("Person", keys)
+    assert_that(node.get_dedup_key(), equal_to(expected))
+
+    other = Node("Person", keys)
+    assert_that(node.get_dedup_key(), equal_to(other.get_dedup_key()))


### PR DESCRIPTION
This worked more by coincidence than by design. The key needs to be ordered by the pairs not just the values. 