### PR TITLE
Bump to Node 20 Based Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,11 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
@@ -36,7 +36,7 @@ jobs:
           poetry run black nodestream tests --check
           poetry run isort nodestream tests --check-only
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.python-version }}-${{ matrix.os }}


### PR DESCRIPTION
Github has been putting out some warnings on the need to migrate to node 20 based actions. See [here](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). 