### PR TITLE
Regression: Fix Issue with Scope Config Being Dropped

### DIFF
--- a/nodestream/pipeline/step.py
+++ b/nodestream/pipeline/step.py
@@ -22,6 +22,10 @@ class Step(ABC):
 class PassStep(Step):
     """A `PassStep` is a step that does nothing."""
 
+    def __init__(self, **kwargs) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
     async def handle_async_record_stream(
         self, record_stream: AsyncGenerator[Any, Any]
     ) -> AsyncGenerator[Any, Any]:

--- a/tests/unit/pipeline/test_pipeline_file.py
+++ b/tests/unit/pipeline/test_pipeline_file.py
@@ -9,6 +9,7 @@ from nodestream.pipeline.pipeline_file_loader import (
     PipelineFileContents,
     PipelineInitializationArguments,
     StepDefinition,
+    ScopeConfig,
 )
 from nodestream.pipeline.step import PassStep
 
@@ -64,4 +65,18 @@ def test_pipeline_file_loads_lazy():
     assert_that(
         file_contents.step_definitions[0].arguments,
         equal_to({"name": LazyLoadedArgument("config", "name")}),
+    )
+
+
+def test_pipeline_file_loads_config_when_set():
+    init_args = PipelineInitializationArguments(
+        effecitve_config_values=ScopeConfig({"name": "test"})
+    )
+    file_contents = PipelineFileContents.read_from_file(
+        Path("tests/unit/pipeline/fixtures/config_pipeline.yaml")
+    )
+    loaded_pipeline = file_contents.initialize_with_arguments(init_args)
+    assert_that(
+        loaded_pipeline.steps[0].name,
+        equal_to("test"),
     )

--- a/tests/unit/pipeline/test_pipeline_file.py
+++ b/tests/unit/pipeline/test_pipeline_file.py
@@ -8,8 +8,8 @@ from nodestream.pipeline.pipeline_file_loader import (
     PipelineFile,
     PipelineFileContents,
     PipelineInitializationArguments,
-    StepDefinition,
     ScopeConfig,
+    StepDefinition,
 )
 from nodestream.pipeline.step import PassStep
 


### PR DESCRIPTION
Due to a missing/ineffective test during the refactor, setting scope level config was not working.  This PR adds back setting scope level config and adds a test that ensures that set config is loaded from yaml correctly. 