### PR TITLE
Fix `do_lowercase_strings` being applied to everything in `SourceNodeInterpretation`

### DIFF
--- a/tests/integration/snapshots/interpretation_snapshot_fifa_2021_player_data.yaml.json
+++ b/tests/integration/snapshots/interpretation_snapshot_fifa_2021_player_data.yaml.json
@@ -13,7 +13,7 @@
                         "hits": "299",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lionel messi",
+                        "name": "Lionel Messi",
                         "overall": "94",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -57,7 +57,7 @@
                         "hits": "299",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lionel messi",
+                        "name": "Lionel Messi",
                         "overall": "94",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -101,7 +101,7 @@
                         "hits": "299",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lionel messi",
+                        "name": "Lionel Messi",
                         "overall": "94",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -145,7 +145,7 @@
                 "hits": "299",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "lionel messi",
+                "name": "Lionel Messi",
                 "overall": "94",
                 "potential": "94",
                 "was_ingested_by_unknown": true
@@ -168,7 +168,7 @@
                         "hits": "276",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cristiano ronaldo",
+                        "name": "Cristiano Ronaldo",
                         "overall": "93",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -212,7 +212,7 @@
                         "hits": "276",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cristiano ronaldo",
+                        "name": "Cristiano Ronaldo",
                         "overall": "93",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -256,7 +256,7 @@
                         "hits": "276",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cristiano ronaldo",
+                        "name": "Cristiano Ronaldo",
                         "overall": "93",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -300,7 +300,7 @@
                 "hits": "276",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "cristiano ronaldo",
+                "name": "Cristiano Ronaldo",
                 "overall": "93",
                 "potential": "93",
                 "was_ingested_by_unknown": true
@@ -323,7 +323,7 @@
                         "hits": "186",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "neymar jr",
+                        "name": "Neymar Jr",
                         "overall": "92",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -367,7 +367,7 @@
                         "hits": "186",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "neymar jr",
+                        "name": "Neymar Jr",
                         "overall": "92",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -411,7 +411,7 @@
                         "hits": "186",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "neymar jr",
+                        "name": "Neymar Jr",
                         "overall": "92",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -455,7 +455,7 @@
                 "hits": "186",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "neymar jr",
+                "name": "Neymar Jr",
                 "overall": "92",
                 "potential": "92",
                 "was_ingested_by_unknown": true
@@ -478,7 +478,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "virgil van dijk",
+                        "name": "Virgil van Dijk",
                         "overall": "91",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -522,7 +522,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "virgil van dijk",
+                        "name": "Virgil van Dijk",
                         "overall": "91",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -566,7 +566,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "virgil van dijk",
+                        "name": "Virgil van Dijk",
                         "overall": "91",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -610,7 +610,7 @@
                 "hits": "127",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "virgil van dijk",
+                "name": "Virgil van Dijk",
                 "overall": "91",
                 "potential": "92",
                 "was_ingested_by_unknown": true
@@ -633,7 +633,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jan oblak",
+                        "name": "Jan Oblak",
                         "overall": "91",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -677,7 +677,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jan oblak",
+                        "name": "Jan Oblak",
                         "overall": "91",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -721,7 +721,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jan oblak",
+                        "name": "Jan Oblak",
                         "overall": "91",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -765,7 +765,7 @@
                 "hits": "47",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "jan oblak",
+                "name": "Jan Oblak",
                 "overall": "91",
                 "potential": "93",
                 "was_ingested_by_unknown": true
@@ -788,7 +788,7 @@
                         "hits": "119",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kevin de bruyne",
+                        "name": "Kevin De Bruyne",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -832,7 +832,7 @@
                         "hits": "119",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kevin de bruyne",
+                        "name": "Kevin De Bruyne",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -876,7 +876,7 @@
                         "hits": "119",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kevin de bruyne",
+                        "name": "Kevin De Bruyne",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -920,7 +920,7 @@
                 "hits": "119",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "kevin de bruyne",
+                "name": "Kevin De Bruyne",
                 "overall": "91",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -943,7 +943,7 @@
                         "hits": "89",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "robert lewandowski",
+                        "name": "Robert Lewandowski",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -987,7 +987,7 @@
                         "hits": "89",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "robert lewandowski",
+                        "name": "Robert Lewandowski",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1031,7 +1031,7 @@
                         "hits": "89",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "robert lewandowski",
+                        "name": "Robert Lewandowski",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1075,7 +1075,7 @@
                 "hits": "89",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "robert lewandowski",
+                "name": "Robert Lewandowski",
                 "overall": "91",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -1098,7 +1098,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "eden hazard",
+                        "name": "Eden Hazard",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1142,7 +1142,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "eden hazard",
+                        "name": "Eden Hazard",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1186,7 +1186,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "eden hazard",
+                        "name": "Eden Hazard",
                         "overall": "91",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1230,7 +1230,7 @@
                 "hits": "66",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "eden hazard",
+                "name": "Eden Hazard",
                 "overall": "91",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -1253,7 +1253,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alisson",
+                        "name": "Alisson",
                         "overall": "90",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1297,7 +1297,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alisson",
+                        "name": "Alisson",
                         "overall": "90",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1341,7 +1341,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alisson",
+                        "name": "Alisson",
                         "overall": "90",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -1385,7 +1385,7 @@
                 "hits": "53",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "alisson",
+                "name": "Alisson",
                 "overall": "90",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -1408,7 +1408,7 @@
                         "hits": "94",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mohamed salah",
+                        "name": "Mohamed Salah",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1452,7 +1452,7 @@
                         "hits": "94",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mohamed salah",
+                        "name": "Mohamed Salah",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1496,7 +1496,7 @@
                         "hits": "94",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mohamed salah",
+                        "name": "Mohamed Salah",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1540,7 +1540,7 @@
                 "hits": "94",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "mohamed salah",
+                "name": "Mohamed Salah",
                 "overall": "90",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -1563,7 +1563,7 @@
                         "hits": "76",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sadio man\u00e9",
+                        "name": "Sadio Man\u00e9",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1607,7 +1607,7 @@
                         "hits": "76",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sadio man\u00e9",
+                        "name": "Sadio Man\u00e9",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1651,7 +1651,7 @@
                         "hits": "76",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sadio man\u00e9",
+                        "name": "Sadio Man\u00e9",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1695,7 +1695,7 @@
                 "hits": "76",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sadio man\u00e9",
+                "name": "Sadio Man\u00e9",
                 "overall": "90",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -1718,7 +1718,7 @@
                         "hits": "68",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marc-andr\u00e9 ter stegen",
+                        "name": "Marc-Andr\u00e9 ter Stegen",
                         "overall": "90",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -1762,7 +1762,7 @@
                         "hits": "68",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marc-andr\u00e9 ter stegen",
