### PR TITLE
Minor Fix to Local Credential Logic

### DIFF
--- a/nodestream/pipeline/extractors/credential_utils.py
+++ b/nodestream/pipeline/extractors/credential_utils.py
@@ -47,7 +47,7 @@ class AwsClientFactory:
         }
 
     def get_credentials_from_provider_chain(self):
-        session = Session(**self.session_args)
+        session = Session()
         session_credentials = session.get_credentials().get_frozen_credentials()
         return {
             "access_key": session_credentials.access_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.12.5a9"
+version = "0.12.5a10"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [


### PR DESCRIPTION
We were accidentlly supplying args intended for boto3 to botocore. In this case, we do not need to supply those args at all, we just need to get the credentials. 