### PR TITLE
Fix Edge Cases in Schema Introspection

### DIFF
--- a/nodestream/interpreting/interpretations/interpretation.py
+++ b/nodestream/interpreting/interpretations/interpretation.py
@@ -11,6 +11,7 @@ INTERPRETATION_REGISTRY = SubclassRegistry()
 @INTERPRETATION_REGISTRY.connect_baseclass
 class Interpretation(ExpandsSchema, Pluggable, ABC):
     entrypoint_name = "interpretations"
+    assigns_source_nodes = False
 
     @abstractmethod
     def interpret(self, context: ProviderContext):

--- a/nodestream/interpreting/interpretations/source_node_interpretation.py
+++ b/nodestream/interpreting/interpretations/source_node_interpretation.py
@@ -72,6 +72,7 @@ class SourceNodeInterpretation(Interpretation, alias="source_node"):
     """
 
     SOURCE_NODE_TYPE_ALIAS = "source_node"
+    assigns_source_nodes = True
 
     __slots__ = (
         "node_type",

--- a/nodestream/interpreting/interpretations/switch_interpretation.py
+++ b/nodestream/interpreting/interpretations/switch_interpretation.py
@@ -1,13 +1,11 @@
-from typing import Any, Dict, Iterable, List
-
-from nodestream.schema.state import ExpandsSchema
+from typing import Any, Dict, List
 
 from ...pipeline.value_providers import (
     ProviderContext,
     StaticValueOrValueProvider,
     ValueProvider,
 )
-from ...schema import ExpandsSchemaFromChildren
+from ...schema import SchemaExpansionCoordinator
 from .interpretation import Interpretation
 
 
@@ -20,7 +18,7 @@ class UnhandledBranchError(ValueError):
         )
 
 
-class SwitchInterpretation(ExpandsSchemaFromChildren, Interpretation, alias="switch"):
+class SwitchInterpretation(Interpretation, alias="switch"):
     __slots__ = (
         "switch_on",
         "interpretations",
@@ -62,11 +60,25 @@ class SwitchInterpretation(ExpandsSchemaFromChildren, Interpretation, alias="swi
         self.normalization = normalization or {}
         self.fail_on_unhandled = fail_on_unhandled
 
-    def get_child_expanders(self) -> Iterable[ExpandsSchema]:
-        for child in self.interpretations.values():
-            yield from child
+    @property
+    def distinct_branches(self) -> bool:
+        # If all branches have at least one interpretation that assigns source nodes,
+        # then the branches are distinct and we should not merge their schemas.
+        return all(
+            any(interpretation.assigns_source_nodes for interpretation in branch)
+            for branch in self.interpretations.values()
+        )
+
+    def expand_schema(self, coordinator: SchemaExpansionCoordinator):
+        for branch in self.interpretations.values():
+            for interpretation in branch:
+                interpretation.expand_schema(coordinator)
+            if self.distinct_branches:
+                coordinator.clear_aliases()
+
         if self.default:
-            yield from self.default
+            for interpretation in self.default:
+                interpretation.expand_schema(coordinator)
 
     def interpret(self, context: ProviderContext):
         key = self.switch_on.normalize_single_value(context, self.normalization)

--- a/nodestream/schema/printers/graphql_schema_printer.py
+++ b/nodestream/schema/printers/graphql_schema_printer.py
@@ -7,7 +7,7 @@ from .schema_printer import SchemaPrinter
 
 NODE_TYPE_DEF_TEMPLATE = """
 {% set node_type = ensure_camel_case(shape.name) %}