+                        "name": "Marc-Andr\u00e9 ter Stegen",
                         "overall": "90",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -1806,7 +1806,7 @@
                         "hits": "68",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marc-andr\u00e9 ter stegen",
+                        "name": "Marc-Andr\u00e9 ter Stegen",
                         "overall": "90",
                         "potential": "93",
                         "was_ingested_by_unknown": true
@@ -1850,7 +1850,7 @@
                 "hits": "68",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "marc-andr\u00e9 ter stegen",
+                "name": "Marc-Andr\u00e9 ter Stegen",
                 "overall": "90",
                 "potential": "93",
                 "was_ingested_by_unknown": true
@@ -1873,7 +1873,7 @@
                         "hits": "50",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ag\u00fcero",
+                        "name": "Sergio Ag\u00fcero",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1917,7 +1917,7 @@
                         "hits": "50",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ag\u00fcero",
+                        "name": "Sergio Ag\u00fcero",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -1961,7 +1961,7 @@
                         "hits": "50",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ag\u00fcero",
+                        "name": "Sergio Ag\u00fcero",
                         "overall": "90",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -2005,7 +2005,7 @@
                 "hits": "50",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sergio ag\u00fcero",
+                "name": "Sergio Ag\u00fcero",
                 "overall": "90",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -2028,7 +2028,7 @@
                         "hits": "222",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kylian mbapp\u00e9",
+                        "name": "Kylian Mbapp\u00e9",
                         "overall": "89",
                         "potential": "95",
                         "was_ingested_by_unknown": true
@@ -2072,7 +2072,7 @@
                         "hits": "222",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kylian mbapp\u00e9",
+                        "name": "Kylian Mbapp\u00e9",
                         "overall": "89",
                         "potential": "95",
                         "was_ingested_by_unknown": true
@@ -2116,7 +2116,7 @@
                         "hits": "222",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kylian mbapp\u00e9",
+                        "name": "Kylian Mbapp\u00e9",
                         "overall": "89",
                         "potential": "95",
                         "was_ingested_by_unknown": true
@@ -2160,7 +2160,7 @@
                 "hits": "222",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "kylian mbapp\u00e9",
+                "name": "Kylian Mbapp\u00e9",
                 "overall": "89",
                 "potential": "95",
                 "was_ingested_by_unknown": true
@@ -2183,7 +2183,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "n'golo kant\u00e9",
+                        "name": "N'Golo Kant\u00e9",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2227,7 +2227,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "n'golo kant\u00e9",
+                        "name": "N'Golo Kant\u00e9",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2271,7 +2271,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "n'golo kant\u00e9",
+                        "name": "N'Golo Kant\u00e9",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2315,7 +2315,7 @@
                 "hits": "75",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "n'golo kant\u00e9",
+                "name": "N'Golo Kant\u00e9",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -2338,7 +2338,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "harry kane",
+                        "name": "Harry Kane",
                         "overall": "89",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -2382,7 +2382,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "harry kane",
+                        "name": "Harry Kane",
                         "overall": "89",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -2426,7 +2426,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "harry kane",
+                        "name": "Harry Kane",
                         "overall": "89",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -2470,7 +2470,7 @@
                 "hits": "64",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "harry kane",
+                "name": "Harry Kane",
                 "overall": "89",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -2493,7 +2493,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "antoine griezmann",
+                        "name": "Antoine Griezmann",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2537,7 +2537,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "antoine griezmann",
+                        "name": "Antoine Griezmann",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2581,7 +2581,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "antoine griezmann",
+                        "name": "Antoine Griezmann",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2625,7 +2625,7 @@
                 "hits": "66",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "antoine griezmann",
+                "name": "Antoine Griezmann",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -2648,7 +2648,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toni kroos",
+                        "name": "Toni Kroos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2692,7 +2692,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toni kroos",
+                        "name": "Toni Kroos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2736,7 +2736,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toni kroos",
+                        "name": "Toni Kroos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2780,7 +2780,7 @@
                 "hits": "37",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "toni kroos",
+                "name": "Toni Kroos",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -2803,7 +2803,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luka modric",
+                        "name": "Luka Modric",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2847,7 +2847,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luka modric",
+                        "name": "Luka Modric",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2891,7 +2891,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luka modric",
+                        "name": "Luka Modric",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -2935,7 +2935,7 @@
                 "hits": "31",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "luka modric",
+                "name": "Luka Modric",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -2958,7 +2958,7 @@
                         "hits": "54",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis su\u00e1rez",
+                        "name": "Luis Su\u00e1rez",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3002,7 +3002,7 @@
                         "hits": "54",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis su\u00e1rez",
+                        "name": "Luis Su\u00e1rez",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3046,7 +3046,7 @@
                         "hits": "54",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis su\u00e1rez",
+                        "name": "Luis Su\u00e1rez",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3090,7 +3090,7 @@
                 "hits": "54",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "luis su\u00e1rez",
+                "name": "Luis Su\u00e1rez",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -3113,7 +3113,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "manuel neuer",
+                        "name": "Manuel Neuer",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3157,7 +3157,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "manuel neuer",
+                        "name": "Manuel Neuer",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3201,7 +3201,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "manuel neuer",
+                        "name": "Manuel Neuer",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3245,7 +3245,7 @@
                 "hits": "42",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "manuel neuer",
+                "name": "Manuel Neuer",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -3268,7 +3268,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ramos",
+                        "name": "Sergio Ramos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3312,7 +3312,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ramos",
+                        "name": "Sergio Ramos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3356,7 +3356,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio ramos",
+                        "name": "Sergio Ramos",
                         "overall": "89",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -3400,7 +3400,7 @@
                 "hits": "55",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sergio ramos",
+                "name": "Sergio Ramos",
                 "overall": "89",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -3423,7 +3423,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ederson",
+                        "name": "Ederson",
                         "overall": "88",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -3467,7 +3467,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ederson",
+                        "name": "Ederson",
                         "overall": "88",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -3511,7 +3511,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ederson",
+                        "name": "Ederson",
                         "overall": "88",
                         "potential": "91",
                         "was_ingested_by_unknown": true
@@ -3555,7 +3555,7 @@
                 "hits": "40",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "ederson",
+                "name": "Ederson",
                 "overall": "88",
                 "potential": "91",
                 "was_ingested_by_unknown": true
@@ -3578,7 +3578,7 @@
                         "hits": "61",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "raheem sterling",
+                        "name": "Raheem Sterling",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -3622,7 +3622,7 @@
                         "hits": "61",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "raheem sterling",
+                        "name": "Raheem Sterling",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -3666,7 +3666,7 @@
                         "hits": "61",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "raheem sterling",
