### PR TITLE
Cardinality Overrides

### DIFF
--- a/nodestream/interpreting/interpretations/relationship_interpretation.py
+++ b/nodestream/interpreting/interpretations/relationship_interpretation.py
@@ -80,6 +80,7 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
 
     __slots__ = (
         "can_find_many",
+        "cardinality",
         "outbound",
         "node_creation_rule",
         "decomposer",
@@ -107,12 +108,14 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
         outbound: bool = True,
         find_many: bool = False,
         iterate_on: Optional[ValueProvider] = None,
+        cardinality: str = "SINGLE",
         node_creation_rule: Optional[str] = None,
         key_normalization: Optional[Dict[str, Any]] = None,
         properties_normalization: Optional[Dict[str, Any]] = None,
         node_additional_types: Optional[Iterable[str]] = None,
     ):
         self.can_find_many = find_many or iterate_on is not None
+        self.cardinality = cardinality
         self.outbound = outbound
         self.node_creation_rule = NodeCreationRule(
             node_creation_rule or NodeCreationRule.EAGER.value
@@ -217,7 +220,7 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
             to_type = related_node if self.outbound else source_node
             foreign_cardinality = Cardinality.MANY
             source_cardinality = (
-                Cardinality.MANY if self.can_find_many else Cardinality.SINGLE
+                Cardinality.MANY if self.can_find_many else self.cardinality
             )
             if self.outbound:
                 to_side_cardinality, from_side_cardinality = (

--- a/nodestream/interpreting/interpretations/relationship_interpretation.py
+++ b/nodestream/interpreting/interpretations/relationship_interpretation.py
@@ -115,7 +115,7 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
         node_additional_types: Optional[Iterable[str]] = None,
     ):
         self.can_find_many = find_many or iterate_on is not None
-        self.cardinality = cardinality
+        self.cardinality = Cardinality(cardinality)
         self.outbound = outbound
         self.node_creation_rule = NodeCreationRule(
             node_creation_rule or NodeCreationRule.EAGER.value

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -324,11 +324,7 @@ class Adjacency:
         from schema import Schema
 
         return Schema(
-            {
-                "from_node_type": str,
-                "to_node_type": str,
-                "relationship_type": str
-            }
+            {"from_node_type": str, "to_node_type": str, "relationship_type": str}
         )
 
     @classmethod
@@ -336,7 +332,7 @@ class Adjacency:
         return cls(
             from_node_type=yaml_data["from_node_type"],
             to_node_type=yaml_data["to_node_type"],
-            relationship_type=yaml_data["relationship_type"]
+            relationship_type=yaml_data["relationship_type"],
         )
 
     def to_file_data(self):
@@ -346,7 +342,6 @@ class Adjacency:
             "relationship_type": self.relationship_type,
         }
 
-    
 
 @dataclass(slots=True, frozen=True)
 class AdjacencyCardinality:
@@ -403,7 +398,12 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             {
                 Optional("nodes"): [GraphObjectSchema.describe_yaml_schema()],
                 Optional("relationships"): [GraphObjectSchema.describe_yaml_schema()],
-                Optional("cardinalities"): [{"adjacency": Adjacency.describe_yaml_schema(), "cardinality": AdjacencyCardinality.describe_yaml_schema()}]
+                Optional("cardinalities"): [
+                    {
+                        "adjacency": Adjacency.describe_yaml_schema(),
+                        "cardinality": AdjacencyCardinality.describe_yaml_schema(),
+                    }
+                ],
             }
         )
 
@@ -419,7 +419,9 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             instance.put_relationship_type(relationship)
         for cardinality_data in yaml_data.get("cardinalities", []):
             adjacency = Adjacency.from_file_data(cardinality_data["adjacency"])
-            cardinality = AdjacencyCardinality.from_file_data(cardinality_data["cardinality"])
+            cardinality = AdjacencyCardinality.from_file_data(
+                cardinality_data["cardinality"]
+            )
             instance.add_adjacency(adjacency, cardinality)
         return instance
 
@@ -432,9 +434,10 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             "cardinalities": [
                 {
                     "adjacency": adjacency.to_file_data(),
-                    "cardinality": cardinality.to_file_data()
-                } for adjacency, cardinality in self.cardinalities.items()
-            ]
+                    "cardinality": cardinality.to_file_data(),
+                }
+                for adjacency, cardinality in self.cardinalities.items()
+            ],
         }
 
     @property

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -319,6 +319,34 @@ class Adjacency:
     to_node_type: str
     relationship_type: str
 
