### PR TITLE
Modified the normalizer to handle single values properly + Neo4j Writer Logs URI

### DIFF
--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -25,7 +25,6 @@ class Neo4jQueryExecutor(QueryExecutor):
         chunk_size: int = 1000,
         execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
-        alias: str = "neo4j-default",
     ) -> None:
         self.driver = driver
         self.ingest_query_builder = ingest_query_builder
@@ -35,7 +34,6 @@ class Neo4jQueryExecutor(QueryExecutor):
         self.chunk_size = chunk_size
         self.execute_chunks_in_parallel = execute_chunks_in_parallel
         self.retries_per_chunk = retries_per_chunk
-        self.alias = alias
 
     async def execute_query_batch(self, batch: QueryBatch):
         await self.execute(
@@ -104,5 +102,5 @@ class Neo4jQueryExecutor(QueryExecutor):
             for record in result.records:
                 self.logger.info(
                     "Gathered Query Results",
-                    extra=dict(**record, query=query.query_statement, alias=self.alias),
+                    extra=dict(**record, query=query.query_statement, uri=self.driver._pool.address.host),
                 )

--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -25,7 +25,7 @@ class Neo4jQueryExecutor(QueryExecutor):
         chunk_size: int = 1000,
         execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
-        alias: str = "neo4j-default"
+        alias: str = "neo4j-default",
     ) -> None:
         self.driver = driver
         self.ingest_query_builder = ingest_query_builder

--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -102,5 +102,9 @@ class Neo4jQueryExecutor(QueryExecutor):
             for record in result.records:
                 self.logger.info(
                     "Gathered Query Results",
-                    extra=dict(**record, query=query.query_statement, uri=self.driver._pool.address.host),
+                    extra=dict(
+                        **record,
+                        query=query.query_statement,
+                        uri=self.driver._pool.address.host
+                    ),
                 )

--- a/nodestream/databases/neo4j/query_executor.py
+++ b/nodestream/databases/neo4j/query_executor.py
@@ -25,6 +25,7 @@ class Neo4jQueryExecutor(QueryExecutor):
         chunk_size: int = 1000,
         execute_chunks_in_parallel: bool = True,
         retries_per_chunk: int = 3,
+        alias: str = "neo4j-default"
     ) -> None:
         self.driver = driver
         self.ingest_query_builder = ingest_query_builder
@@ -34,6 +35,7 @@ class Neo4jQueryExecutor(QueryExecutor):
         self.chunk_size = chunk_size
         self.execute_chunks_in_parallel = execute_chunks_in_parallel
         self.retries_per_chunk = retries_per_chunk