+                        "name": "Raheem Sterling",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -3710,7 +3710,7 @@
                 "hits": "61",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "raheem sterling",
+                "name": "Raheem Sterling",
                 "overall": "88",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -3733,7 +3733,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "roberto firmino",
+                        "name": "Roberto Firmino",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -3777,7 +3777,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "roberto firmino",
+                        "name": "Roberto Firmino",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -3821,7 +3821,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "roberto firmino",
+                        "name": "Roberto Firmino",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -3865,7 +3865,7 @@
                 "hits": "79",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "roberto firmino",
+                "name": "Roberto Firmino",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -3888,7 +3888,7 @@
                         "hits": "78",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kalidou koulibaly",
+                        "name": "Kalidou Koulibaly",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -3932,7 +3932,7 @@
                         "hits": "78",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kalidou koulibaly",
+                        "name": "Kalidou Koulibaly",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -3976,7 +3976,7 @@
                         "hits": "78",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "kalidou koulibaly",
+                        "name": "Kalidou Koulibaly",
                         "overall": "88",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -4020,7 +4020,7 @@
                 "hits": "78",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "kalidou koulibaly",
+                "name": "Kalidou Koulibaly",
                 "overall": "88",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -4043,7 +4043,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "casemiro",
+                        "name": "Casemiro",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4087,7 +4087,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "casemiro",
+                        "name": "Casemiro",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4131,7 +4131,7 @@
                         "hits": "37",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "casemiro",
+                        "name": "Casemiro",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4175,7 +4175,7 @@
                 "hits": "37",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "casemiro",
+                "name": "Casemiro",
                 "overall": "88",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -4198,7 +4198,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "de gea",
+                        "name": "De Gea",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4242,7 +4242,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "de gea",
+                        "name": "De Gea",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4286,7 +4286,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "de gea",
+                        "name": "De Gea",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4330,7 +4330,7 @@
                 "hits": "39",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "de gea",
+                "name": "De Gea",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -4353,7 +4353,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thibaut courtois",
+                        "name": "Thibaut Courtois",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4397,7 +4397,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thibaut courtois",
+                        "name": "Thibaut Courtois",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4441,7 +4441,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thibaut courtois",
+                        "name": "Thibaut Courtois",
                         "overall": "88",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -4485,7 +4485,7 @@
                 "hits": "34",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "thibaut courtois",
+                "name": "Thibaut Courtois",
                 "overall": "88",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -4508,7 +4508,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio busquets",
+                        "name": "Sergio Busquets",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4552,7 +4552,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio busquets",
+                        "name": "Sergio Busquets",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4596,7 +4596,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergio busquets",
+                        "name": "Sergio Busquets",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4640,7 +4640,7 @@
                 "hits": "34",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sergio busquets",
+                "name": "Sergio Busquets",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -4663,7 +4663,7 @@
                         "hits": "114",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pierre-emerick aubameyang",
+                        "name": "Pierre-Emerick Aubameyang",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4707,7 +4707,7 @@
                         "hits": "114",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pierre-emerick aubameyang",
+                        "name": "Pierre-Emerick Aubameyang",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4751,7 +4751,7 @@
                         "hits": "114",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pierre-emerick aubameyang",
+                        "name": "Pierre-Emerick Aubameyang",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4795,7 +4795,7 @@
                 "hits": "114",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "pierre-emerick aubameyang",
+                "name": "Pierre-Emerick Aubameyang",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -4818,7 +4818,7 @@
                         "hits": "51",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "karim benzema",
+                        "name": "Karim Benzema",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4862,7 +4862,7 @@
                         "hits": "51",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "karim benzema",
+                        "name": "Karim Benzema",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4906,7 +4906,7 @@
                         "hits": "51",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "karim benzema",
+                        "name": "Karim Benzema",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -4950,7 +4950,7 @@
                 "hits": "51",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "karim benzema",
+                "name": "Karim Benzema",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -4973,7 +4973,7 @@
                         "hits": "13",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samir handanovic",
+                        "name": "Samir Handanovic",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5017,7 +5017,7 @@
                         "hits": "13",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samir handanovic",
+                        "name": "Samir Handanovic",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5061,7 +5061,7 @@
                         "hits": "13",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samir handanovic",
+                        "name": "Samir Handanovic",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5105,7 +5105,7 @@
                 "hits": "13",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "samir handanovic",
+                "name": "Samir Handanovic",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -5128,7 +5128,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "piqu\u00e9",
+                        "name": "Piqu\u00e9",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5172,7 +5172,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "piqu\u00e9",
+                        "name": "Piqu\u00e9",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5216,7 +5216,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "piqu\u00e9",
+                        "name": "Piqu\u00e9",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5260,7 +5260,7 @@
                 "hits": "41",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "piqu\u00e9",
+                "name": "Piqu\u00e9",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -5283,7 +5283,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "giorgio chiellini",
+                        "name": "Giorgio Chiellini",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5327,7 +5327,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "giorgio chiellini",
+                        "name": "Giorgio Chiellini",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5371,7 +5371,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "giorgio chiellini",
+                        "name": "Giorgio Chiellini",
                         "overall": "88",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -5415,7 +5415,7 @@
                 "hits": "19",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "giorgio chiellini",
+                "name": "Giorgio Chiellini",
                 "overall": "88",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -5438,7 +5438,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bernardo silva",
+                        "name": "Bernardo Silva",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5482,7 +5482,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bernardo silva",
+                        "name": "Bernardo Silva",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5526,7 +5526,7 @@
                         "hits": "53",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bernardo silva",
+                        "name": "Bernardo Silva",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5570,7 +5570,7 @@
                 "hits": "53",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "bernardo silva",
+                "name": "Bernardo Silva",
                 "overall": "87",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -5593,7 +5593,7 @@
                         "hits": "82",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "joshua kimmich",
+                        "name": "Joshua Kimmich",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5637,7 +5637,7 @@
                         "hits": "82",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "joshua kimmich",
+                        "name": "Joshua Kimmich",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5681,7 +5681,7 @@
                         "hits": "82",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "joshua kimmich",
+                        "name": "Joshua Kimmich",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5725,7 +5725,7 @@
                 "hits": "82",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "joshua kimmich",
+                "name": "Joshua Kimmich",
                 "overall": "87",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -5748,7 +5748,7 @@
                         "hits": "38",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "aymeric laporte",
+                        "name": "Aymeric Laporte",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5792,7 +5792,7 @@
                         "hits": "38",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "aymeric laporte",
+                        "name": "Aymeric Laporte",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5836,7 +5836,7 @@
                         "hits": "38",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "aymeric laporte",
+                        "name": "Aymeric Laporte",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5880,7 +5880,7 @@
                 "hits": "38",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "aymeric laporte",