-type {{ node_type }} @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}} {% if node_type != shape.name %} @node(labels: ["{{ shape.name }}"]) {% endif %} {
+type {{ node_type }} @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10}) {% if node_type != shape.name %} @node(labels: ["{{ shape.name }}"]) {% endif %} {
     # Node Properties
 {% for property in shape.properties.items() %}
     {{ property[0] }}: {{ field_mappings[property[1].type] }}

--- a/tests/data/dns.csv
+++ b/tests/data/dns.csv
@@ -2,3 +2,4 @@ type,name,value
 A,foo.bar.com,1.1.1.1
 A,foo.bar.com,1.0.0.1
 CNAME,baz.bar.com,baz.vendordns.com
+AAAA,foo.bar.com,2001:db8::1

--- a/tests/data/dns.csv
+++ b/tests/data/dns.csv
@@ -1,0 +1,4 @@
+type,name,value
+A,foo.bar.com,1.1.1.1
+A,foo.bar.com,1.0.0.1
+CNAME,baz.bar.com,baz.vendordns.com

--- a/tests/data/people.json
+++ b/tests/data/people.json
@@ -1,0 +1,25 @@
+{
+    "organization": {
+        "name": "Acme Inc."
+    },
+    "people": [
+        {
+            "name": "John",
+            "surname": "Doe",
+            "age": 30,
+            "contact": {
+                "email": "jdoe@example.com",
+                "phone": "555-555-5555"
+            }
+        },
+        {
+            "name": "Jane",
+            "surname": "Doe",
+            "age": 28,
+            "contact": {
+                "email": "jane_doe@example.com",
+                "phone": "555-555-5555"
+            }
+        }
+    ]
+}

--- a/tests/integration/fixtures/pipelines/dns.yaml
+++ b/tests/integration/fixtures/pipelines/dns.yaml
@@ -8,6 +8,13 @@
     interpretations:
       - type: switch
         switch_on: !jmespath 'type'
+        default:
+          - type: source_node
+            node_type: Unknown
+            key:
+              name: !jmespath 'name'
+            properties:
+              value: !jmespath 'value'
         cases:
           A:
           - type: source_node

--- a/tests/integration/fixtures/pipelines/dns.yaml
+++ b/tests/integration/fixtures/pipelines/dns.yaml
@@ -1,0 +1,31 @@
+- implementation: nodestream.pipeline.extractors:FileExtractor
+  arguments:
+    globs:
+      - tests/data/dns.csv
+
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    interpretations:
+      - type: switch
+        switch_on: !jmespath 'type'
+        cases:
+          A:
+          - type: source_node
+            node_type: A
+            key:
+              name: !jmespath 'name'
+          - type: relationship
+            node_type: Ipv4
+            relationship_type: RESOLVES_TO
+            node_key:
+              address: !jmespath 'value'
+          CNAME:
+          - type: source_node
+            node_type: CNAME
+            key:
+              name: !jmespath 'name'
+          - type: relationship
+            node_type: A
+            relationship_type: RESOLVES_TO
+            node_key:
+              name: !jmespath 'value'

--- a/tests/integration/fixtures/pipelines/people.yaml
+++ b/tests/integration/fixtures/pipelines/people.yaml
@@ -1,0 +1,30 @@
+- implementation: nodestream.pipeline.extractors:FileExtractor
+  arguments:
+    globs:
+      - tests/data/people.json
+
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    before_iteration:
+      - type: relationship
+        relationship_type: IS_MEMBER_OF
+        node_type: Organization
+        node_key:
+          name: !jmespath organization.name
+    iterate_on: !jmespath people
+    interpretations:
+      - type: source_node
+        node_type: Person
+        key:
+          first_name: !jmespath name
+          last_name: !jmespath surname
+      - type: relationship
+        relationship_type: HAS_CONTACT
+        node_type: Email
+        node_key:
+          email: !jmespath contact.email
+      - type: relationship
+        relationship_type: HAS_CONTACT
+        node_type: Phone
+        node_key:
+          phone: !jmespath contact.phone

--- a/tests/integration/snapshots/schema_snapshot_airports.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_airports.yaml_graphql.txt
@@ -1,6 +1,6 @@
 
 
-type Airport @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Airport @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     identifier: String
@@ -31,7 +31,7 @@ type Airport @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: 
 
 }
 
