### PR TITLE
Refactor File Handling Code to Fix S3 Incompatability Issues

### DIFF
--- a/nodestream/interpreting/interpretation_passes.py
+++ b/nodestream/interpreting/interpretation_passes.py
@@ -53,7 +53,6 @@ class SingleSequenceInterpretationPass(InterpretationPass):
 
     @classmethod
     def from_file_data(cls, interpretation_arg_list):
-
         interpretations = (
             Interpretation.from_file_data(**args) for args in interpretation_arg_list
         )

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -1,15 +1,22 @@
 import bz2
 import gzip
 import json
-import os
 import tempfile
 from abc import ABC, abstractmethod
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager
 from csv import DictReader
 from glob import glob
-from io import BufferedReader, BytesIO, IOBase, StringIO, TextIOWrapper
+from io import BufferedReader, IOBase, TextIOWrapper
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, Generator, Iterable, Optional
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    AsyncIterator,
+    Iterable,
+    List,
+    Tuple,
+)
 
 import pandas as pd
 from httpx import AsyncClient
@@ -17,152 +24,216 @@ from yaml import safe_load
 
 from ...model import JsonLikeDocument
 from ...pluggable import Pluggable
-from ...subclass_registry import SubclassRegistry
+from ...subclass_registry import MissingFromRegistryError, SubclassRegistry
 from .extractor import Extractor
 
 SUPPORTED_FILE_FORMAT_REGISTRY = SubclassRegistry()
 SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY = SubclassRegistry()
 
 
-class IngestibleFile:
-    def __init__(
+@abstractmethod
+class ReadableFile:
+    def as_reader(self, cls: type[IOBase]) -> AsyncContextManager[IOBase]:
+        """Return a reader for the file.
+
+        Given a class that represents a file reader, return an async context
+        manager that yields an instance of that class. This allows different
+        file types to be read in a uniform way.
+
+        The context manager will close when the file is done being read and
+        is no longer needed by the pipeline. Therefore, you can perform cleanup
+        operations in the context manager on exit
+        (i.e after the yield statement).
+        """
+        ...
+
+    def path_like(self) -> Path:
+        """Return a Path object that represents the path to the file.
+
+        This method should return a Path object that represents the path to the
+        file. Note, the path does not need to be an actual file on the
+        filesystem. It can be a URL or any other path-like object that can
+        be used to identify the file.
+
+        This will be called to sniff the file format and compression format of
+        the file from the suffixes of the path.
+        """
+        ...
+
+    @asynccontextmanager
+    async def popped_suffix_tempfile(
         self,
-        path: Path,
-        fp: IOBase | None = None,
-        delete_on_ingestion: bool = False,
-        on_ingestion: Callable[[Any], Any] = lambda: (),
-    ) -> None:
-        self.extension = path.suffix
-        self.suffixes = path.suffixes
-        self.fp = fp
+    ) -> AsyncContextManager[Tuple[Path, tempfile.SpooledTemporaryFile]]:
+        """Create a temporary file with the same suffixes sans the last one.
+
+        This method creates a temporary file with the same suffixes as the
+        original file sans the last one. This is useful when creating
+        intermediary files that need to be passed through multiple codecs.
+
+        For instance, imagine a file such as foo.txt.gz. When the file is
+        being ingested, we will pass the file through the decompression codec
+        and then through the file format codec. The decompression codec will
+        remove the .gz suffix. And store it in an intermediary file which can
+        be read by the file format codec (.txt in this case).
+        """
+        new = self.path_like().with_suffix("")
+        with tempfile.NamedTemporaryFile(suffix="".join(new.suffixes)) as fp:
+            yield Path(fp.name), fp
+
+
+class LocalFile(ReadableFile):
+    """A class that represents a local file that can be read.
+
+    This class is used to read files from the local filesystem. The class
+    takes a Path object that represents the path to the file. The class
+    uses the Path object to open the file and return a reader that can be
+    used to read the file.
+    """
+
+    def __init__(self, path: Path, pointer=None) -> None:
         self.path = path
-        self.delete_on_ingestion = delete_on_ingestion
-        self.on_ingestion = on_ingestion
+        self.pointer = pointer
 
-    @classmethod
-    def from_file_pointer_and_suffixes(
-        cls,
-        fp: IOBase,
-        suffixes: str | list[str],
-        on_ingestion: Callable[[Any], Any] = lambda: (),
-    ) -> "IngestibleFile":
-        fd, temp_path = tempfile.mkstemp(suffix="".join(suffixes))
-        os.close(fd)
+    @asynccontextmanager
+    async def as_reader(self, cls: type[IOBase]):
+        if self.pointer:
+            yield cls(self.pointer)
+        else:
+            with self.path.open("rb") as fp:
+                yield cls(fp)
 
-        with open(temp_path, "wb") as temp_file:
-            for chunk in iter(lambda: fp.read(1024), b""):
-                temp_file.write(chunk)
-            temp_file.flush()
+    def path_like(self) -> Path:
+        return self.path
 
-        with open(temp_path, "rb+") as fp:
-            return IngestibleFile(Path(temp_path), fp, True, on_ingestion)
 