+                "name": "Aymeric Laporte",
                 "overall": "87",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -5903,7 +5903,7 @@
                         "hits": "95",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paulo dybala",
+                        "name": "Paulo Dybala",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5947,7 +5947,7 @@
                         "hits": "95",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paulo dybala",
+                        "name": "Paulo Dybala",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -5991,7 +5991,7 @@
                         "hits": "95",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paulo dybala",
+                        "name": "Paulo Dybala",
                         "overall": "87",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -6035,7 +6035,7 @@
                 "hits": "95",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "paulo dybala",
+                "name": "Paulo Dybala",
                 "overall": "87",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -6058,7 +6058,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "heung min son",
+                        "name": "Heung Min Son",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6102,7 +6102,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "heung min son",
+                        "name": "Heung Min Son",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6146,7 +6146,7 @@
                         "hits": "75",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "heung min son",
+                        "name": "Heung Min Son",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6190,7 +6190,7 @@
                 "hits": "75",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "heung min son",
+                "name": "Heung Min Son",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -6213,7 +6213,7 @@
                         "hits": "45",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco verratti",
+                        "name": "Marco Verratti",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6257,7 +6257,7 @@
                         "hits": "45",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco verratti",
+                        "name": "Marco Verratti",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6301,7 +6301,7 @@
                         "hits": "45",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco verratti",
+                        "name": "Marco Verratti",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6345,7 +6345,7 @@
                 "hits": "45",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "marco verratti",
+                "name": "Marco Verratti",
                 "overall": "87",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -6368,7 +6368,7 @@
                         "hits": "70",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paul pogba",
+                        "name": "Paul Pogba",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6412,7 +6412,7 @@
                         "hits": "70",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paul pogba",
+                        "name": "Paul Pogba",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6456,7 +6456,7 @@
                         "hits": "70",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "paul pogba",
+                        "name": "Paul Pogba",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -6500,7 +6500,7 @@
                 "hits": "70",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "paul pogba",
+                "name": "Paul Pogba",
                 "overall": "87",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -6523,7 +6523,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "keylor navas",
+                        "name": "Keylor Navas",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6567,7 +6567,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "keylor navas",
+                        "name": "Keylor Navas",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6611,7 +6611,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "keylor navas",
+                        "name": "Keylor Navas",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6655,7 +6655,7 @@
                 "hits": "28",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "keylor navas",
+                "name": "Keylor Navas",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -6678,7 +6678,7 @@
                         "hits": "130",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ciro immobile",
+                        "name": "Ciro Immobile",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6722,7 +6722,7 @@
                         "hits": "130",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ciro immobile",
+                        "name": "Ciro Immobile",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6766,7 +6766,7 @@
                         "hits": "130",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "ciro immobile",
+                        "name": "Ciro Immobile",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6810,7 +6810,7 @@
                 "hits": "130",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "ciro immobile",
+                "name": "Ciro Immobile",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -6833,7 +6833,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "christian eriksen",
+                        "name": "Christian Eriksen",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6877,7 +6877,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "christian eriksen",
+                        "name": "Christian Eriksen",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6921,7 +6921,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "christian eriksen",
+                        "name": "Christian Eriksen",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -6965,7 +6965,7 @@
                 "hits": "48",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "christian eriksen",
+                "name": "Christian Eriksen",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -6988,7 +6988,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "parejo",
+                        "name": "Parejo",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7032,7 +7032,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "parejo",
+                        "name": "Parejo",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7076,7 +7076,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "parejo",
+                        "name": "Parejo",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7120,7 +7120,7 @@
                 "hits": "14",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "parejo",
+                "name": "Parejo",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -7143,7 +7143,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco reus",
+                        "name": "Marco Reus",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7187,7 +7187,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco reus",
+                        "name": "Marco Reus",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7231,7 +7231,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marco reus",
+                        "name": "Marco Reus",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7275,7 +7275,7 @@
                 "hits": "42",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "marco reus",
+                "name": "Marco Reus",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -7298,7 +7298,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "wojciech szczesny",
+                        "name": "Wojciech Szczesny",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -7342,7 +7342,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "wojciech szczesny",
+                        "name": "Wojciech Szczesny",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -7386,7 +7386,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "wojciech szczesny",
+                        "name": "Wojciech Szczesny",
                         "overall": "87",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -7430,7 +7430,7 @@
                 "hits": "17",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "wojciech szczesny",
+                "name": "Wojciech Szczesny",
                 "overall": "87",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -7453,7 +7453,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "\u00e1ngel di mar\u00eda",
+                        "name": "\u00c1ngel Di Mar\u00eda",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7497,7 +7497,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "\u00e1ngel di mar\u00eda",
+                        "name": "\u00c1ngel Di Mar\u00eda",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7541,7 +7541,7 @@
                         "hits": "41",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "\u00e1ngel di mar\u00eda",
+                        "name": "\u00c1ngel Di Mar\u00eda",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7585,7 +7585,7 @@
                 "hits": "41",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "\u00e1ngel di mar\u00eda",
+                "name": "\u00c1ngel Di Mar\u00eda",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -7608,7 +7608,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "diego god\u00edn",
+                        "name": "Diego God\u00edn",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7652,7 +7652,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "diego god\u00edn",
+                        "name": "Diego God\u00edn",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7696,7 +7696,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "diego god\u00edn",
+                        "name": "Diego God\u00edn",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7740,7 +7740,7 @@
                 "hits": "16",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "diego god\u00edn",
+                "name": "Diego God\u00edn",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -7763,7 +7763,7 @@
                         "hits": "18",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mats hummels",
+                        "name": "Mats Hummels",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7807,7 +7807,7 @@
                         "hits": "18",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mats hummels",
+                        "name": "Mats Hummels",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7851,7 +7851,7 @@
                         "hits": "18",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mats hummels",
+                        "name": "Mats Hummels",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7895,7 +7895,7 @@
                 "hits": "18",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "mats hummels",
+                "name": "Mats Hummels",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -7918,7 +7918,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "dries mertens",
+                        "name": "Dries Mertens",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -7962,7 +7962,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "dries mertens",
+                        "name": "Dries Mertens",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8006,7 +8006,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "dries mertens",
+                        "name": "Dries Mertens",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8050,7 +8050,7 @@
                 "hits": "34",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "dries mertens",
+                "name": "Dries Mertens",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -8073,7 +8073,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "david silva",
+                        "name": "David Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8117,7 +8117,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "david silva",
+                        "name": "David Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8161,7 +8161,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "david silva",
+                        "name": "David Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8205,7 +8205,7 @@
                 "hits": "28",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "david silva",