-type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     code: String
@@ -49,7 +49,7 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: 
 
 }
 
-type Region @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Region @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     code: String

--- a/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
@@ -58,6 +58,21 @@ type Ipv4 @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {de
     # Outbound Relationships
 
 }
+
+type Unknown @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    name: String
+
+    value: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    # Outbound Relationships
+
+}
 interface ResolvesTo @relationshipProperties {
 
     last_ingested_at: LocalDateTime

--- a/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
@@ -1,0 +1,65 @@
+
+
+type A @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    
+    cNAMEResolvesTo: [CNAME!]!
+        @relationship(type: "RESOLVES_TO", direction: IN, properties: "ResolvesTo")
+    
+
+    # Outbound Relationships
+
+    
+    resolvesToIpv4: Ipv4
+        @relationship(type: "RESOLVES_TO", direction: OUT, properties: "ResolvesTo")
+    
+
+}
+
+type CNAME @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    # Outbound Relationships
+
+    
+    resolvesToA: A
+        @relationship(type: "RESOLVES_TO", direction: OUT, properties: "ResolvesTo")
+    
+
+}
+
+type Ipv4 @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    address: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    
+    aResolvesTo: [A!]!
+        @relationship(type: "RESOLVES_TO", direction: IN, properties: "ResolvesTo")
+    
+
+    # Outbound Relationships
+
+}
+interface ResolvesTo @relationshipProperties {
+
+    last_ingested_at: LocalDateTime
+
+}

--- a/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_dns.yaml_graphql.txt
@@ -1,6 +1,6 @@
 
 
-type A @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type A @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
@@ -23,7 +23,7 @@ type A @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {defau
 
 }
 
-type CNAME @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type CNAME @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
@@ -41,7 +41,7 @@ type CNAME @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {d
 
 }
 
-type Ipv4 @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Ipv4 @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     address: String
@@ -59,7 +59,7 @@ type Ipv4 @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {de
 
 }
 
-type Unknown @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Unknown @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String

--- a/tests/integration/snapshots/schema_snapshot_dns.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_dns.yaml_plain.txt
@@ -1,0 +1,11 @@
+[NODE] A:
+  name: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] RESOLVES_TO:
+  last_ingested_at: DATETIME
+[NODE] Ipv4:
+  address: STRING
+  last_ingested_at: DATETIME
+[NODE] CNAME:
+  name: STRING
+  last_ingested_at: DATETIME

--- a/tests/integration/snapshots/schema_snapshot_dns.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_dns.yaml_plain.txt
@@ -9,3 +9,7 @@
 [NODE] CNAME:
   name: STRING
   last_ingested_at: DATETIME
+[NODE] Unknown:
+  name: STRING
+  value: STRING
+  last_ingested_at: DATETIME

--- a/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_graphql.txt
@@ -1,6 +1,6 @@
 
 
-type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
@@ -18,7 +18,7 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: 
 
 }
 
-type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     player_id: String
@@ -56,7 +56,7 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {
 
 }
 
-type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
@@ -74,7 +74,7 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit:
 
 }
 
-type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String