+    @classmethod
+    def describe_yaml_schema(cls):
+        from schema import Schema
+
+        return Schema(
+            {
+                "from_node_type": str,
+                "to_node_type": str,
+                "relationship_type": str
+            }
+        )
+
+    @classmethod
+    def from_file_data(cls, yaml_data):
+        return cls(
+            from_node_type=yaml_data["from_node_type"],
+            to_node_type=yaml_data["to_node_type"],
+            relationship_type=yaml_data["relationship_type"]
+        )
+
+    def to_file_data(self):
+        return {
+            "from_node_type": self.from_node_type,
+            "to_node_type": self.to_node_type,
+            "relationship_type": self.relationship_type,
+        }
+
+    
 
 @dataclass(slots=True, frozen=True)
 class AdjacencyCardinality:
@@ -326,6 +354,30 @@ class AdjacencyCardinality:
 
     from_side_cardinality: Cardinality = Cardinality.SINGLE
     to_side_cardinality: Cardinality = Cardinality.SINGLE
+
+    @classmethod
+    def describe_yaml_schema(cls):
+        from schema import Schema
+
+        return Schema(
+            {
+                "from_side_cardinality": str,
+                "to_side_cardinality": str,
+            }
+        )
+
+    @classmethod
+    def from_file_data(cls, yaml_data):
+        return cls(
+            from_side_cardinality=Cardinality(yaml_data["from_side_cardinality"]),
+            to_side_cardinality=Cardinality(yaml_data["to_side_cardinality"]),
+        )
+
+    def to_file_data(self):
+        return {
+            "from_side_cardinality": self.from_side_cardinality,
+            "to_side_cardinality": self.to_side_cardinality,
+        }
 
 
 @dataclass(slots=True, frozen=True)
@@ -351,6 +403,7 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             {
                 Optional("nodes"): [GraphObjectSchema.describe_yaml_schema()],
                 Optional("relationships"): [GraphObjectSchema.describe_yaml_schema()],
+                Optional("cardinalities"): [{"adjacency": Adjacency.describe_yaml_schema(), "cardinality": AdjacencyCardinality.describe_yaml_schema()}]
             }
         )
 
@@ -364,7 +417,10 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
         for relationship_data in yaml_data.get("relationships", []):
             relationship = GraphObjectSchema.from_file_data(relationship_data)
             instance.put_relationship_type(relationship)
-
+        for cardinality_data in yaml_data.get("cardinalities", []):
+            adjacency = Adjacency.from_file_data(cardinality_data["adjacency"])
+            cardinality = AdjacencyCardinality.from_file_data(cardinality_data["cardinality"])
+            instance.add_adjacency(adjacency, cardinality)
         return instance
 
     def to_file_data(self):
@@ -373,6 +429,12 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             "relationships": [
                 relationship.to_file_data() for relationship in self.relationships
             ],
+            "cardinalities": [
+                {
+                    "adjacency": adjacency.to_file_data(),
+                    "cardinality": cardinality.to_file_data()
+                } for adjacency, cardinality in self.cardinalities.items()
+            ]
         }
 
     @property

--- a/tests/unit/interpreting/interpretations/matchers.py
+++ b/tests/unit/interpreting/interpretations/matchers.py
@@ -3,7 +3,8 @@ from typing import Iterable
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
 
-from nodestream.schema import GraphObjectType, SchemaExpansionCoordinator
+from nodestream.schema import GraphObjectType, SchemaExpansionCoordinator, Cardinality
+from nodestream.schema.state import UnboundAdjacency
 
 
 class HasObjectKeyDefined(BaseMatcher):
@@ -93,6 +94,28 @@ class HasObjectIndexesDefined(BaseMatcher):
             f"has indexes {self.indexes} defined for {self.object_type}"
         )
 
+class HasUnboundAdjacencyDefined(BaseMatcher):
+    def __init__(self,
+                from_node_type_or_alias,
+                to_node_type_or_alias,
+                relationship_type,
+                from_node_cardinality,
+                to_node_cardinality
+            ) -> None:
+        self.unbound_adjacency = UnboundAdjacency(
+            from_node_type_or_alias,
+            to_node_type_or_alias,
+            relationship_type,
+            from_node_cardinality,
+            to_node_cardinality
+        )
+
+    def _matches(self, item: SchemaExpansionCoordinator):
+        return self.unbound_adjacency in item.unbound_adjacencies
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text(f"has node types {self.unbound_adjacency} inside unbound adjacency list.")
+
 
 class DefinedNodeTypes(BaseMatcher):
     def __init__(self, node_types: Iterable[str]) -> None:
@@ -172,9 +195,17 @@ def has_defined_relationships(
     return DefinedRelationshipTypes(relationship_types)
 
 
-def has_adjaceny(
+def has_unbound_adjacency(
     from_node_type_or_alias: str,
     to_node_type_or_alias: str,
-    relaitionship: str,
+    relationship_type: str,
+    from_node_cardinality: Cardinality,
+    to_node_cardinality: Cardinality
 ):
-    pass
+    return HasUnboundAdjacencyDefined(
+        from_node_type_or_alias,
+        to_node_type_or_alias,
+        relationship_type,
+        from_node_cardinality,
+        to_node_cardinality
+    )

--- a/tests/unit/interpreting/interpretations/matchers.py
+++ b/tests/unit/interpreting/interpretations/matchers.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
 
-from nodestream.schema import GraphObjectType, SchemaExpansionCoordinator, Cardinality
+from nodestream.schema import Cardinality, GraphObjectType, SchemaExpansionCoordinator
 from nodestream.schema.state import UnboundAdjacency
 
 

--- a/tests/unit/interpreting/interpretations/matchers.py
+++ b/tests/unit/interpreting/interpretations/matchers.py
@@ -94,27 +94,31 @@ class HasObjectIndexesDefined(BaseMatcher):
             f"has indexes {self.indexes} defined for {self.object_type}"
         )
 
+
 class HasUnboundAdjacencyDefined(BaseMatcher):
-    def __init__(self,
-                from_node_type_or_alias,
-                to_node_type_or_alias,
-                relationship_type,
-                from_node_cardinality,
-                to_node_cardinality
-            ) -> None:
+    def __init__(
+        self,
+        from_node_type_or_alias,
+        to_node_type_or_alias,
+        relationship_type,
+        from_node_cardinality,
+        to_node_cardinality,
+    ) -> None:
         self.unbound_adjacency = UnboundAdjacency(
             from_node_type_or_alias,
             to_node_type_or_alias,
             relationship_type,
             from_node_cardinality,
-            to_node_cardinality
+            to_node_cardinality,
         )
 
     def _matches(self, item: SchemaExpansionCoordinator):
         return self.unbound_adjacency in item.unbound_adjacencies
 
     def describe_to(self, description: Description) -> None:
-        description.append_text(f"has node types {self.unbound_adjacency} inside unbound adjacency list.")
+        description.append_text(
+            f"has node types {self.unbound_adjacency} inside unbound adjacency list."
+        )
 
 
 class DefinedNodeTypes(BaseMatcher):
@@ -200,12 +204,12 @@ def has_unbound_adjacency(
     to_node_type_or_alias: str,
     relationship_type: str,
     from_node_cardinality: Cardinality,
-    to_node_cardinality: Cardinality
+    to_node_cardinality: Cardinality,
 ):
     return HasUnboundAdjacencyDefined(
         from_node_type_or_alias,
         to_node_type_or_alias,
         relationship_type,
         from_node_cardinality,
-        to_node_cardinality
+        to_node_cardinality,
     )

--- a/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
@@ -16,7 +16,7 @@ from .matchers import (
     has_node_keys,
     has_node_properties,
     has_relationship_keys,
-    has_unbound_adjacency
+    has_unbound_adjacency,
 )
 
 
@@ -251,16 +251,20 @@ def test_relationship_interpretation_generates_cardinality_based_on_iteration_pa
         node_key={"hello": "world"},
         relationship_type="Static",
         iterate_on=StubbedValueProvider(values=["thing1", "thing2"]),
-        find_many=True
+        find_many=True,
     )
     subject.expand_schema(schema_coordinator)