-    def __enter__(self):
-        return self
+class RemoteFile(ReadableFile):
+    """A class that represents a remote file that can be read.
 
-    def __exit__(self, type, value, traceback):
-        if self.fp:
-            self.fp.close()
-        if self.delete_on_ingestion:
-            self.tempfile_cleanup()
+    This class is used to read files from a remote URL. The class uses the
+    httpx library to stream the file from the URL and return a reader that
+    can be used to read the file.
+    """
 
-    def ingested(self):
-        if self.delete_on_ingestion:
-            self.tempfile_cleanup()
-        self.on_ingestion()
+    def __init__(
+        self, url: str, client: AsyncClient, memory_spooling_in_mb: int
+    ) -> None:
+        self.url = url
+        self.client = client
+        self.max_memory_spooling = memory_spooling_in_mb * 1024 * 1024
 
-    def tempfile_cleanup(self):
-        if self.fp:
-            self.fp.close()
-        if os.path.isfile(self.path):
-            os.remove(self.path)
+    @asynccontextmanager
+    async def as_reader(self, cls: type[IOBase]):
+        with tempfile.SpooledTemporaryFile(max_size=self.max_memory_spooling) as fp:
+            async with self.client.stream("GET", self.url) as response:
+                async for chunk in response.aiter_bytes():
+                    fp.write(chunk)
+            fp.seek(0)
+            yield cls(fp)
+
+    def path_like(self) -> Path:
+        return Path(self.url)
+
+
+@abstractmethod
+class FileSource:
+    def get_files(self) -> AsyncIterator[ReadableFile]:
+        """Return an async iterator of files to be processed.
+
+        This method should return an async iterator that yields instances of
+        ReadableFile. The ReadableFile instances should be able to be read
+        by the Extractor class. This method is used to abstract away the
+        details of how files are read from different sources (i.e local files,
+        remote files, etc).
+
+        The async iterator should yield all the files that need to be processed
+        by the pipeline. The Extractor class will then read the files and
+        extract the records from them.
+        """
+        ...
 
 
 @SUPPORTED_FILE_FORMAT_REGISTRY.connect_baseclass
-class SupportedFileFormat(Pluggable, ABC):
+class FileCodec(Pluggable, ABC):
+    """Base class for file codecs.
+
+    This class is used to define the interface for file codecs. File codecs
+    are used to read files of a specific format. The class should implement
+    the read_file_from_handle method which reads the file and returns an
+    iterable of records.
+
+    A class can define the `reader` attribute to specify the class that should
+    be used to read the file. If the `reader` attribute is not defined, the
+    default class used to read the file is a simple base io reader. In other
+    words, if you don't define the `reader` attribute, the file will be read
+    as a binary file. If you want to read the file as a text file, you should
+    define the `reader` attribute as TextIOWrapper.
+    """
+
     reader = None
     entrypoint_name = "file_formats"
 
-    def __init__(self, file: IngestibleFile) -> None:
-        self.file = file
-
-    @contextmanager
-    def read_handle(self) -> Iterable | BufferedReader:
-        if isinstance(self.file, Path):
-            with open(self.file, "rb") as fp:
-                yield fp
-        else:
-            yield self.file
-
-    def read_file(self) -> Iterable[JsonLikeDocument]:
-        with self.read_handle() as fp:
-            if self.reader is not None:
-                if self.reader is TextIOWrapper:
-                    reader = self.reader(fp, encoding="utf-8")
-                else:
-                    reader = self.reader(fp)
-
-            else:
-                reader = fp
-            return self.read_file_from_handle(reader)
-
-    @classmethod
-    @contextmanager
-    def open(
-        cls, file: IngestibleFile, extension_override: Optional[str] = ""
-    ) -> Generator["SupportedFileFormat", None, None]:
-        extension = extension_override or file.extension
-        if extension == "":
-            raise ValueError(f"File has no extension: '{file.path}'")
-        # Decompress file if in Supported Compressed File Format Registry
-        while extension in SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY:
-            compressed_file_format = SupportedCompressedFileFormat.open(file)
-            file = compressed_file_format.decompress_file()
-            extension = file.extension
-        with open(file.path, "rb") as fp:
-            yield cls.from_file_pointer_and_format(fp, extension)
-
-    @classmethod
-    def from_file_pointer_and_format(
-        cls, fp: IOBase, file_format: str
-    ) -> "SupportedFileFormat":
-        # Import all file formats so that they can register themselves
-        cls.import_all()
-        file_format = SUPPORTED_FILE_FORMAT_REGISTRY.get(file_format)
-        return file_format(fp)
-
     @abstractmethod
-    def read_file_from_handle(
-        self, fp: BufferedReader
-    ) -> Iterable[JsonLikeDocument]: ...
+    def read_file_from_handle(self, reader: IOBase) -> Iterable[JsonLikeDocument]:
+        """Read the file from the reader and return an iterable of records.
+
+        This method should read the file from the reader and return an iterable
+        of records. The records should be in a format that can be processed by
+        the pipeline and be "JSON-like" (i.e a dictionary, list, etc).
+        The method should yield the records one by one as they are read from
+        the file.
+        """
+        ...
 
 
 @SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY.connect_baseclass
