### PR TITLE
Fixed the effective annotations from overwriting from parent

### DIFF
--- a/nodestream/project/pipeline_definition.py
+++ b/nodestream/project/pipeline_definition.py
@@ -37,9 +37,8 @@ class PipelineConfiguration:
 
     @property
     def effective_annotations(self) -> Dict[str, Any]:
-        annotations = dict(self.annotations)
-        if self.parent is not None:
-            annotations.update(self.parent.effective_annotations)
+        annotations = dict(self.parent.effective_annotations) if self.parent else {}
+        annotations.update(self.annotations)
         return annotations
 
     def to_file_data(self, verbose: bool = False):

--- a/tests/unit/project/test_pipeline_definition.py
+++ b/tests/unit/project/test_pipeline_definition.py
@@ -200,20 +200,14 @@ def test_effective_annotation_prioritizes_self():
     pipeline_configuration = PipelineConfiguration(
         targets=[],
         exclude_inherited_targets=False,
-        annotations={
-            "key": "value"
-        },
+        annotations={"key": "value"},
         parent=PipelineConfiguration(
             targets=[],
             exclude_inherited_targets=False,
-            annotations={
-                "key": "other_value",
-                "other_key": "arbitrary_value"
-            },
-        )
+            annotations={"key": "other_value", "other_key": "arbitrary_value"},
+        ),
     )
-    assert pipeline_configuration.effective_annotations=={
+    assert pipeline_configuration.effective_annotations == {
         "key": "value",
-        "other_key": "arbitrary_value"
+        "other_key": "arbitrary_value",
     }
-

--- a/tests/unit/project/test_pipeline_definition.py
+++ b/tests/unit/project/test_pipeline_definition.py
@@ -194,3 +194,26 @@ def test_from_path():
     assert_that(result.name, equal_to("test"))
     assert_that(result.configuration.annotations, equal_to({}))
     assert_that(result.file_path, equal_to(path))
+
+
+def test_effective_annotation_prioritizes_self():
+    pipeline_configuration = PipelineConfiguration(
+        targets=[],
+        exclude_inherited_targets=False,
+        annotations={
+            "key": "value"
+        },
+        parent=PipelineConfiguration(
+            targets=[],
+            exclude_inherited_targets=False,
+            annotations={
+                "key": "other_value",
+                "other_key": "arbitrary_value"
+            },
+        )
+    )
+    assert pipeline_configuration.effective_annotations=={
+        "key": "value",
+        "other_key": "arbitrary_value"
+    }
+


### PR DESCRIPTION
In any pipeline configuration, inherit the paren't annotations then overwrite them with our annotations within the configuration's scope.