+                "name": "David Silva",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -8228,7 +8228,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hugo lloris",
+                        "name": "Hugo Lloris",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8272,7 +8272,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hugo lloris",
+                        "name": "Hugo Lloris",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8316,7 +8316,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hugo lloris",
+                        "name": "Hugo Lloris",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8360,7 +8360,7 @@
                 "hits": "19",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "hugo lloris",
+                "name": "Hugo Lloris",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -8383,7 +8383,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago silva",
+                        "name": "Thiago Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8427,7 +8427,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago silva",
+                        "name": "Thiago Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8471,7 +8471,7 @@
                         "hits": "28",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago silva",
+                        "name": "Thiago Silva",
                         "overall": "87",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -8515,7 +8515,7 @@
                 "hits": "28",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "thiago silva",
+                "name": "Thiago Silva",
                 "overall": "87",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -8538,7 +8538,7 @@
                         "hits": "300",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jadon sancho",
+                        "name": "Jadon Sancho",
                         "overall": "86",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -8582,7 +8582,7 @@
                         "hits": "300",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jadon sancho",
+                        "name": "Jadon Sancho",
                         "overall": "86",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -8626,7 +8626,7 @@
                         "hits": "300",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jadon sancho",
+                        "name": "Jadon Sancho",
                         "overall": "86",
                         "potential": "94",
                         "was_ingested_by_unknown": true
@@ -8670,7 +8670,7 @@
                 "hits": "300",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "jadon sancho",
+                "name": "Jadon Sancho",
                 "overall": "86",
                 "potential": "94",
                 "was_ingested_by_unknown": true
@@ -8693,7 +8693,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "milan \u0161kriniar",
+                        "name": "Milan \u0160kriniar",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -8737,7 +8737,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "milan \u0161kriniar",
+                        "name": "Milan \u0160kriniar",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -8781,7 +8781,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "milan \u0161kriniar",
+                        "name": "Milan \u0160kriniar",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -8825,7 +8825,7 @@
                 "hits": "62",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "milan \u0161kriniar",
+                "name": "Milan \u0160kriniar",
                 "overall": "86",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -8848,7 +8848,7 @@
                         "hits": "126",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "frenkie de jong",
+                        "name": "Frenkie de Jong",
                         "overall": "86",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -8892,7 +8892,7 @@
                         "hits": "126",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "frenkie de jong",
+                        "name": "Frenkie de Jong",
                         "overall": "86",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -8936,7 +8936,7 @@
                         "hits": "126",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "frenkie de jong",
+                        "name": "Frenkie de Jong",
                         "overall": "86",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -8980,7 +8980,7 @@
                 "hits": "126",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "frenkie de jong",
+                "name": "Frenkie de Jong",
                 "overall": "86",
                 "potential": "92",
                 "was_ingested_by_unknown": true
@@ -9003,7 +9003,7 @@
                         "hits": "74",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leroy san\u00e9",
+                        "name": "Leroy San\u00e9",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9047,7 +9047,7 @@
                         "hits": "74",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leroy san\u00e9",
+                        "name": "Leroy San\u00e9",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9091,7 +9091,7 @@
                         "hits": "74",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leroy san\u00e9",
+                        "name": "Leroy San\u00e9",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9135,7 +9135,7 @@
                 "hits": "74",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "leroy san\u00e9",
+                "name": "Leroy San\u00e9",
                 "overall": "86",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -9158,7 +9158,7 @@
                         "hits": "58",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cl\u00e9ment lenglet",
+                        "name": "Cl\u00e9ment Lenglet",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9202,7 +9202,7 @@
                         "hits": "58",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cl\u00e9ment lenglet",
+                        "name": "Cl\u00e9ment Lenglet",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9246,7 +9246,7 @@
                         "hits": "58",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "cl\u00e9ment lenglet",
+                        "name": "Cl\u00e9ment Lenglet",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -9290,7 +9290,7 @@
                 "hits": "58",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "cl\u00e9ment lenglet",
+                "name": "Cl\u00e9ment Lenglet",
                 "overall": "86",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -9313,7 +9313,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andrew robertson",
+                        "name": "Andrew Robertson",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9357,7 +9357,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andrew robertson",
+                        "name": "Andrew Robertson",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9401,7 +9401,7 @@
                         "hits": "66",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andrew robertson",
+                        "name": "Andrew Robertson",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9445,7 +9445,7 @@
                 "hits": "66",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "andrew robertson",
+                "name": "Andrew Robertson",
                 "overall": "86",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -9468,7 +9468,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bruno fernandes",
+                        "name": "Bruno Fernandes",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9512,7 +9512,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bruno fernandes",
+                        "name": "Bruno Fernandes",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9556,7 +9556,7 @@
                         "hits": "127",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "bruno fernandes",
+                        "name": "Bruno Fernandes",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9600,7 +9600,7 @@
                 "hits": "127",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "bruno fernandes",
+                "name": "Bruno Fernandes",
                 "overall": "86",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -9623,7 +9623,7 @@
                         "hits": "136",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "timo werner",
+                        "name": "Timo Werner",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9667,7 +9667,7 @@
                         "hits": "136",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "timo werner",
+                        "name": "Timo Werner",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9711,7 +9711,7 @@
                         "hits": "136",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "timo werner",
+                        "name": "Timo Werner",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -9755,7 +9755,7 @@
                 "hits": "136",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "timo werner",
+                "name": "Timo Werner",
                 "overall": "86",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -9778,7 +9778,7 @@
                         "hits": "44",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "fabinho",
+                        "name": "Fabinho",
                         "overall": "86",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -9822,7 +9822,7 @@
                         "hits": "44",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "fabinho",
+                        "name": "Fabinho",
                         "overall": "86",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -9866,7 +9866,7 @@
                         "hits": "44",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "fabinho",
+                        "name": "Fabinho",
                         "overall": "86",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -9910,7 +9910,7 @@
                 "hits": "44",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "fabinho",
+                "name": "Fabinho",
                 "overall": "86",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -9933,7 +9933,7 @@
                         "hits": "43",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jamie vardy",
+                        "name": "Jamie Vardy",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -9977,7 +9977,7 @@
                         "hits": "43",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jamie vardy",
+                        "name": "Jamie Vardy",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10021,7 +10021,7 @@
                         "hits": "43",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jamie vardy",
+                        "name": "Jamie Vardy",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10065,7 +10065,7 @@
                 "hits": "43",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "jamie vardy",
+                "name": "Jamie Vardy",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -10088,7 +10088,7 @@
                         "hits": "113",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hakim ziyech",
+                        "name": "Hakim Ziyech",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10132,7 +10132,7 @@
                         "hits": "113",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hakim ziyech",
+                        "name": "Hakim Ziyech",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10176,7 +10176,7 @@
                         "hits": "113",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "hakim ziyech",