-    assert_that(schema_coordinator, has_unbound_adjacency(
-        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
-        to_node_type_or_alias="Static",
-        relationship_type="Static",
-        from_node_cardinality=Cardinality.MANY,
-        to_node_cardinality=Cardinality.MANY
-    ))
+    assert_that(
+        schema_coordinator,
+        has_unbound_adjacency(
+            from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+            to_node_type_or_alias="Static",
+            relationship_type="Static",
+            from_node_cardinality=Cardinality.MANY,
+            to_node_cardinality=Cardinality.MANY,
+        ),
+    )
+
 
 def test_relationship_interpretation_generates_cardinality_based_on_lack_of_iteration_parameters(
     schema_coordinator,
@@ -271,13 +275,17 @@ def test_relationship_interpretation_generates_cardinality_based_on_lack_of_iter
         relationship_type="Static",
     )
     subject.expand_schema(schema_coordinator)
-    assert_that(schema_coordinator, has_unbound_adjacency(
-        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
-        to_node_type_or_alias="Static",
-        relationship_type="Static",
-        from_node_cardinality=Cardinality.SINGLE,
-        to_node_cardinality=Cardinality.MANY
-    ))
+    assert_that(
+        schema_coordinator,
+        has_unbound_adjacency(
+            from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+            to_node_type_or_alias="Static",
+            relationship_type="Static",
+            from_node_cardinality=Cardinality.SINGLE,
+            to_node_cardinality=Cardinality.MANY,
+        ),
+    )
+
 
 def test_relationship_interpretation_generates_cardinality_based_on_manual_declaration(
     schema_coordinator,
@@ -286,16 +294,19 @@ def test_relationship_interpretation_generates_cardinality_based_on_manual_decla
         node_type="Static",
         node_key={"hello": "world"},
         relationship_type="Static",
-        cardinality="MANY"
+        cardinality="MANY",
     )
     subject.expand_schema(schema_coordinator)
-    assert_that(schema_coordinator, has_unbound_adjacency(
-        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
-        to_node_type_or_alias="Static",
-        relationship_type="Static",
-        from_node_cardinality=Cardinality.MANY,
-        to_node_cardinality=Cardinality.MANY
-    ))
+    assert_that(
+        schema_coordinator,
+        has_unbound_adjacency(
+            from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+            to_node_type_or_alias="Static",
+            relationship_type="Static",
+            from_node_cardinality=Cardinality.MANY,
+            to_node_cardinality=Cardinality.MANY,
+        ),
+    )
 
 
 def test_relationship_interpretation_addtional_node_types(blank_context):

--- a/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
@@ -1,12 +1,12 @@
 import pytest
 from hamcrest import assert_that, equal_to, has_entries, has_length
 
+from nodestream.interpreting.interpretations import SourceNodeInterpretation
 from nodestream.interpreting.interpretations.relationship_interpretation import (
     InvalidKeyLengthError,
     RelationshipInterpretation,
 )
 from nodestream.schema import Cardinality
-from nodestream.interpreting.interpretations import SourceNodeInterpretation
 
 from ...stubs import StubbedValueProvider
 from .matchers import (

--- a/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_relationship_interpretation.py
@@ -5,6 +5,8 @@ from nodestream.interpreting.interpretations.relationship_interpretation import 
     InvalidKeyLengthError,
     RelationshipInterpretation,
 )
