### PR TITLE
Search for matches anywhere in the string

### DIFF
--- a/nodestream/pipeline/value_providers/regex_value_provider.py
+++ b/nodestream/pipeline/value_providers/regex_value_provider.py
@@ -14,7 +14,7 @@ class RegexValueProvider(ValueProvider):
         self.data = data
 
     def apply_regex_to_value(self, value: Any) -> Any:
-        match = self.regex.match(value)
+        match = self.regex.search(value)
         if match:
             return match.group(self.group)
         return None

--- a/tests/unit/pipeline/value_providers/test_regex_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_regex_value_provider.py
@@ -11,7 +11,7 @@ from ...stubs import StubbedValueProvider
 def subject_with_named_groups():
     return RegexValueProvider(
         regex="(?P<name>[a-z]+) (?P<age>[0-9]+)",
-        data=StubbedValueProvider(["I am john 42", "I am jane 32"]),
+        data=StubbedValueProvider(["I am john 42", "jane 32"]),
         group="name",
     )
 

--- a/tests/unit/pipeline/value_providers/test_regex_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_regex_value_provider.py
@@ -11,7 +11,7 @@ from ...stubs import StubbedValueProvider
 def subject_with_named_groups():
     return RegexValueProvider(
         regex="(?P<name>[a-z]+) (?P<age>[0-9]+)",
-        data=StubbedValueProvider(["john 42", "jane 32"]),
+        data=StubbedValueProvider(["I am john 42", "I am jane 32"]),
         group="name",
     )
 


### PR DESCRIPTION
Currently Regex Value Provider automatically anchors to the begging of the string. That means that searching the string for a specific pattern would always require having .* in the beginning.
Ex:
Given:
text = "I am Kevin"

1) regex = "Kevin" - Would find no matches
2) regex = ".*Kevin" - would find matches

Since this is not a common constraint on regexes, using python `re.search()` method will result in matches being found for both regexes.