+                        "name": "Hakim Ziyech",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10220,7 +10220,7 @@
                 "hits": "113",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "hakim ziyech",
+                "name": "Hakim Ziyech",
                 "overall": "86",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -10243,7 +10243,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marquinhos",
+                        "name": "Marquinhos",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -10287,7 +10287,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marquinhos",
+                        "name": "Marquinhos",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -10331,7 +10331,7 @@
                         "hits": "48",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "marquinhos",
+                        "name": "Marquinhos",
                         "overall": "86",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -10375,7 +10375,7 @@
                 "hits": "48",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "marquinhos",
+                "name": "Marquinhos",
                 "overall": "86",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -10398,7 +10398,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "riyad mahrez",
+                        "name": "Riyad Mahrez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10442,7 +10442,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "riyad mahrez",
+                        "name": "Riyad Mahrez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10486,7 +10486,7 @@
                         "hits": "40",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "riyad mahrez",
+                        "name": "Riyad Mahrez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10530,7 +10530,7 @@
                 "hits": "40",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "riyad mahrez",
+                "name": "Riyad Mahrez",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -10553,7 +10553,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rapha\u00ebl varane",
+                        "name": "Rapha\u00ebl Varane",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -10597,7 +10597,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rapha\u00ebl varane",
+                        "name": "Rapha\u00ebl Varane",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -10641,7 +10641,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rapha\u00ebl varane",
+                        "name": "Rapha\u00ebl Varane",
                         "overall": "86",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -10685,7 +10685,7 @@
                 "hits": "39",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "rapha\u00ebl varane",
+                "name": "Rapha\u00ebl Varane",
                 "overall": "86",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -10708,7 +10708,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mauro icardi",
+                        "name": "Mauro Icardi",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10752,7 +10752,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mauro icardi",
+                        "name": "Mauro Icardi",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10796,7 +10796,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "mauro icardi",
+                        "name": "Mauro Icardi",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -10840,7 +10840,7 @@
                 "hits": "47",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "mauro icardi",
+                "name": "Mauro Icardi",
                 "overall": "86",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -10863,7 +10863,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lorenzo insigne",
+                        "name": "Lorenzo Insigne",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10907,7 +10907,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lorenzo insigne",
+                        "name": "Lorenzo Insigne",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10951,7 +10951,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "lorenzo insigne",
+                        "name": "Lorenzo Insigne",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -10995,7 +10995,7 @@
                 "hits": "42",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "lorenzo insigne",
+                "name": "Lorenzo Insigne",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11018,7 +11018,7 @@
                         "hits": "15",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "koke",
+                        "name": "Koke",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11062,7 +11062,7 @@
                         "hits": "15",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "koke",
+                        "name": "Koke",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11106,7 +11106,7 @@
                         "hits": "15",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "koke",
+                        "name": "Koke",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11150,7 +11150,7 @@
                 "hits": "15",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "koke",
+                "name": "Koke",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11173,7 +11173,7 @@
                         "hits": "63",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "romelu lukaku",
+                        "name": "Romelu Lukaku",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -11217,7 +11217,7 @@
                         "hits": "63",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "romelu lukaku",
+                        "name": "Romelu Lukaku",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -11261,7 +11261,7 @@
                         "hits": "63",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "romelu lukaku",
+                        "name": "Romelu Lukaku",
                         "overall": "86",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -11305,7 +11305,7 @@
                 "hits": "63",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "romelu lukaku",
+                "name": "Romelu Lukaku",
                 "overall": "86",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -11328,7 +11328,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago",
+                        "name": "Thiago",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11372,7 +11372,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago",
+                        "name": "Thiago",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11416,7 +11416,7 @@
                         "hits": "47",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "thiago",
+                        "name": "Thiago",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11460,7 +11460,7 @@
                 "hits": "47",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "thiago",
+                "name": "Thiago",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11483,7 +11483,7 @@
                         "hits": "35",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jordi alba",
+                        "name": "Jordi Alba",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11527,7 +11527,7 @@
                         "hits": "35",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jordi alba",
+                        "name": "Jordi Alba",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11571,7 +11571,7 @@
                         "hits": "35",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jordi alba",
+                        "name": "Jordi Alba",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11615,7 +11615,7 @@
                 "hits": "35",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "jordi alba",
+                "name": "Jordi Alba",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11638,7 +11638,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leonardo bonucci",
+                        "name": "Leonardo Bonucci",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11682,7 +11682,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leonardo bonucci",
+                        "name": "Leonardo Bonucci",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11726,7 +11726,7 @@
                         "hits": "17",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "leonardo bonucci",
+                        "name": "Leonardo Bonucci",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11770,7 +11770,7 @@
                 "hits": "17",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "leonardo bonucci",
+                "name": "Leonardo Bonucci",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11793,7 +11793,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toby alderweireld",
+                        "name": "Toby Alderweireld",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11837,7 +11837,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toby alderweireld",
+                        "name": "Toby Alderweireld",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11881,7 +11881,7 @@
                         "hits": "16",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "toby alderweireld",
+                        "name": "Toby Alderweireld",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11925,7 +11925,7 @@
                 "hits": "16",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "toby alderweireld",
+                "name": "Toby Alderweireld",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -11948,7 +11948,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "miralem pjanic",
+                        "name": "Miralem Pjanic",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -11992,7 +11992,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "miralem pjanic",
+                        "name": "Miralem Pjanic",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12036,7 +12036,7 @@
                         "hits": "31",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "miralem pjanic",
+                        "name": "Miralem Pjanic",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12080,7 +12080,7 @@
                 "hits": "31",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "miralem pjanic",
+                "name": "Miralem Pjanic",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -12103,7 +12103,7 @@
                         "hits": "26",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "edinson cavani",
+                        "name": "Edinson Cavani",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12147,7 +12147,7 @@
                         "hits": "26",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "edinson cavani",
+                        "name": "Edinson Cavani",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12191,7 +12191,7 @@
                         "hits": "26",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "edinson cavani",
+                        "name": "Edinson Cavani",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12235,7 +12235,7 @@
                 "hits": "26",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "edinson cavani",
+                "name": "Edinson Cavani",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -12258,7 +12258,7 @@
                         "hits": "5",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "yann sommer",
+                        "name": "Yann Sommer",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12302,7 +12302,7 @@
                         "hits": "5",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "yann sommer",
+                        "name": "Yann Sommer",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12346,7 +12346,7 @@
                         "hits": "5",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "yann sommer",
+                        "name": "Yann Sommer",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12390,7 +12390,7 @@
                 "hits": "5",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "yann sommer",
+                "name": "Yann Sommer",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -12413,7 +12413,7 @@
                         "hits": "49",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alejandro g\u00f3mez",
