### PR TITLE
Fix Migrator Resiliency Issues

### DIFF
--- a/nodestream/schema/migrations/auto_change_detector.py
+++ b/nodestream/schema/migrations/auto_change_detector.py
@@ -377,6 +377,8 @@ class AutoChangeDetector:
 
     def make_node_property_change_operations(self) -> Iterable[Operation]:
         for type, deleted_field in self.deleted_node_properties:
+            if (type, deleted_field) in self.added_node_keys:
+                continue
             yield DropNodeProperty(type, deleted_field)
 
         for type, old_field, new_field in self.renamed_node_properties:
@@ -387,6 +389,8 @@ class AutoChangeDetector:
 
     def make_relationship_property_change_operations(self) -> Iterable[Operation]:
         for type, deleted_field in self.deleted_relationship_properties:
+            if (type, deleted_field) in self.added_relationship_keys:
+                continue
             yield DropRelationshipProperty(type, deleted_field)
 
         for type, old_field, new_field in self.renamed_relationship_properties:

--- a/nodestream/schema/migrations/migrator.py
+++ b/nodestream/schema/migrations/migrator.py
@@ -135,8 +135,12 @@ class Migrator:
             await self.acquire_lock()
 
         async with self.transaction():
-            for operation in migration.operations:
-                await self.execute_operation(operation)
+            try:
+                for operation in migration.operations:
+                    await self.execute_operation(operation)
+            except Exception:
+                await self.release_lock()
+                raise
 
         async with self.transaction():
             await self.mark_migration_as_executed(migration)

--- a/tests/unit/schema/migrations/test_auto_detector.py
+++ b/tests/unit/schema/migrations/test_auto_detector.py
@@ -532,6 +532,37 @@ class DroppedRelationshipPropertyIndex(Scenario):
         )
 
 
+class MovePropertyToKey(Scenario):
+    # If a property is moved to a key, then the detector should detect that the
+    # key was extended only. It should not detect that the property was dropped
+    # as it was only moved to the key.
+
+    def get_intial_state_operations(self) -> Iterable[Operation]:
+        yield CreateNodeType(
+            name=self.get_name("node_type"),
+            properties={self.get_name("property")},
+            keys={self.get_name("key")},
+        )
+
+    def get_change_operations(self) -> Iterable[Operation]:
+        yield DropNodeProperty(
+            node_type=self.get_name("node_type"),
+            property_name=self.get_name("property"),
+        )
+        yield NodeKeyExtended(
+            node_type=self.get_name("node_type"),
+            added_key_property=self.get_name("property"),
+            default=None,
+        )
+
+    def get_expected_detections(self) -> Iterable[Operation]:
+        yield NodeKeyExtended(
+            node_type=self.get_name("node_type"),
+            added_key_property=self.get_name("property"),
+            default=None,
+        )
+
+
 ALL_PERMUTABLE_SCENARIOS = [
     AddedNodeType,
     DroppedNodeType,
@@ -553,6 +584,7 @@ ALL_PERMUTABLE_SCENARIOS = [
     ExtendedRelationshipKey,
     RenamedNodeKeyPart,
     RenamedRelationshipKeyPart,
+    MovePropertyToKey,
 ]
 
 

--- a/tests/unit/schema/migrations/test_auto_detector.py
+++ b/tests/unit/schema/migrations/test_auto_detector.py
@@ -532,7 +532,7 @@ class DroppedRelationshipPropertyIndex(Scenario):
         )
 
 
-class MovePropertyToKey(Scenario):
+class MoveNodePropertyToKey(Scenario):
     # If a property is moved to a key, then the detector should detect that the
     # key was extended only. It should not detect that the property was dropped
     # as it was only moved to the key.
@@ -563,6 +563,37 @@ class MovePropertyToKey(Scenario):
         )
 
 
+class MoveRelationshipPropertyToKey(Scenario):
+    # If a property is moved to a key, then the detector should detect that the
+    # key was extended only. It should not detect that the property was dropped
+    # as it was only moved to the key.
+
+    def get_intial_state_operations(self) -> Iterable[Operation]:
+        yield CreateRelationshipType(
+            name=self.get_name("relationship_type"),
+            properties={self.get_name("property")},
+            keys={self.get_name("key")},
+        )
+
+    def get_change_operations(self) -> Iterable[Operation]:
+        yield DropRelationshipProperty(
+            relationship_type=self.get_name("relationship_type"),
+            property_name=self.get_name("property"),
+        )
+        yield RelationshipKeyExtended(
+            relationship_type=self.get_name("relationship_type"),
+            added_key_property=self.get_name("property"),
+            default=None,
+        )
+
+    def get_expected_detections(self) -> Iterable[Operation]:
+        yield RelationshipKeyExtended(
+            relationship_type=self.get_name("relationship_type"),
+            added_key_property=self.get_name("property"),
+            default=None,
+        )
+
+
 ALL_PERMUTABLE_SCENARIOS = [
     AddedNodeType,
     DroppedNodeType,
@@ -584,7 +615,8 @@ ALL_PERMUTABLE_SCENARIOS = [
     ExtendedRelationshipKey,
     RenamedNodeKeyPart,
     RenamedRelationshipKeyPart,
-    MovePropertyToKey,
+    MoveNodePropertyToKey,
+    MoveRelationshipPropertyToKey,
 ]
 
 

--- a/tests/unit/schema/migrations/test_migrator.py
+++ b/tests/unit/schema/migrations/test_migrator.py
@@ -68,7 +68,7 @@ async def test_execute_migration_fail_to_execute_operation(
     assert_that(migrator.commit_transaction.await_count, equal_to(1))
     migrator.rollback_transaction.assert_awaited_once()
     migrator.acquire_lock.assert_awaited_once()
-    migrator.release_lock.assert_not_called()
+    migrator.release_lock.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR introduces two changes to migrations: 

1. Fixes an issue where properties that have been promoted to keys are considered dropped. 
2. Fixes an issue where the migration lock is not released after a failure. This means that in the cases where a spurious error occurs, the migrations cannot be reran without manually removing the lock. 