+        self.alias = alias
 
     async def execute_query_batch(self, batch: QueryBatch):
         await self.execute(
@@ -102,5 +104,5 @@ class Neo4jQueryExecutor(QueryExecutor):
             for record in result.records:
                 self.logger.info(
                     "Gathered Query Results",
-                    extra=dict(**record, query=query.query_statement),
+                    extra=dict(**record, query=query.query_statement, alias=self.alias),
                 )

--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -277,6 +277,7 @@ class Pipeline(AggregatedIntrospectiveIngestionComponent):
         tasks = self.build_steps_into_tasks(progress_reporter)
         return_states = await asyncio.gather(*tasks, return_exceptions=True)
         self.propogate_errors_from_return_states(return_states)
+        self.logger.info("Pipeline Completed")
 
     def all_subordinate_components(self) -> Iterable[IntrospectiveIngestionComponent]:
         return (s for s in self.steps if isinstance(s, IntrospectiveIngestionComponent))

--- a/nodestream/pipeline/value_providers/normalizer_value_provider.py
+++ b/nodestream/pipeline/value_providers/normalizer_value_provider.py
@@ -13,7 +13,11 @@ class NormalizerValueProvider(ValueProvider):
         self.data = data
 
     def single_value(self, context: ProviderContext) -> Any:
-        return next(self.many_values(context))
+        values = list(self.many_values(context))
+        if values:
+            return next((value for value in values))
+        else:
+            return None
 
     def many_values(self, context: ProviderContext) -> Iterable[Any]:
         return map(self.normalizer.normalize_value, self.data.many_values(context))

--- a/nodestream/pipeline/value_providers/normalizer_value_provider.py
+++ b/nodestream/pipeline/value_providers/normalizer_value_provider.py
@@ -13,11 +13,7 @@ class NormalizerValueProvider(ValueProvider):
         self.data = data
 
     def single_value(self, context: ProviderContext) -> Any:
-        values = list(self.many_values(context))
-        if values:
-            return next((value for value in values))
-        else:
-            return None
+        return next(self.many_values(context), None)
 
     def many_values(self, context: ProviderContext) -> Iterable[Any]:
         return map(self.normalizer.normalize_value, self.data.many_values(context))

--- a/tests/integration/test_pipeline_error_propagation.py
+++ b/tests/integration/test_pipeline_error_propagation.py
@@ -127,7 +127,7 @@ async def test_immediate_error_propogation(interpreter):
     assert did_except
     ending_time = datetime.now()
     difference = ending_time - beginning_time
-    assert difference.total_seconds() < 0.4 * 2
+    assert difference.total_seconds() < 0.5 * 2
 
 
 # Testing that the exception is propagated. Also testing that we would see a failure in the stop-process if necessary.
@@ -144,7 +144,7 @@ async def test_immediate_error_propagation_fails_all_steps():
     did_except = False
 
     try:
-        await asyncio.wait_for(pipeline.run(), timeout=3.2 * 2)
+        await asyncio.wait_for(pipeline.run(), timeout=4.2 * 2)
     except PipelineException as exception:
         # Every step should have a Stepexeption except for the last one that has a Exception
         extractor_work_body_exception = exception.errors[0].exceptions[
@@ -160,4 +160,4 @@ async def test_immediate_error_propagation_fails_all_steps():
     assert did_except
     ending_time = datetime.now()
     difference = ending_time - beginning_time
-    assert difference.total_seconds() < 0.4 * 2
+    assert difference.total_seconds() < 0.5 * 2

--- a/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nodestream.pipeline.value_providers import NormalizerValueProvider
+from nodestream.pipeline.value_providers import NormalizerValueProvider, StaticValueProvider
 from nodestream.subclass_registry import MissingFromRegistryError
 
 from ...stubs import StubbedValueProvider
@@ -25,3 +25,16 @@ def test_invalid_normalizer(blank_context):
         NormalizerValueProvider(
             using="not_a_normalizer", data=StubbedValueProvider(["ABC"])
         )
+
+def test_empty_results_single(blank_context):
+    subject = NormalizerValueProvider(
+        using="lowercase_strings", data=StubbedValueProvider([])
+    )
+    assert subject.single_value(blank_context) == None
+
+
+def test_empty_results_many(blank_context):
+    subject = NormalizerValueProvider(
+        using="lowercase_strings", data=StubbedValueProvider([])
+    )
+    assert list(subject.many_values(blank_context)) == []

--- a/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
@@ -31,7 +31,7 @@ def test_empty_results_single(blank_context):
     subject = NormalizerValueProvider(
         using="lowercase_strings", data=StubbedValueProvider([])
     )
-    assert subject.single_value(blank_context) == None
+    assert subject.single_value(blank_context) is None
 
 
 def test_empty_results_many(blank_context):

--- a/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
@@ -1,6 +1,9 @@
 import pytest
 
-from nodestream.pipeline.value_providers import NormalizerValueProvider, StaticValueProvider
+from nodestream.pipeline.value_providers import (
+    NormalizerValueProvider,
+    StaticValueProvider,
+)
 from nodestream.subclass_registry import MissingFromRegistryError
 
 from ...stubs import StubbedValueProvider
@@ -25,6 +28,7 @@ def test_invalid_normalizer(blank_context):
         NormalizerValueProvider(
             using="not_a_normalizer", data=StubbedValueProvider(["ABC"])
         )
+
 
 def test_empty_results_single(blank_context):
     subject = NormalizerValueProvider(

--- a/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_normalizer_value_provider.py
@@ -1,9 +1,6 @@
 import pytest
 
-from nodestream.pipeline.value_providers import (
-    NormalizerValueProvider,
-    StaticValueProvider,
-)
+from nodestream.pipeline.value_providers import NormalizerValueProvider
 from nodestream.subclass_registry import MissingFromRegistryError
 
 from ...stubs import StubbedValueProvider


### PR DESCRIPTION
- Fixing a bug with the normalize value provider that crashes when the data returns None. 
- Adding database uri for logging. This can be used to specify logs between different database targets.
- Increase the timeout window for error collecting tests for more deterministic tests.