+                        "name": "Alejandro G\u00f3mez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12457,7 +12457,7 @@
                         "hits": "49",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alejandro g\u00f3mez",
+                        "name": "Alejandro G\u00f3mez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12501,7 +12501,7 @@
                         "hits": "49",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "alejandro g\u00f3mez",
+                        "name": "Alejandro G\u00f3mez",
                         "overall": "86",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -12545,7 +12545,7 @@
                 "hits": "49",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "alejandro g\u00f3mez",
+                "name": "Alejandro G\u00f3mez",
                 "overall": "86",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -12568,7 +12568,7 @@
                         "hits": "110",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "matthijs de ligt",
+                        "name": "Matthijs de Ligt",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -12612,7 +12612,7 @@
                         "hits": "110",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "matthijs de ligt",
+                        "name": "Matthijs de Ligt",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -12656,7 +12656,7 @@
                         "hits": "110",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "matthijs de ligt",
+                        "name": "Matthijs de Ligt",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -12700,7 +12700,7 @@
                 "hits": "110",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "matthijs de ligt",
+                "name": "Matthijs de Ligt",
                 "overall": "85",
                 "potential": "92",
                 "was_ingested_by_unknown": true
@@ -12723,7 +12723,7 @@
                         "hits": "36",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rodri",
+                        "name": "Rodri",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -12767,7 +12767,7 @@
                         "hits": "36",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rodri",
+                        "name": "Rodri",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -12811,7 +12811,7 @@
                         "hits": "36",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "rodri",
+                        "name": "Rodri",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -12855,7 +12855,7 @@
                 "hits": "36",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "rodri",
+                "name": "Rodri",
                 "overall": "85",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -12878,7 +12878,7 @@
                         "hits": "135",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "trent alexander-arnold",
+                        "name": "Trent Alexander-Arnold",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -12922,7 +12922,7 @@
                         "hits": "135",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "trent alexander-arnold",
+                        "name": "Trent Alexander-Arnold",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -12966,7 +12966,7 @@
                         "hits": "135",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "trent alexander-arnold",
+                        "name": "Trent Alexander-Arnold",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13010,7 +13010,7 @@
                 "hits": "135",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "trent alexander-arnold",
+                "name": "Trent Alexander-Arnold",
                 "overall": "85",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -13033,7 +13033,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "arthur",
+                        "name": "Arthur",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13077,7 +13077,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "arthur",
+                        "name": "Arthur",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13121,7 +13121,7 @@
                         "hits": "64",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "arthur",
+                        "name": "Arthur",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13165,7 +13165,7 @@
                 "hits": "64",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "arthur",
+                "name": "Arthur",
                 "overall": "85",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -13188,7 +13188,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "gianluigi donnarumma",
+                        "name": "Gianluigi Donnarumma",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -13232,7 +13232,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "gianluigi donnarumma",
+                        "name": "Gianluigi Donnarumma",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -13276,7 +13276,7 @@
                         "hits": "62",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "gianluigi donnarumma",
+                        "name": "Gianluigi Donnarumma",
                         "overall": "85",
                         "potential": "92",
                         "was_ingested_by_unknown": true
@@ -13320,7 +13320,7 @@
                 "hits": "62",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "gianluigi donnarumma",
+                "name": "Gianluigi Donnarumma",
                 "overall": "85",
                 "potential": "92",
                 "was_ingested_by_unknown": true
@@ -13343,7 +13343,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andr\u00e9 onana",
+                        "name": "Andr\u00e9 Onana",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13387,7 +13387,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andr\u00e9 onana",
+                        "name": "Andr\u00e9 Onana",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13431,7 +13431,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "andr\u00e9 onana",
+                        "name": "Andr\u00e9 Onana",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13475,7 +13475,7 @@
                 "hits": "55",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "andr\u00e9 onana",
+                "name": "Andr\u00e9 Onana",
                 "overall": "85",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -13498,7 +13498,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergej milinkovic-savic",
+                        "name": "Sergej Milinkovic-Savic",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13542,7 +13542,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergej milinkovic-savic",
+                        "name": "Sergej Milinkovic-Savic",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13586,7 +13586,7 @@
                         "hits": "55",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sergej milinkovic-savic",
+                        "name": "Sergej Milinkovic-Savic",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -13630,7 +13630,7 @@
                 "hits": "55",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sergej milinkovic-savic",
+                "name": "Sergej Milinkovic-Savic",
                 "overall": "85",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -13653,7 +13653,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "nabil fekir",
+                        "name": "Nabil Fekir",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -13697,7 +13697,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "nabil fekir",
+                        "name": "Nabil Fekir",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -13741,7 +13741,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "nabil fekir",
+                        "name": "Nabil Fekir",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -13785,7 +13785,7 @@
                 "hits": "34",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "nabil fekir",
+                "name": "Nabil Fekir",
                 "overall": "85",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -13808,7 +13808,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jos\u00e9 mar\u00eda gim\u00e9nez",
+                        "name": "Jos\u00e9 Mar\u00eda Gim\u00e9nez",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13852,7 +13852,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jos\u00e9 mar\u00eda gim\u00e9nez",
+                        "name": "Jos\u00e9 Mar\u00eda Gim\u00e9nez",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13896,7 +13896,7 @@
                         "hits": "34",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "jos\u00e9 mar\u00eda gim\u00e9nez",
+                        "name": "Jos\u00e9 Mar\u00eda Gim\u00e9nez",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -13940,7 +13940,7 @@
                 "hits": "34",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "jos\u00e9 mar\u00eda gim\u00e9nez",
+                "name": "Jos\u00e9 Mar\u00eda Gim\u00e9nez",
                 "overall": "85",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -13963,7 +13963,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "niklas s\u00fcle",
+                        "name": "Niklas S\u00fcle",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -14007,7 +14007,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "niklas s\u00fcle",
+                        "name": "Niklas S\u00fcle",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -14051,7 +14051,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "niklas s\u00fcle",
+                        "name": "Niklas S\u00fcle",
                         "overall": "85",
                         "potential": "90",
                         "was_ingested_by_unknown": true
@@ -14095,7 +14095,7 @@
                 "hits": "42",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "niklas s\u00fcle",
+                "name": "Niklas S\u00fcle",
                 "overall": "85",
                 "potential": "90",
                 "was_ingested_by_unknown": true
@@ -14118,7 +14118,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sa\u00fal",
+                        "name": "Sa\u00fal",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -14162,7 +14162,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sa\u00fal",
+                        "name": "Sa\u00fal",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -14206,7 +14206,7 @@
                         "hits": "39",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "sa\u00fal",
+                        "name": "Sa\u00fal",
                         "overall": "85",
                         "potential": "89",
                         "was_ingested_by_unknown": true