--- a/tests/integration/snapshots/schema_snapshot_people.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_people.yaml_graphql.txt
@@ -1,0 +1,95 @@
+
+
+type Email @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    email: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    
+    personHasContact: [Person!]!
+        @relationship(type: "HAS_CONTACT", direction: IN, properties: "HasContact")
+    
+
+    # Outbound Relationships
+
+}
+
+type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    
+    personIsMemberOf: [Person!]!
+        @relationship(type: "IS_MEMBER_OF", direction: IN, properties: "IsMemberOf")
+    
+
+    # Outbound Relationships
+
+}
+
+type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    first_name: String
+
+    last_name: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    # Outbound Relationships
+
+    
+    isMemberOfOrganization: Organization
+        @relationship(type: "IS_MEMBER_OF", direction: OUT, properties: "IsMemberOf")
+    
+
+    
+    hasContactEmail: Email
+        @relationship(type: "HAS_CONTACT", direction: OUT, properties: "HasContact")
+    
+
+    
+    hasContactPhone: Phone
+        @relationship(type: "HAS_CONTACT", direction: OUT, properties: "HasContact")
+    
+
+}
+
+type Phone @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+    # Node Properties
+
+    phone: String
+
+    last_ingested_at: LocalDateTime
+
+    # Inbound Relationships
+
+    
+    personHasContact: [Person!]!
+        @relationship(type: "HAS_CONTACT", direction: IN, properties: "HasContact")
+    
+
+    # Outbound Relationships
+
+}
+interface IsMemberOf @relationshipProperties {
+
+    last_ingested_at: LocalDateTime
+
+}
+interface HasContact @relationshipProperties {
+
+    last_ingested_at: LocalDateTime
+
+}

--- a/tests/integration/snapshots/schema_snapshot_people.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_people.yaml_graphql.txt
@@ -1,6 +1,6 @@
 
 
-type Email @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Email @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     email: String
@@ -18,7 +18,7 @@ type Email @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {d
 
 }
 
-type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
@@ -36,7 +36,7 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{li
 
 }
 
-type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     first_name: String
@@ -66,7 +66,7 @@ type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {
 
 }
 
-type Phone @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Phone @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     phone: String

--- a/tests/integration/snapshots/schema_snapshot_people.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_people.yaml_plain.txt
@@ -1,0 +1,17 @@
+[RELATIONSHIP] IS_MEMBER_OF:
+  last_ingested_at: DATETIME
+[NODE] Organization:
+  name: STRING
+  last_ingested_at: DATETIME
+[NODE] Person:
+  first_name: STRING
+  last_name: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] HAS_CONTACT:
+  last_ingested_at: DATETIME
+[NODE] Email:
+  email: STRING
+  last_ingested_at: DATETIME
+[NODE] Phone:
+  phone: STRING
+  last_ingested_at: DATETIME

--- a/tests/integration/test_pipeline_and_data_interpretation.py
+++ b/tests/integration/test_pipeline_and_data_interpretation.py
@@ -75,6 +75,10 @@ async def test_pipeline_interpretation_snapshot(
         ("fifa_2021_player_data.yaml", "graphql"),
         ("airports.yaml", "plain"),
         ("airports.yaml", "graphql"),
+        ("people.yaml", "plain"),
+        ("people.yaml", "graphql"),
+        ("dns.yaml", "plain"),
+        ("dns.yaml", "graphql"),
     ],
 )
 async def test_pipeline_schema_inference(pipeline_name, format, snapshot):

--- a/tests/unit/schema/printers/test_graphql_schema_printer.py
+++ b/tests/unit/schema/printers/test_graphql_schema_printer.py
@@ -3,7 +3,7 @@ from hamcrest import assert_that, equal_to_ignoring_whitespace
 from nodestream.schema.printers import GraphQLSchemaPrinter
 
 EXPECTED_GRAPHQL_SCHEMA = """
-type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10}) {
     # Node Properties
 
     name: String
@@ -19,7 +19,7 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{li
         @relationship(type: "HAS_EMPLOYEE", direction: OUT, properties: "HasEmployee")
 }
 
-type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @pageOptions{limit: {default: 10}}  {
+type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10}) {
     # Node Properties
 
     name: String


### PR DESCRIPTION
There are two issues with schema introspection. Specifically: 

- If you have a switch statement that provides completely different set of interpretations per-branch, then it will merge the schemas together. This is in appropriate because each branch provides a different part of the schema that should be isolated and only merged together once complete. This PR prevents this from occurring. 

- If you attempt to define a relationship interpretation before defining the source node, it will not be bound to the source node type. 

- Fix a syntax issue in the graphql schema. 