+from nodestream.schema import Cardinality
+from nodestream.interpreting.interpretations import SourceNodeInterpretation
 
 from ...stubs import StubbedValueProvider
 from .matchers import (
@@ -14,6 +16,7 @@ from .matchers import (
     has_node_keys,
     has_node_properties,
     has_relationship_keys,
+    has_unbound_adjacency
 )
 
 
@@ -238,6 +241,61 @@ def test_relationship_interpretation_gather_object_shapes_not_static_node(
     )
     subject.expand_schema(schema_coordinator)
     assert_that(schema_coordinator, has_no_defined_nodes())
+
+
+def test_relationship_interpretation_generates_cardinality_based_on_iteration_parameters(
+    schema_coordinator,
+):
+    subject = RelationshipInterpretation(
+        node_type="Static",
+        node_key={"hello": "world"},
+        relationship_type="Static",
+        iterate_on=StubbedValueProvider(values=["thing1", "thing2"]),
+        find_many=True
+    )
+    subject.expand_schema(schema_coordinator)
+    assert_that(schema_coordinator, has_unbound_adjacency(
+        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+        to_node_type_or_alias="Static",
+        relationship_type="Static",
+        from_node_cardinality=Cardinality.MANY,
+        to_node_cardinality=Cardinality.MANY
+    ))
+
+def test_relationship_interpretation_generates_cardinality_based_on_lack_of_iteration_parameters(
+    schema_coordinator,
+):
+    subject = RelationshipInterpretation(
+        node_type="Static",
+        node_key={"hello": "world"},
+        relationship_type="Static",
+    )
+    subject.expand_schema(schema_coordinator)
+    assert_that(schema_coordinator, has_unbound_adjacency(
+        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+        to_node_type_or_alias="Static",
+        relationship_type="Static",
+        from_node_cardinality=Cardinality.SINGLE,
+        to_node_cardinality=Cardinality.MANY
+    ))
+
+def test_relationship_interpretation_generates_cardinality_based_on_manual_declaration(
+    schema_coordinator,
+):
+    subject = RelationshipInterpretation(
+        node_type="Static",
+        node_key={"hello": "world"},
+        relationship_type="Static",
+        cardinality="MANY"
+    )
+    subject.expand_schema(schema_coordinator)
+    assert_that(schema_coordinator, has_unbound_adjacency(
+        from_node_type_or_alias=SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS,
+        to_node_type_or_alias="Static",
+        relationship_type="Static",
+        from_node_cardinality=Cardinality.MANY,
+        to_node_cardinality=Cardinality.MANY
+    ))
 
 
 def test_relationship_interpretation_addtional_node_types(blank_context):

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -22,6 +22,11 @@ def test_basic_schema_to_and_from_file(basic_schema):
         rebuilt_schema.relationships_by_name,
         equal_to(basic_schema.relationships_by_name),
     )
+    assert_that(
+        all(
+            (adjacency in rebuilt_schema.cardinalities and rebuilt_schema.cardinalities[adjacency] == cardinality) for adjacency, cardinality, in basic_schema.cardinalities.items()
+        )
+    )
 
 
 def test_basic_schema_merge_with_self_should_be_same(basic_schema):

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -24,7 +24,11 @@ def test_basic_schema_to_and_from_file(basic_schema):
     )
     assert_that(
         all(
-            (adjacency in rebuilt_schema.cardinalities and rebuilt_schema.cardinalities[adjacency] == cardinality) for adjacency, cardinality, in basic_schema.cardinalities.items()
+            (
+                adjacency in rebuilt_schema.cardinalities
+                and rebuilt_schema.cardinalities[adjacency] == cardinality
+            )
+            for adjacency, cardinality, in basic_schema.cardinalities.items()
         )
     )
 
@@ -57,17 +61,11 @@ def test_merge_with_differences(basic_schema):
         basic_schema.get_node_type_by_name("Person").properties, has_key("new_property")
     )
 
+
 def test_merge_with_adjacency_override(basic_schema):
     copy = deepcopy(basic_schema)
-    adjacency = Adjacency(
-        "Person",
-        "Person",
-        "BEST_FRIEND_OF"
-    )
-    cardinality = AdjacencyCardinality(
-        "MANY",
-        "MANY"
-    )
+    adjacency = Adjacency("Person", "Person", "BEST_FRIEND_OF")
+    cardinality = AdjacencyCardinality("MANY", "MANY")
     copy.cardinalities.clear()
     copy.cardinalities[adjacency] = cardinality
 

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -57,6 +57,24 @@ def test_merge_with_differences(basic_schema):
         basic_schema.get_node_type_by_name("Person").properties, has_key("new_property")
     )
 
+def test_merge_with_adjacency_override(basic_schema):
+    copy = deepcopy(basic_schema)
+    adjacency = Adjacency(
+        "Person",
+        "Person",
+        "BEST_FRIEND_OF"
+    )
+    cardinality = AdjacencyCardinality(
+        "MANY",
+        "MANY"
+    )
+    copy.cardinalities.clear()
+    copy.cardinalities[adjacency] = cardinality
+
+    basic_schema.merge(copy)
+    assert_that(len(basic_schema.cardinalities), equal_to(2))
+    assert_that(basic_schema.cardinalities[adjacency], equal_to(cardinality))
+
 
 def test_has_node_of_type(basic_schema):
     assert_that(basic_schema.has_node_of_type("Person"), equal_to(True))


### PR DESCRIPTION
This change allows the developer to do the following:

Modify the cardinality of a relationship from the declaration of the interpretation
Override the cardinality of a relationship from the override schema. 
It also outputs the cardinalities of the schema when creating an output of the schema. 