@@ -14250,7 +14250,7 @@
                 "hits": "39",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "sa\u00fal",
+                "name": "Sa\u00fal",
                 "overall": "85",
                 "potential": "89",
                 "was_ingested_by_unknown": true
@@ -14273,7 +14273,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "serge gnabry",
+                        "name": "Serge Gnabry",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -14317,7 +14317,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "serge gnabry",
+                        "name": "Serge Gnabry",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -14361,7 +14361,7 @@
                         "hits": "79",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "serge gnabry",
+                        "name": "Serge Gnabry",
                         "overall": "85",
                         "potential": "87",
                         "was_ingested_by_unknown": true
@@ -14405,7 +14405,7 @@
                 "hits": "79",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "serge gnabry",
+                "name": "Serge Gnabry",
                 "overall": "85",
                 "potential": "87",
                 "was_ingested_by_unknown": true
@@ -14428,7 +14428,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samuel umtiti",
+                        "name": "Samuel Umtiti",
                         "overall": "85",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -14472,7 +14472,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samuel umtiti",
+                        "name": "Samuel Umtiti",
                         "overall": "85",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -14516,7 +14516,7 @@
                         "hits": "42",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "samuel umtiti",
+                        "name": "Samuel Umtiti",
                         "overall": "85",
                         "potential": "88",
                         "was_ingested_by_unknown": true
@@ -14560,7 +14560,7 @@
                 "hits": "42",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "samuel umtiti",
+                "name": "Samuel Umtiti",
                 "overall": "85",
                 "potential": "88",
                 "was_ingested_by_unknown": true
@@ -14583,7 +14583,7 @@
                         "hits": "24",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "carvajal",
+                        "name": "Carvajal",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -14627,7 +14627,7 @@
                         "hits": "24",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "carvajal",
+                        "name": "Carvajal",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -14671,7 +14671,7 @@
                         "hits": "24",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "carvajal",
+                        "name": "Carvajal",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -14715,7 +14715,7 @@
                 "hits": "24",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "carvajal",
+                "name": "Carvajal",
                 "overall": "85",
                 "potential": "85",
                 "was_ingested_by_unknown": true
@@ -14738,7 +14738,7 @@
                         "hits": "27",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis alberto",
+                        "name": "Luis Alberto",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -14782,7 +14782,7 @@
                         "hits": "27",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis alberto",
+                        "name": "Luis Alberto",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -14826,7 +14826,7 @@
                         "hits": "27",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "luis alberto",
+                        "name": "Luis Alberto",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -14870,7 +14870,7 @@
                 "hits": "27",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "luis alberto",
+                "name": "Luis Alberto",
                 "overall": "85",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -14893,7 +14893,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "stefan de vrij",
+                        "name": "Stefan de Vrij",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -14937,7 +14937,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "stefan de vrij",
+                        "name": "Stefan de Vrij",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -14981,7 +14981,7 @@
                         "hits": "19",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "stefan de vrij",
+                        "name": "Stefan de Vrij",
                         "overall": "85",
                         "potential": "86",
                         "was_ingested_by_unknown": true
@@ -15025,7 +15025,7 @@
                 "hits": "19",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "stefan de vrij",
+                "name": "Stefan de Vrij",
                 "overall": "85",
                 "potential": "86",
                 "was_ingested_by_unknown": true
@@ -15048,7 +15048,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pizzi",
+                        "name": "Pizzi",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15092,7 +15092,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pizzi",
+                        "name": "Pizzi",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15136,7 +15136,7 @@
                         "hits": "14",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "pizzi",
+                        "name": "Pizzi",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15180,7 +15180,7 @@
                 "hits": "14",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "pizzi",
+                "name": "Pizzi",
                 "overall": "85",
                 "potential": "85",
                 "was_ingested_by_unknown": true
@@ -15203,7 +15203,7 @@
                         "hits": "25",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "isco",
+                        "name": "Isco",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15247,7 +15247,7 @@
                         "hits": "25",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "isco",
+                        "name": "Isco",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15291,7 +15291,7 @@
                         "hits": "25",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "isco",
+                        "name": "Isco",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15335,7 +15335,7 @@
                 "hits": "25",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "isco",
+                "name": "Isco",
                 "overall": "85",
                 "potential": "85",
                 "was_ingested_by_unknown": true
@@ -15358,7 +15358,7 @@
                         "hits": "10",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "iago aspas",
+                        "name": "Iago Aspas",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15402,7 +15402,7 @@
                         "hits": "10",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "iago aspas",
+                        "name": "Iago Aspas",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15446,7 +15446,7 @@
                         "hits": "10",
                         "last_ingested_at": "2021-06-18T00:00:00",
                         "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                        "name": "iago aspas",
+                        "name": "Iago Aspas",
                         "overall": "85",
                         "potential": "85",
                         "was_ingested_by_unknown": true
@@ -15490,7 +15490,7 @@
                 "hits": "10",
                 "last_ingested_at": "2021-06-18T00:00:00",
                 "last_ingested_by_unknown_at": "2021-06-18T00:00:00",
-                "name": "iago aspas",
+                "name": "Iago Aspas",
                 "overall": "85",
                 "potential": "85",
                 "was_ingested_by_unknown": true

--- a/tests/unit/interpreting/interpretations/test_source_node_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_source_node_interpretation.py
@@ -60,7 +60,7 @@ def test_source_node_interpretaton_applies_static_properties(blank_context):
 
 def test_source_node_interpretation_applies_dynamic_properties(blank_context):
     first_name = "zach"
-    expected_properties = {"first_name": first_name, "last_name": "probst"}
+    expected_properties = {"first_name": first_name, "last_name": "Probst"}
     dynamic_first_name = StubbedValueProvider(values=[first_name])
     subject = SourceNodeInterpretation(
         node_type=EXPECTED_NODE_TYPE,
@@ -140,3 +140,23 @@ def test_source_node_interpretation_with_properties_from_value_provider_wrong_ty
             properties=StubbedValueProvider(values=["prop"]),
         )
         subject.interpret(blank_context)
+
+
+def test_source_node_interpretation_setting_both_normalization_and_properties_normalization():
+    with pytest.raises(ValueError):
+        SourceNodeInterpretation(
+            node_type="Static",
+            key={"hello": "world"},
+            properties_normalization={"foo": "bar"},
+            normalization={"baz": "qux"},
+        )
+
+
+def test_source_node_interpretation_setting_both_normalization_and_key_normalization():
+    with pytest.raises(ValueError):
+        SourceNodeInterpretation(
+            node_type="Static",
+            key={"hello": "world"},
+            key_normalization={"foo": "bar"},
+            normalization={"baz": "qux"},
+        )


### PR DESCRIPTION
Closes #277 