### PR TITLE
Fix `Target` and `Schema` bugs

### DIFF
--- a/nodestream/databases/database_connector.py
+++ b/nodestream/databases/database_connector.py
@@ -15,7 +15,7 @@ class DatabaseConnector(ABC, Pluggable):
 
     @classmethod
     def from_database_args(
-        cls, database: str = "neo4j", **database_args
+        cls, database: str = "null", **database_args
     ) -> "DatabaseConnector":
         DatabaseConnector.import_all()
 

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -49,6 +49,9 @@ class NullRetriver(TypeRetriever):
 
 
 class NullConnector(DatabaseConnector, alias="null"):
+    def __init__(self, **_) -> None:
+        pass
+
     def make_migrator(self) -> TypeRetriever:
         return NullMigrator()
 

--- a/nodestream/databases/writer.py
+++ b/nodestream/databases/writer.py
@@ -19,6 +19,21 @@ class GraphDatabaseWriter(Writer):
         connector = DatabaseConnector.from_database_args(
             database=database, **database_args
         )
+        return cls.from_connector(
+            connector=connector,
+            ingest_strategy_name=ingest_strategy_name,
+            collect_stats=collect_stats,
+            batch_size=batch_size,
+        )
+
+    @classmethod
+    def from_connector(
+        cls,
+        connector: DatabaseConnector,
+        ingest_strategy_name: str,
+        collect_stats: bool,
+        batch_size: int,
+    ):
         executor = connector.get_query_executor(collect_stats=collect_stats)
         ingest_strategy_cls = INGESTION_STRATEGY_REGISTRY.get(ingest_strategy_name)
         ingest_strategy = ingest_strategy_cls(executor)

--- a/nodestream/project/project.py
+++ b/nodestream/project/project.py
@@ -97,7 +97,9 @@ class Project(ExpandsSchemaFromChildren, LoadsFromYamlFile, SavesToYamlFile):
         ]
 
         targets = data.pop("targets", {})
-        target_cfgs = {name: Target(name, value) for name, value in targets.items()}
+        target_cfgs = {
+            name: Target.from_file_data(name, data) for name, data in targets.items()
+        }
 
         project = cls(targets_by_name=target_cfgs)
         for plugin in plugins:

--- a/nodestream/project/target.py
+++ b/nodestream/project/target.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 from ..file_io import LazyLoadedArgument
 from ..schema.migrations import Migrator
 
-
 WRITER_ARGUMENTS = ("batch_size", "collect_stats", "ingest_strategy_name")
 
 

--- a/nodestream/project/target.py
+++ b/nodestream/project/target.py
@@ -51,4 +51,4 @@ class Target:
         return self.connector.make_migrator()
 
     def to_file_data(self):
-        return self.connector_config
+        return dict(**self.connector_config, **self.writer_arguments)

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -226,7 +226,11 @@ class GraphObjectSchema(LoadsFromYaml, SavesToYaml):
         Args:
             property_name: The property name.
         """
-        self.properties[property_name] = metadata or PropertyMetadata()
+        metadata = metadata or PropertyMetadata()
+        if property_name in self.properties:
+            self.properties[property_name].merge(metadata)
+        else:
+            self.properties[property_name] = metadata
 
     def drop_property(self, property_name: str):
         """Drop a property.

--- a/tests/unit/project/test_target.py
+++ b/tests/unit/project/test_target.py
@@ -1,14 +1,35 @@
+from unittest.mock import ANY
 from hamcrest import assert_that, equal_to
 
 from nodestream.file_io import LazyLoadedArgument
 from nodestream.project import Target
 
 
-def test_target_make_writer(mocker):
-    target = Target("test", {"a": "b"})
+def test_target_make_writer_default_writer_args(mocker):
+    target = Target.from_file_data("test", {"a": "b"})
     mock_writer = mocker.patch("nodestream.databases.GraphDatabaseWriter")
     target.make_writer()
-    mock_writer.from_file_data.assert_called_once_with(a="b")
+    mock_writer.from_connector.assert_called_once_with(connector=ANY)
+
+
+def test_target_make_writer_custom_writer_args(mocker):
+    target = Target.from_file_data(
+        "test",
+        {
+            "a": "b",
+            "batch_size": 500,
+            "collect_stats": False,
+            "ingest_strategy_name": "immediate",
+        },
+    )
+    mock_writer = mocker.patch("nodestream.databases.GraphDatabaseWriter")
+    target.make_writer()
+    mock_writer.from_connector.assert_called_once_with(
+        connector=ANY,
+        ingest_strategy_name="immediate",
+        collect_stats=False,
+        batch_size=500,
+    )
 
 
 def test_target_make_type_retriever(mocker):

--- a/tests/unit/project/test_target.py
+++ b/tests/unit/project/test_target.py
@@ -1,9 +1,10 @@
 from unittest.mock import ANY
+
 from hamcrest import assert_that, equal_to, instance_of
 
+from nodestream.databases.null import NullMigrator
 from nodestream.file_io import LazyLoadedArgument
 from nodestream.project import Target
-from nodestream.databases.null import NullMigrator
 
 
 def test_target_make_writer_default_writer_args(mocker):

--- a/tests/unit/project/test_target.py
+++ b/tests/unit/project/test_target.py
@@ -1,8 +1,9 @@
 from unittest.mock import ANY
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, instance_of
 
 from nodestream.file_io import LazyLoadedArgument
 from nodestream.project import Target
+from nodestream.databases.null import NullMigrator
 
 
 def test_target_make_writer_default_writer_args(mocker):
@@ -30,6 +31,12 @@ def test_target_make_writer_custom_writer_args(mocker):
         collect_stats=False,
         batch_size=500,
     )
+
+
+def test_make_migrator_with_writer_args(mocker):
+    target = Target.from_file_data("test", {"database": "null", "batch_size": 500})
+    result = target.make_migrator()
+    assert_that(result, instance_of(NullMigrator))
 
 
 def test_target_make_type_retriever(mocker):

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -114,3 +114,14 @@ def test_invalid_merge_mismatched_keys(basic_schema):
     other_person = GraphObjectSchema("Person", {"ssn": PropertyMetadata(is_key=True)})
     with pytest.raises(ValueError):
         person.merge(other_person)
+
+
+def test_overlapping_property_definitions(basic_schema):
+    person = basic_schema.get_node_type_by_name("NewType")
+    person.add_index("name")
+    person.add_key("name")
+    person.add_property("name")
+
+    property_defintion = person.properties["name"]
+    assert_that(property_defintion.is_key, equal_to(True))
+    assert_that(property_defintion.is_indexed, equal_to(True))


### PR DESCRIPTION
This PR Fixes two issues:

1. If you have two pipelines; one that says a property is a key and another that says it only knows the property as a property, the order of operations takes precedence. This occurs when using a match only clause. If we know something is a key, it needs to be defined as such. Same thing with indexes. 

2. Currently we are passing writer configurations (such as `batch_size`) through the target. Currently these values are getting passed as part of the the connector configuration directly to the writer that is able to sort through these arguments and use them. However, with the addition of the `Migrator`, these configuration values are treated as invalid. This PR shuffles the writer configuration values as well the connector specific values away from one another and only sends the writer arguments when appropriate. 