### PR TITLE
Add Slightly Better Error Messages

### DIFF
--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -15,6 +15,7 @@ STATS_TABLE_COLS = ["Statistic", "Value"]
 ERROR_NO_PIPELINES_FOUND = "<error>No pipelines with the provided name were found in your project. If you didn't provide a name, you have no pipelines.</error>"
 HINT_CHECK_PIPELINE_NAME = "<info>HINT: Check that the pipelines you are trying to run are named correctly and in the registry.</info>"
 HINT_USE_NODESTREAM_SHOW = "<info>HINT: You can view your project's pipelines by running 'nodestream show'. </info>"
+WARNING_NO_TARGETS_PROVIDED = "<error>No targets provided. Running pipeline without writing to any targets.</error>"
 
 
 class RunPipeline(Operation):
@@ -78,7 +79,10 @@ class RunPipeline(Operation):
     ):
         from_cli = set(command.option("target") or {})
         from_pipeline = set(pipeline.configuration.effective_targets or {})
-        return from_cli.union(from_pipeline)
+        effective_target_names = from_cli.union(from_pipeline)
+        if not effective_target_names:
+            command.line(WARNING_NO_TARGETS_PROVIDED)
+        return effective_target_names
 
     def make_run_request(
         self, command: NodestreamCommand, pipeline: PipelineDefinition

--- a/nodestream/subclass_registry.py
+++ b/nodestream/subclass_registry.py
@@ -1,6 +1,5 @@
 from functools import wraps
 
-
 MISSING_FROM_REGISTRY_MESSAGE_FORMAT = "{registered_class_name} '{name}' is not registered. Did you forget to install a plugin?"
 
 

--- a/nodestream/subclass_registry.py
+++ b/nodestream/subclass_registry.py
@@ -1,6 +1,9 @@
 from functools import wraps
 
 
+MISSING_FROM_REGISTRY_MESSAGE_FORMAT = "{registered_class_name} '{name}' is not registered. Did you forget to install a plugin?"
+
+
 class AlreadyInRegistryError(ValueError):
     """Raised when a subclass with the same name is already in the subclass registry."""
 
@@ -16,7 +19,10 @@ class MissingFromRegistryError(ValueError):
 
     def __init__(self, name, registry: "SubclassRegistry", *args: object) -> None:
         super().__init__(
-            f"{name} is not in the subclass registry for: {registry.linked_base.__name__}",
+            MISSING_FROM_REGISTRY_MESSAGE_FORMAT.format(
+                name=name,
+                registered_class_name=registry.linked_base.__name__,
+            ),
             *args,
         )
 

--- a/playground_project/nodestream.yaml
+++ b/playground_project/nodestream.yaml
@@ -6,4 +6,4 @@ scopes:
 
 targets:
   db-one:
-    database: "nil"
+    database: "null"

--- a/playground_project/nodestream.yaml
+++ b/playground_project/nodestream.yaml
@@ -6,4 +6,4 @@ scopes:
 
 targets:
   db-one:
-    database: "null"
+    database: "nil"

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -2,9 +2,9 @@ import pytest
 from hamcrest import assert_that, equal_to
 
 from nodestream.cli.operations.run_pipeline import (
+    WARNING_NO_TARGETS_PROVIDED,
     RunPipeline,
     SpinnerProgressIndicator,
-    WARNING_NO_TARGETS_PROVIDED,
 )
 from nodestream.pipeline.meta import PipelineContext
 from nodestream.project import PipelineConfiguration, PipelineDefinition, Project

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -1,7 +1,11 @@
 import pytest
 from hamcrest import assert_that, equal_to
 
-from nodestream.cli.operations.run_pipeline import RunPipeline, SpinnerProgressIndicator
+from nodestream.cli.operations.run_pipeline import (
+    RunPipeline,
+    SpinnerProgressIndicator,
+    WARNING_NO_TARGETS_PROVIDED,
+)
 from nodestream.pipeline.meta import PipelineContext
 from nodestream.project import PipelineConfiguration, PipelineDefinition, Project
 
@@ -79,6 +83,14 @@ def test_combine_targets_from_command_and_pipeline(
         command, pipeline
     )
     assert_that(result, equal_to(expected))
+
+
+def test_combine_targets_from_command_and_pipeline_warns_when_targets_not_set(mocker):
+    command = mocker.Mock()
+    pipeline = PipelineDefinition(None, None, configuration=PipelineConfiguration())
+    command.option.return_value = []
+    RunPipeline(None).combine_targets_from_command_and_pipeline(command, pipeline)
+    command.line.assert_called_once_with(WARNING_NO_TARGETS_PROVIDED)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_subclass_registry.py
+++ b/tests/unit/test_subclass_registry.py
@@ -25,7 +25,9 @@ def test_remembers_subclasses_by_name():
 
 
 def test_raises_errors_when_invalid_named_subclass():
-    with pytest.raises(MissingFromRegistryError):
+    with pytest.raises(
+        MissingFromRegistryError, match="Did you forget to install a plugin?"
+    ):
         TEST_REGISTRY.get("not_there")
 
 


### PR DESCRIPTION
This adds two new error messages: 

- When there are no targets for the pipeline; provides a warning that it is running the pipeline without writing anywhere. 
- When you hit a `MissingFromRegistryError`, the message now asks you if you forgot to install a plugin. 