### PR TITLE
Automatically Release with OIDC and Attestations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Release
+
+# Trigger the workflow on a release event. 
+# This will trigger the workflow when a release is published - so draft releases will not trigger the workflow.
+on: 
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    # Name of the job for the workflow.
+    name: Publish Package to PyPI
+    runs-on: ubuntu-latest
+    
+    # Get the oidc token with write permissions to upload the package to PyPI.
+    # We have configured the trusted OIDC token in the pypi project settings.
+    # See here: https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+  
+    # Use the Github Actions Environment to isolate the workflow from the rest of the repository. 
+    # See here: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nodestream/
+    
+    steps:
+      # Checkout the repository subject to the release.
+      - uses: actions/checkout@v4
+
+      # Install poetry to build the package.
+      - name: Install poetry
+        run: pipx install poetry
+
+      # Set up Python 3.12 to build the package.
+      # Python version here does not really matter as long as it works with 
+      # poetry because its simply building the package. We've confirmed functionality
+      # with CI testing before this step.
+      - name: Set up Python 3.12 
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: 'poetry'
+      
+      # Build the package using poetry. This will create a dist directory with the package.
+      # Poetry isn't _special_ in the sense that it builds packages in some unique way.
+      # Therefore, we can use poetry built packaes with PyPA's action for publishing packages below.
+      # See: https://python-poetry.org/docs/cli/#build
+      - name: Build Package
+        run: poetry build
+      
+      # Publish the package to PyPI using the OIDC token and PyPA's action for publishing packages.
+      # By default, this action will publish to the PyPI server and pull artifacts from the dist directory.
+      # Dist directory is where poetry builds the package in the previous step.
+      # See:
+      # - https://github.com/marketplace/actions/pypi-publish
+      # - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      # We are then going to store the built package as an artifact. 
+      # This is so we can sign the package and upload it to the GitHub release.
+      # this is being done as a seperate job so that we can minimize the permissions needed for the publish job.
+      - name: Store the Built Package
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distribution
+          path: dist/
+
+      # We are then going to sign the package using Github's Attest Build Provenance action.
+      # This action will sign the package and upload the signature to the GitHub release.
+      # This is to ensure that the package is verified and trusted by the user.
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     # See here: https://docs.pypi.org/trusted-publishers/using-a-publisher/
     permissions:
       id-token: write
+      attestations: write
   
     # Use the Github Actions Environment to isolate the workflow from the rest of the repository. 
     # See here: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.12.5a1"
+version = "0.12.5a2"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.12.4"
+version = "0.12.5a1"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [


### PR DESCRIPTION
This PR uses short-lived OIDC tokens to publish built packages to PyPi. Additionally, it uses Github's Attestations features to produce an attestation on the provenance of packages so developers can verify it is untampered. 