-class SupportedCompressedFileFormat(Pluggable, ABC):
-    def __init__(self, file: IngestibleFile) -> None:
+class CompressionCodec(Pluggable, ABC):
+    """Base class for compression codecs.
+
+    This class is used to define the interface for compression codecs.
+    Compression codecs are used to decompress files that are compressed
+    using a specific compression algorithm. The class should implement the
+    decompress_file method which decompresses the file and returns a new file
+    that can be read by the file format codec or another decompression codec.
+    """
+
+    def __init__(self, file: ReadableFile) -> None:
         self.file = file
 
-    @classmethod
-    def open(cls, file: IngestibleFile) -> "SupportedCompressedFileFormat":
-        with open(file.path, "rb") as fp:
-            return cls.from_file_pointer_and_path(fp, file.path)
-
-    @classmethod
-    def from_file_pointer_and_path(
-        cls, fp: IOBase, path: Path
-    ) -> "SupportedCompressedFileFormat":
-        # Import all compression file formats so that they can register themselves
-        cls.import_all()
-        file_format = SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY.get(path.suffix)
-        file = IngestibleFile(path, fp)
-        file.on_ingestion = lambda: file.tempfile_cleanup()
-        return file_format(file)
-
     @abstractmethod
-    def decompress_file(self) -> IngestibleFile: ...
+    def decompress_file(self) -> AsyncContextManager[ReadableFile]:
+        """Decompress the file and return a new file that can be read.
+
+        This method should decompress the file and return a new file that can
+        be read by the file format codec or another decompression codec.
+        The method should return a new instance of ReadableFile that can be
+        read by the pipeline.
+
+        `ReadableFile` contains a helper method `popped_suffix_tempfile` that
+        can be used to create a new file with the same suffixes as the original
+        file sans the last suffix. This is useful when creating intermediary
+        files that need to be passed through multiple codecs.
+
+        For instance, imagine a file such as foo.txt.gz. When the file is
+        being ingested, we will pass the file through the decompression codec
+        and then through the file format codec. The decompression codec will
+        remove the .gz suffix. And store it in an intermediary file which can
+        be read by the file format codec (.txt in this case).
+        """
+        ...
 
 
-class JsonFileFormat(SupportedFileFormat, alias=".json"):
+class JsonFileFormat(FileCodec, alias=".json"):
+    """File format codec for JSON files.
+
+    This class is used to read JSON files. The class reads the file and
+    returns an iterable of records. The records are read one by one from
+    the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".json". This means that when the pipeline encounters a file with the
+    suffix .json, it will use this class to read the file.
+    """
+
     reader = TextIOWrapper
 
     def read_file_from_handle(
@@ -171,7 +242,20 @@ class JsonFileFormat(SupportedFileFormat, alias=".json"):
         return [json.load(reader)]
 
 
-class LineSeperatedJsonFileFormat(SupportedFileFormat, alias=".jsonl"):
+class LineSeperatedJsonFileFormat(FileCodec, alias=".jsonl"):
+    """File format codec for line separated JSON files.
+
+    This class is used to read line separated JSON files. The class reads the
+    file and returns an iterable of records. The records are read one by one
+    from the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".jsonl". This means that when the pipeline encounters a file with the
+    suffix .jsonl, it will use this class to read the file.
+
+    The class reads the file line by line and loads each line as a JSON object.
+    """
+
     reader = TextIOWrapper
 
     def read_file_from_handle(
@@ -180,13 +264,41 @@ class LineSeperatedJsonFileFormat(SupportedFileFormat, alias=".jsonl"):
         return (json.loads(line.strip()) for line in reader.readlines())
 
 
-class ParquetFileFormat(SupportedFileFormat, alias=".parquet"):
-    def read_file_from_handle(self, fp: StringIO) -> Iterable[JsonLikeDocument]:
+class ParquetFileFormat(FileCodec, alias=".parquet"):
+    """File format codec for Parquet files.
+
+    This class is used to read Parquet files. The class reads the file and
+    returns an iterable of records. The records are read one by one from
+    the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".parquet". This means that when the pipeline encounters a file with the
+    suffix .parquet, it will use this class to read the file.
+
+    The class reads the file using the pandas library and yields the records
+    one by one as they are read.
+    """
+
+    def read_file_from_handle(self, fp: IOBase) -> Iterable[JsonLikeDocument]:
         df = pd.read_parquet(fp, engine="pyarrow")
         return (row[1].to_dict() for row in df.iterrows())
 
 
-class TextFileFormat(SupportedFileFormat, alias=".txt"):
+class TextFileFormat(FileCodec, alias=".txt"):
+    """File format codec for text files.
+
+    This class is used to read text files. The class reads the file and
+    returns an iterable of records. The records are read one by one from
+    the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".txt". This means that when the pipeline encounters a file with the
+    suffix .txt, it will use this class to read the file.
+
+    The class reads the file line by line and yields each line as a record in
+    a dictionary with a single key "line".
+    """
+
     reader = TextIOWrapper
 
     def read_file_from_handle(
@@ -195,7 +307,21 @@ class TextFileFormat(SupportedFileFormat, alias=".txt"):
         return ({"line": line.strip()} for line in reader.readlines())
 
 
-class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):
+class CommaSeperatedValuesFileFormat(FileCodec, alias=".csv"):
+    """File format codec for CSV files.
+
+    This class is used to read CSV files. The class reads the file and
+    returns an iterable of records. The records are read one by one from
+    the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".csv". This means that when the pipeline encounters a file with the
+    suffix .csv, it will use this class to read the file.
+
+    The class reads the file using the csv.DictReader class and yields the
+    records one by one as they are read
+    """
+
     reader = TextIOWrapper
 
     def read_file_from_handle(
@@ -204,7 +330,21 @@ class CommaSeperatedValuesFileFormat(SupportedFileFormat, alias=".csv"):
         return DictReader(reader)
 
 
-class YamlFileFormat(SupportedFileFormat, alias=".yaml"):
+class YamlFileFormat(FileCodec, alias=".yaml"):
+    """File format codec for YAML files.
+
+    This class is used to read YAML files. The class reads the file and
+    returns an iterable of records. The records are read one by one from
+    the file and yielded as they are read.
+
+    The class is registered with the file format registry using the alias
+    ".yaml". This means that when the pipeline encounters a file with the
+    suffix .yaml, it will use this class to read the file.
+
+    The class reads the file using the yaml.safe_load function and yields one
+    record which is the entire file.
+    """
+
     reader = TextIOWrapper
 
     def read_file_from_handle(
@@ -213,87 +353,198 @@ class YamlFileFormat(SupportedFileFormat, alias=".yaml"):
         return [safe_load(reader)]
 
 
-class GzipFileFormat(SupportedCompressedFileFormat, alias=".gz"):
-    def decompress_file(self) -> IngestibleFile:
-        decompressed_data = BytesIO()
-        with gzip.open(self.file.path, "rb") as f_in:
-            chunk_size = 1024 * 1024
-            while True:
-                chunk = f_in.read(chunk_size)
-                if len(chunk) == 0:
-                    break
-                decompressed_data.write(chunk)
-        decompressed_data.seek(0)
-        new_path = self.file.path.with_suffix("")
-        temp_file = IngestibleFile.from_file_pointer_and_suffixes(
-            decompressed_data, new_path.suffixes
-        )
-        self.file.ingested()
-        return temp_file
+class GzipFileFormat(CompressionCodec, alias=".gz"):
+    """Compression codec for Gzip files.
+
+    This class is used to decompress Gzip files. The class takes a file that
+    is compressed using the Gzip compression algorithm and decompresses it.
+    The class returns a new file that can be read by the file format codec
+    or another decompression codec.
+
+    The class is registered with the compression codec registry using the
+    alias ".gz". This means that when the pipeline encounters a file with
+    the suffix .gz, it will use this class to decompress the file.
+    """
+
+    @asynccontextmanager
+    async def decompress_file(self) -> ReadableFile:
+        async with self.file.popped_suffix_tempfile() as (new_path, temp_file):
+            async with self.file.as_reader(BufferedReader) as reader:
+                with gzip.GzipFile(fileobj=reader) as decompressor:
+                    temp_file.write(decompressor.read())
+            temp_file.seek(0)
+            yield LocalFile(new_path, temp_file)
 
 
-class Bz2FileFormat(SupportedCompressedFileFormat, alias=".bz2"):
-    def decompress_file(self) -> IngestibleFile:
-        decompressed_data = BytesIO()
-        with bz2.open(self.file.path, "rb") as f_in:
-            chunk_size = 1024 * 1024
-            while True:
-                chunk = f_in.read(chunk_size)
-                if len(chunk) == 0:
-                    break
-                decompressed_data.write(chunk)
-        decompressed_data.seek(0)
-        new_path = self.file.path.with_suffix("")
-        temp_file = IngestibleFile.from_file_pointer_and_suffixes(
-            decompressed_data, new_path.suffixes
-        )
-        self.file.ingested()
-        return temp_file
+class Bz2FileFormat(CompressionCodec, alias=".bz2"):
+    """Compression codec for BZ2 files.
+
+    This class is used to decompress BZ2 files. The class takes a file that
+    is compressed using the BZ2 compression algorithm and decompresses it.
+    The class returns a new file that can be read by the file format codec
+    or another decompression codec.
+
+    The class is registered with the compression codec registry using the
+    alias ".bz2". This means that when the pipeline encounters a file with
+    the suffix .bz2, it will use this class to decompress the file.
+    """
+
+    @asynccontextmanager
+    async def decompress_file(self) -> ReadableFile:
+        async with self.file.popped_suffix_tempfile() as (new_path, temp_file):
+            async with self.file.as_reader(BufferedReader) as reader:
+                decompressor = bz2.BZ2Decompressor()
+                for chunk in iter(lambda: reader.read(1024 * 1024), b""):
+                    temp_file.write(decompressor.decompress(chunk))
+            temp_file.seek(0)
+            yield LocalFile(new_path, temp_file)
 
 
-class FileExtractor(Extractor):
-    @classmethod
-    def from_file_data(cls, globs: Iterable[str]):
-        all_matching_paths = (
+class LocalFileSource(FileSource):
+    """A class that represents a source of local files to be read.
+
+    This class is used to read files from the local filesystem. The class
+    takes a list of glob patterns that are used to find files on the local
+    filesystem. The class uses the glob module to find all the files that
+    match the glob patterns and then yields instances of LocalFile that
+    can be read by the pipeline.
+    """
+
+    @staticmethod
+    def from_globs(*globs: str) -> "LocalFileSource":
+        all_matches = (
             Path(file)
             for glob_string in globs
             for file in glob(glob_string, recursive=True)
         )
-        final_paths = {p for p in all_matching_paths if p.is_file()}
-        return cls(final_paths)
+        return LocalFileSource(list(sorted(filter(Path.is_file, all_matches))))
 
-    def __init__(self, paths: Iterable[Path]) -> None:
+    def __init__(self, paths: List[Path]) -> None:
         self.paths = paths
 
-    def _ordered_paths(self) -> Iterable[Path]:
-        return sorted(self.paths)
-
-    async def extract_records(self) -> AsyncGenerator[Any, Any]:
-        for path in self._ordered_paths():
-            with SupportedFileFormat.open(IngestibleFile(path)) as file:
-                for record in file.read_file():
-                    yield record
+    async def get_files(self) -> AsyncIterator[ReadableFile]:
+        for path in self.paths:
+            yield LocalFile(path)
 
 
-class RemoteFileExtractor(Extractor):
+class RemoteFileSource(FileSource):
+    """A class that represents a source of remote files to be read.
+
+    This class is used to read files from remote URLs. The class takes a list
+    of URLs and a memory spooling maximum size in MB. The class uses the httpx
+    library to stream the files from the URLs and yield instances of RemoteFile
+    that can be read by the pipeline.
+    """
+
     def __init__(
-        self, urls: Iterable[str], memory_spooling_max_size_in_mb: int = 5
+        self, urls: Iterable[str], memory_spooling_max_size_in_mb: int
     ) -> None:
         self.urls = urls
         self.memory_spooling_max_size = memory_spooling_max_size_in_mb * 1024 * 1024
 
-    @asynccontextmanager
-    async def download_file(self, client: AsyncClient, url: str) -> SupportedFileFormat:
-        with tempfile.TemporaryFile() as fp:
-            async with client.stream("GET", url) as response:
-                async for chunk in response.aiter_bytes():
-                    fp.write(chunk)
-            fp.seek(0)
-            yield SupportedFileFormat.from_file_pointer_and_format(fp, Path(url).suffix)
-
-    async def extract_records(self) -> AsyncGenerator[Any, Any]:
+    async def get_files(self) -> AsyncIterator[ReadableFile]:
         async with AsyncClient() as client:
             for url in self.urls:
-                async with self.download_file(client, url) as file:
-                    for record in file.read_file():
+                yield RemoteFile(url, client, self.memory_spooling_max_size)
+
+
+class UnifiedFileExtractor(Extractor):
+    """A class that extracts records from files.
+
+    This class is used to extract records from files. The class takes a list
+    of file sources that are used to read the files. The class uses the file
+    sources to get a list of files and then reads the files using the file
+    codecs. The class yields the records one by one as they are read from the
+    files.
+    """
+
+    def __init__(self, file_sources: Iterable[FileSource]) -> None:
+        self.file_sources = file_sources
+
+    async def read_file(self, file: ReadableFile) -> Iterable[JsonLikeDocument]:
+        intermediaries: List[AsyncContextManager[ReadableFile]] = []
+
+        while True:
+            suffix = file.path_like().suffix
+
+            # Try to find a compression codec that can decompress the file.
+            # If a compression codec is found, decompress the file and store
+            # the decompressed file in an intermediary file. The intermediary
+            # file will be read by the file format codec.
+            try:
+                algo = SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY.get(suffix)(file)
+                decompression = algo.decompress_file()
+                file = await decompression.__aenter__()
+                intermediaries.append(decompression)
+                continue
+            except MissingFromRegistryError:
+                pass
+
+            # If we didn't find a compression codec, try to find a file format
+            # codec that can read the file. If a file format codec is found,
+            # read the file and yield the records.
+            try:
+                codec = SUPPORTED_FILE_FORMAT_REGISTRY.get(suffix)()
+                async with file.as_reader(codec.reader or BufferedReader) as reader:
+                    for record in codec.read_file_from_handle(reader):
                         yield record
+            except MissingFromRegistryError:
+                # If we didn't find a file format codec, break out of the loop
+                # and yield no records.
+                pass
+
+            # Regardless of whether we found a codec or not, break out of the
+            # loop and yield no more records becaause either (a) we found a
+            # codec and read the file or (b) we didn't find a codec and
+            # couldn't read the file. Trying again would be futile.
+            break
+
+        # Cleanup the intermediary files.
+        for intermediary in reversed(intermediaries):
+            await intermediary.__aexit__(None, None, None)
+
+    async def extract_records(self) -> AsyncGenerator[Any, Any]:
+        for file_source in self.file_sources:
+            async for file in file_source.get_files():
+                async for record in self.read_file(file):
+                    yield record
+
+
+# DEPRECATED CODE BELOW ##
+#
+# The classes below are slated to be removed in the future.
+# Additionally, there are aliases from the old class names to the new class
+# names to ensure backwards compatibility. These aliases will be removed in
+# the future.
+
+
+class FileExtractor(UnifiedFileExtractor):
+    """A class that extracts records from local files.
+
+    This class is slated to be removed in the future. It is a subclass of
+    UnifiedFileExtractor that is used to extract records from local files
+    """
+
+    @classmethod
+    def from_file_data(cls, globs: Iterable[str]):
+        return cls([LocalFileSource.from_globs(globs)])
+
+
+class RemoteFileExtractor(UnifiedFileExtractor):
+    """A class that extracts records from remote files.
+
+    This class is slated to be removed in the future. It is a subclass of
+    UnifiedFileExtractor that is used to extract records from remote files.
+    """
+
+    @classmethod
+    def from_file_data(
+        cls,
+        urls: Iterable[str],
+        memory_spooling_max_size_in_mb: int = 10,  # TODO: Check that this is named correctly.
+    ):
+        return cls([RemoteFileSource(urls, memory_spooling_max_size_in_mb)])
+
+
+SupportedFileFormat = FileCodec
+SupportedCompressedFileFormat = CompressionCodec

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -230,7 +230,7 @@ class CompressionCodec(Pluggable, ABC):
         remove the .gz suffix. And store it in an intermediary file which can
         be read by the file format codec (.txt in this case).
         """
-        ...
+        raise NotImplementedError
 
 
 class JsonFileFormat(FileCodec, alias=".json"):

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -51,7 +51,7 @@ class ReadableFile:
         operations in the context manager on exit
         (i.e after the yield statement).
         """
-        ...
+        raise NotImplementedError
 
     def path_like(self) -> Path:
         """Return a Path object that represents the path to the file.
@@ -64,12 +64,12 @@ class ReadableFile:
         This will be called to sniff the file format and compression format of
         the file from the suffixes of the path.
         """
-        ...
+        raise NotImplementedError
 
     @asynccontextmanager
     async def popped_suffix_tempfile(
         self,
-    ) -> AsyncContextManager[Tuple[Path, tempfile.SpooledTemporaryFile]]:
+    ) -> AsyncContextManager[Tuple[Path, tempfile.NamedTemporaryFile]]:
         """Create a temporary file with the same suffixes sans the last one.
 
         This method creates a temporary file with the same suffixes as the
@@ -160,7 +160,7 @@ class FileSource:
         by the pipeline. The Extractor class will then read the files and
         extract the records from them.
         """
-        ...
+        raise NotImplementedError
 
 
 @SUPPORTED_FILE_FORMAT_REGISTRY.connect_baseclass
@@ -193,7 +193,7 @@ class FileCodec(Pluggable, ABC):
         The method should yield the records one by one as they are read from
         the file.
         """
-        ...
+        raise NotImplementedError
 
 
 @SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY.connect_baseclass

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -129,7 +129,7 @@ class RemoteFile(ReadableFile):
 
     @asynccontextmanager
     async def as_reader(self, cls: type[IOBase]):
-        if sys.version_info.minor >= (3, 11):
+        if sys.version_info >= (3, 11):
             temp_file = tempfile.SpooledTemporaryFile(max_size=self.max_memory_spooling)
         else:
             temp_file = tempfile.TemporaryFile()

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -129,7 +129,7 @@ class RemoteFile(ReadableFile):
 
     @asynccontextmanager
     async def as_reader(self, cls: type[IOBase]):
-        if sys.version_info > (3, 10):
+        if sys.version_info.minor >= (3, 11):
             temp_file = tempfile.SpooledTemporaryFile(max_size=self.max_memory_spooling)
         else:
             temp_file = tempfile.TemporaryFile()

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -32,6 +32,11 @@ SUPPORTED_FILE_FORMAT_REGISTRY = SubclassRegistry()
 SUPPORTED_COMPRESSED_FILE_FORMAT_REGISTRY = SubclassRegistry()
 
 
+class Utf8TextIOWrapper(TextIOWrapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, encoding="utf-8")
+
+
 @abstractmethod
 class ReadableFile:
     def as_reader(self, cls: type[IOBase]) -> AsyncContextManager[IOBase]:
@@ -240,7 +245,7 @@ class JsonFileFormat(FileCodec, alias=".json"):
     suffix .json, it will use this class to read the file.
     """
 
-    reader = TextIOWrapper
+    reader = Utf8TextIOWrapper
 
     def read_file_from_handle(
         self, reader: TextIOWrapper
@@ -262,7 +267,7 @@ class LineSeperatedJsonFileFormat(FileCodec, alias=".jsonl"):
     The class reads the file line by line and loads each line as a JSON object.
     """
 
-    reader = TextIOWrapper
+    reader = Utf8TextIOWrapper
 
     def read_file_from_handle(
         self, reader: TextIOWrapper
@@ -305,7 +310,7 @@ class TextFileFormat(FileCodec, alias=".txt"):
     a dictionary with a single key "line".
     """
 
-    reader = TextIOWrapper
+    reader = Utf8TextIOWrapper
 
     def read_file_from_handle(
         self, reader: TextIOWrapper
@@ -328,7 +333,7 @@ class CommaSeperatedValuesFileFormat(FileCodec, alias=".csv"):
     records one by one as they are read
     """
 
-    reader = TextIOWrapper
+    reader = Utf8TextIOWrapper
 
     def read_file_from_handle(
         self, reader: TextIOWrapper
@@ -351,7 +356,7 @@ class YamlFileFormat(FileCodec, alias=".yaml"):
     record which is the entire file.
     """
 
-    reader = TextIOWrapper
+    reader = Utf8TextIOWrapper
 
     def read_file_from_handle(
         self, reader: TextIOWrapper

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -527,7 +527,7 @@ class FileExtractor(UnifiedFileExtractor):
 
     @classmethod
     def from_file_data(cls, globs: Iterable[str]):
-        return cls([LocalFileSource.from_globs(globs)])
+        return cls([LocalFileSource.from_globs(*globs)])
 
 
 class RemoteFileExtractor(UnifiedFileExtractor):

--- a/nodestream/pipeline/extractors/files.py
+++ b/nodestream/pipeline/extractors/files.py
@@ -1,8 +1,8 @@
 import bz2
 import gzip
 import json
-import tempfile
 import sys
+import tempfile
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from csv import DictReader

--- a/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
+++ b/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
@@ -72,17 +72,13 @@ class S3FileSource(FileSource):
     def find_keys_in_bucket(self) -> Iterable[str]:
         # Returns all keys in the bucket that are not in the archive dir
         # and have the prefix.
-        print("find keys in bucket")
-        print(self.s3_client)
         paginator = self.s3_client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.prefix)
         for page in page_iterator:
             keys = (obj["Key"] for obj in page.get("Contents", []))
-            print(keys)
             yield from filter(lambda k: not self.object_is_in_archive(k), keys)
 
     async def get_files(self):
-        print("get files")
         for key in self.find_keys_in_bucket():
             yield S3File(
                 key=key,

--- a/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
+++ b/nodestream/pipeline/extractors/stores/aws/s3_extractor.py
@@ -1,14 +1,107 @@
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
+from io import IOBase
 from logging import getLogger
 from pathlib import Path
-from typing import Any, AsyncGenerator, Generator, Optional
+from typing import Iterable, Optional
 
 from ...credential_utils import AwsClientFactory
-from ...extractor import Extractor
-from ...files import IngestibleFile, SupportedFileFormat
+from ...files import FileSource, ReadableFile, UnifiedFileExtractor
+
+LOGGER = getLogger(__name__)
 
 
-class S3Extractor(Extractor):
+class S3File(ReadableFile):
+    def __init__(
+        self,
+        key: str,
+        s3_client,
+        bucket: str,
+        archive_dir: str | None,
+        object_format: str | None,
+    ) -> None:
+        self.key = key
+        self.s3_client = s3_client
+        self.bucket = bucket
+        self.archive_dir = archive_dir
+        self.object_format = object_format
+
+    def archive_if_required(self, key: str):
+        if not self.archive_dir:
+            pass
+
+        LOGGER.info("Archiving S3 Object", extra=dict(key=key))
+        filename = Path(key).name
+        self.s3_client.copy(
+            Bucket=self.bucket,
+            Key=f"{self.archive_dir}/{filename}",
+            CopySource={"Bucket": self.bucket, "Key": key},
+        )
+        self.s3_client.delete_object(Bucket=self.bucket, Key=key)
+
+    def path_like(self) -> Path:
+        path = Path(self.key)
+        return path.with_suffix(self.object_format or path.suffix)
+
+    @asynccontextmanager
+    async def as_reader(self, reader: IOBase):
+        streaming_body = self.s3_client.get_object(Bucket=self.bucket, Key=self.key)[
+            "Body"
+        ]
+        yield reader(streaming_body._raw_stream)
+        self.archive_if_required(self.key)
+
+
+class S3FileSource(FileSource):
+    def __init__(
+        self,
+        bucket: str,
+        s3_client,
+        archive_dir: str,
+        object_format: str,
+        prefix: str | None = None,
+    ):
+        self.bucket = bucket
+        self.s3_client = s3_client
+        self.archive_dir = archive_dir
+        self.object_format = object_format
+        self.prefix = prefix or ""
+
+    def object_is_in_archive(self, key: str) -> bool:
+        return key.startswith(self.archive_dir) if self.archive_dir else False
+
+    def find_keys_in_bucket(self) -> Iterable[str]:
+        # Returns all keys in the bucket that are not in the archive dir
+        # and have the prefix.
+        print("find keys in bucket")
+        print(self.s3_client)
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.prefix)
+        for page in page_iterator:
+            keys = (obj["Key"] for obj in page.get("Contents", []))
+            print(keys)
+            yield from filter(lambda k: not self.object_is_in_archive(k), keys)
+
+    async def get_files(self):
+        print("get files")
+        for key in self.find_keys_in_bucket():
+            yield S3File(
+                key=key,
+                s3_client=self.s3_client,
+                bucket=self.bucket,
+                archive_dir=self.archive_dir,
+                object_format=self.object_format,
+            )
+
+
+class S3Extractor(UnifiedFileExtractor):
+    """Extracts files from S3.
+
+
+    NOTE: This class is slated for deprecation in favor of the more general
+    `UnifiedFileExtractor` class. It is recommended to use the
+    `UnifiedFileExtractor` class directly instead of this class.
+    """
+
     @classmethod
     def from_file_data(
         cls,
@@ -18,74 +111,12 @@ class S3Extractor(Extractor):
         object_format: Optional[str] = None,
         **aws_client_args,
     ):
-        return cls(
+        source = S3FileSource(
             bucket=bucket,
-            object_format=object_format,
             prefix=prefix,
             archive_dir=archive_dir,
+            object_format=object_format,
             s3_client=AwsClientFactory(**aws_client_args).make_client("s3"),
         )
 
-    def __init__(
-        self,
-        bucket: str,
-        s3_client,
-        archive_dir: Optional[str] = None,
-        object_format: Optional[str] = None,
-        prefix: Optional[str] = None,
-    ) -> None:
-        self.object_format = object_format
-        self.prefix = prefix or ""
-        self.bucket = bucket
-        self.archive_dir = archive_dir
-        self.s3_client = s3_client
-        self.logger = getLogger(__name__)
-
-    @contextmanager
-    def get_object_as_tempfile(self, key: str):
-        streaming_body = self.s3_client.get_object(Bucket=self.bucket, Key=key)["Body"]
-        file = IngestibleFile.from_file_pointer_and_suffixes(
-            streaming_body, Path(key).suffixes, lambda: self.archive_s3_object(key)
-        )
-        yield file
-
-    def archive_s3_object(self, key: str):
-        if self.archive_dir:
-            self.logger.info("Archiving S3 Object", extra=dict(key=key))
-            filename = Path(key).name
-            self.s3_client.copy(
-                Bucket=self.bucket,
-                Key=f"{self.archive_dir}/{filename}",
-                CopySource={"Bucket": self.bucket, "Key": key},
-            )
-            self.s3_client.delete_object(Bucket=self.bucket, Key=key)
-
-    @contextmanager
-    def get_object_as_file(
-        self, key: str
-    ) -> Generator[SupportedFileFormat, None, None]:
-        with self.get_object_as_tempfile(key) as temp_file:
-            with SupportedFileFormat.open(temp_file, self.object_format) as file_format:
-                yield file_format
-
-    def is_object_in_archive(self, key: str) -> bool:
-        if self.archive_dir:
-            return key.startswith(self.archive_dir)
-        return False
-
-    def find_keys_in_bucket(self) -> list[str]:
-        # Returns all keys in the bucket that are not in the archive dir and have the prefix.
-        paginator = self.s3_client.get_paginator("list_objects_v2")
-        page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.prefix)
-        for page in page_iterator:
-            keys = (obj["Key"] for obj in page.get("Contents", []))
-            yield from filter(lambda k: not self.is_object_in_archive(k), keys)
-
-    async def extract_records(self) -> AsyncGenerator[Any, Any]:
-        for key in self.find_keys_in_bucket():
-            try:
-                with self.get_object_as_file(key) as records:
-                    for record in records.read_file():
-                        yield record
-            finally:
-                self.archive_s3_object(key)
+        return cls([source])

--- a/tests/unit/pipeline/extractors/test_files.py
+++ b/tests/unit/pipeline/extractors/test_files.py
@@ -26,6 +26,17 @@ def fixture_directory():
 
 
 @pytest.fixture
+def unspported_file(fixture_directory):
+    with NamedTemporaryFile(
+        "w+", suffix=".unsupported", dir=fixture_directory, delete=False
+    ) as temp_file:
+        name = temp_file.name
+        temp_file.write("hello world")
+        temp_file.seek(0)
+    yield Path(name)
+
+
+@pytest.fixture
 def json_file(fixture_directory):
     with NamedTemporaryFile(
         "w+", suffix=".json", dir=fixture_directory, delete=False
@@ -123,6 +134,13 @@ def bz2_file(fixture_directory):
         if not temp_file.name.endswith(".json.bz2"):
             raise Exception("not a json bz2 file")
     yield Path(name)
+
+
+@pytest.mark.asyncio
+async def test_unsupported_file(unspported_file):
+    subject = FileExtractor([LocalFileSource([unspported_file])])
+    results = [r async for r in subject.extract_records()]
+    assert_that(results, equal_to([]))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipeline/extractors/test_files.py
+++ b/tests/unit/pipeline/extractors/test_files.py
@@ -197,6 +197,6 @@ async def test_remote_file_extractor_extract_records(mocker, httpx_mock):
             method="GET",
             json=SIMPLE_RECORD,
         )
-    subject = RemoteFileExtractor(files)
+    subject = RemoteFileExtractor.from_file_data(urls=files)
     results = [r async for r in subject.extract_records()]
     assert_that(results, equal_to([SIMPLE_RECORD, SIMPLE_RECORD]))


### PR DESCRIPTION
In this PR, we a complete refactoring to the internals of the file handling logic that allows for increased interoperability and maintainability between file handling logic and sources. To accomplish this, the PR introduces the following changes: 

- Rename `SupportedFileFormat` and `SupportedCompressedFileFormat` to `FileCodec` and `CompressionCodec` respectively to provide a better naming for their changed roles. Now, these types simply provided the decode behaviors and do not own a file in anyway.
- Introduce `ReadableFile` and its subclasses which define methods for building reader types from `self` as well as defining the `path` of the file (which can be a non-real path).
- Introduce `FileSource` and its subclasses which essentially work to build instances of `ReadableFile` and return them to a single unified file extractor behavior.
- Add dramatically better documentation as to what the code does across the entire `files` module. 
- Deprecate the old extractor types for future removal. 