### PR TITLE
Squash Migrations

### DIFF
--- a/nodestream/cli/commands/__init__.py
+++ b/nodestream/cli/commands/__init__.py
@@ -10,6 +10,7 @@ from .run_migrations import RunMigrations
 from .scaffold import Scaffold
 from .show import Show
 from .show_migrations import ShowMigrations
+from .squash_migrations import SquashMigration
 
 __all__ = (
     "AuditCommand",
@@ -24,4 +25,5 @@ __all__ = (
     "Scaffold",
     "ShowMigrations",
     "Show",
+    "SquashMigration",
 )

--- a/nodestream/cli/commands/squash_migrations.py
+++ b/nodestream/cli/commands/squash_migrations.py
@@ -14,12 +14,9 @@ class SquashMigration(NodestreamCommand):
             "from",
             description="The name of the migration to squash from.",
             value_required=True,
+            flag=False,
         ),
-        option(
-            "to",
-            description="The name of the migration to squash to.",
-            value_required=True,
-        ),
+        option("to", description="The name of the migration to squash to.", flag=False),
     ]
 
     async def handle_async(self):

--- a/nodestream/cli/commands/squash_migrations.py
+++ b/nodestream/cli/commands/squash_migrations.py
@@ -1,0 +1,34 @@
+from cleo.helpers import option
+
+from ..operations import GenerateSquashedMigration
+from .nodestream_command import NodestreamCommand
+from .shared_options import PROJECT_FILE_OPTION
+
+
+class SquashMigration(NodestreamCommand):
+    name = "migrations squash"
+    description = "Generate a migration for the current project."
+    options = [
+        PROJECT_FILE_OPTION,
+        option(
+            "from",
+            description="The name of the migration to squash from.",
+            value_required=True,
+        ),
+        option(
+            "to",
+            description="The name of the migration to squash to.",
+            value_required=True,
+        ),
+    ]
+
+    async def handle_async(self):
+        from_migration_name = self.option("from")
+        to_migration_name = self.option("to")
+        migrations = self.get_migrations()
+        operation = GenerateSquashedMigration(
+            migrations,
+            from_migration_name,
+            to_migration_name,
+        )
+        await self.run_operation(operation)

--- a/nodestream/cli/operations/__init__.py
+++ b/nodestream/cli/operations/__init__.py
@@ -3,6 +3,7 @@ from .commit_project_to_disk import CommitProjectToDisk
 from .execute_migration import ExecuteMigrations
 from .generate_migration import GenerateMigration
 from .generate_pipeline_scaffold import GeneratePipelineScaffold
+from .generate_squashed_migration import GenerateSquashedMigration
 from .initialize_logger import InitializeLogger
 from .initialize_project import InitializeProject
 from .operation import Operation
@@ -20,6 +21,7 @@ __all__ = (
     "ExecuteMigrations",
     "GenerateMigration",
     "GeneratePipelineScaffold",
+    "GenerateSquashedMigration",
     "InitializeLogger",
     "InitializeProject",
     "Operation",

--- a/nodestream/cli/operations/generate_squashed_migration.py
+++ b/nodestream/cli/operations/generate_squashed_migration.py
@@ -15,7 +15,11 @@ class GenerateSquashedMigration(Operation):
 
     async def perform(self, command: NodestreamCommand):
         from_migration = self.migrations.graph.get_migration(self.from_migration_name)
-        to_migration = self.migrations.graph.get_migration(self.to_migration_name)
+        to_migration = (
+            self.migrations.graph.get_migration(self.to_migration_name)
+            if self.to_migration_name
+            else None
+        )
         migration, path = self.migrations.create_squash_between(
             from_migration, to_migration
         )

--- a/nodestream/cli/operations/generate_squashed_migration.py
+++ b/nodestream/cli/operations/generate_squashed_migration.py
@@ -1,0 +1,29 @@
+from ...schema.migrations import ProjectMigrations
+from .operation import NodestreamCommand, Operation
+
+
+class GenerateSquashedMigration(Operation):
+    def __init__(
+        self,
+        migrations: ProjectMigrations,
+        from_migration_name: str,
+        to_migration_name: str,
+    ) -> None:
+        self.migrations = migrations
+        self.from_migration_name = from_migration_name
+        self.to_migration_name = to_migration_name
+
+    async def perform(self, command: NodestreamCommand):
+        from_migration = self.migrations.graph.get_migration(self.from_migration_name)
+        to_migration = self.migrations.graph.get_migration(self.to_migration_name)
+        migration, path = self.migrations.create_squash_between(
+            from_migration, to_migration
+        )
+        command.line(f"Generated squashed migration {migration.name}.")
+        command.line(
+            f"The migration contains {len(migration.operations)} schema changes."
+        )
+        for operation in migration.operations:
+            command.line(f"  - {operation.describe()}")
+        command.line(f"Migration written to {path}")
+        command.line("Run `nodestream migrations run` to apply the migration.")

--- a/nodestream/schema/migrations/migrations.py
+++ b/nodestream/schema/migrations/migrations.py
@@ -86,17 +86,6 @@ class Migration(LoadsFromYamlFile, SavesToYamlFile):
         """
         return len(self.replaces) > 0
 
-    def replaces_migration(self, migration: "Migration") -> bool:
-        """Check if this migration replaces another migration.
-
-        Args:
-            migration: The migration to check if this migration replaces.
-
-        Returns:
-            True if this migration replaces the other migration, False otherwise.
-        """
-        return migration.name in self.replaces
-
     @classmethod
     def squash(
         cls,
@@ -127,7 +116,7 @@ class Migration(LoadsFromYamlFile, SavesToYamlFile):
             }
         )
         if optimize_operations:
-            effective_operations = Operation.optimize_operations(effective_operations)
+            effective_operations = Operation.optimize(effective_operations)
 
         return cls(
             name=new_name,

--- a/nodestream/schema/migrations/migrations.py
+++ b/nodestream/schema/migrations/migrations.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from ...file_io import LoadsFromYamlFile, SavesToYamlFile
 from .operations import Operation
@@ -217,7 +217,10 @@ class MigrationGraph:
         return visited_order
 
     def squash_between(
-        self, name: str, from_migration: Migration, to_migration: Migration
+        self,
+        name: str,
+        from_migration: Migration,
+        to_migration: Optional[Migration] = None,
     ):
         """Squash all migrations between two migrations.
 
@@ -231,7 +234,7 @@ class MigrationGraph:
         """
         ordered = self.topological_order()
         from_index = ordered.index(from_migration)
-        to_index = ordered.index(to_migration)
+        to_index = ordered.index(to_migration) if to_migration else len(ordered) - 1
         migrations_to_squash = ordered[from_index : to_index + 1]
         return Migration.squash(name, migrations_to_squash)
 

--- a/nodestream/schema/migrations/migrations.py
+++ b/nodestream/schema/migrations/migrations.py
@@ -177,7 +177,6 @@ class MigrationGraph:
             # add it to the plan only if none of the migrations that it replaces
             # have been completed.
             if migration.is_squashed_migration():
-                print("squashed", migration.name)
                 if any(r in completed_migration_names for r in migration.replaces):
                     continue
 

--- a/nodestream/schema/migrations/migrations.py
+++ b/nodestream/schema/migrations/migrations.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List
 
@@ -16,12 +16,14 @@ class Migration(LoadsFromYamlFile, SavesToYamlFile):
     name: str
     operations: List[Operation]
     dependencies: List[str]
+    replaces: List[str] = field(default_factory=list)
 
     def to_file_data(self):
         return {
             "name": self.name,
             "operations": [operation.to_file_data() for operation in self.operations],
             "dependencies": self.dependencies,
+            "replaces": self.replaces,
         }
 
     @classmethod
@@ -33,17 +35,19 @@ class Migration(LoadsFromYamlFile, SavesToYamlFile):
                 for operation_file_data in file_data["operations"]
             ],
             dependencies=file_data["dependencies"],
+            replaces=file_data.get("replaces", []),
         )
 
     @classmethod
     def describe_yaml_schema(cls):
-        from schema import Schema
+        from schema import Optional, Schema
 
         return Schema(
             {
                 "name": str,
                 "operations": [Operation.describe_yaml_schema()],
                 "dependencies": [str],
+                Optional("replaces"): [str],
             }
         )
 
@@ -74,6 +78,64 @@ class Migration(LoadsFromYamlFile, SavesToYamlFile):
         self.write_to_file(path)
         return path
 
+    def is_squashed_migration(self) -> bool:
+        """Check if this migration is a squashed migration.
+
+        Returns:
+            True if this migration is a squashed migration, False otherwise.
+        """
+        return len(self.replaces) > 0
+
+    def replaces_migration(self, migration: "Migration") -> bool:
+        """Check if this migration replaces another migration.
+
+        Args:
+            migration: The migration to check if this migration replaces.
+
+        Returns:
+            True if this migration replaces the other migration, False otherwise.
+        """
+        return migration.name in self.replaces
+
+    @classmethod
+    def squash(
+        cls,
+        new_name: str,
+        migrations: Iterable["Migration"],
+        optimize_operations: bool = True,
+    ) -> "Migration":
+        """Make a new migration as the squashed for the given migrations.
+
+        Args:
+            new_name: The name of the new migration.
+            migrations: The migrations to squash.
+            optimize_operations: Whether to optimize the operations
+            before squashing.
+
+        Returns:
+            The new migration that is the effective squash of the
+            given migrations.
+        """
+        names_of_migrations_being_squashed = {m.name for m in migrations}
+        effective_operations = [o for m in migrations for o in m.operations]
+        dependencies = list(
+            {
+                d
+                for m in migrations
+                for d in m.dependencies
+                if d not in names_of_migrations_being_squashed
+            }
+        )
+        if optimize_operations:
+            effective_operations = Operation.optimize_operations(effective_operations)
+
+        return cls(
+            name=new_name,
+            operations=effective_operations,
+            replaces=list(names_of_migrations_being_squashed),
+            dependencies=dependencies,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class MigrationGraph:
@@ -98,20 +160,60 @@ class MigrationGraph:
         """
         return self.migrations_by_name[name]
 
-    def get_ordered_migration_plan(self) -> List[Migration]:
+    def get_ordered_migration_plan(
+        self, completed_migrations: List[Migration]
+    ) -> List[Migration]:
+        completed_migration_names = {m.name for m in completed_migrations}
+        replacement_index = {r: m for m in self.all_migrations() for r in m.replaces}
         plan_order = []
 
-        for migration in self.all_migrations():
-            for required_migration in self.plan_to_execute_migration(migration):
-                if required_migration not in plan_order:
-                    plan_order.append(required_migration)
+        for migration in self.topological_order():
+            if migration.name in completed_migration_names:
+                continue
+
+            # If we are considering a migration that has been replaced,
+            # we _only_ want to add it if at least one of the migrations
+            # replaced by the replacing migration has not been completed.
+            # IN otherwords, if the changes from a squashed migration have
+            # have (at least partially) been applied, we don't want to add
+            # the squashed migration to the plan but will want to add the
+            # migrations that were replaced to the plan.
+            if (replacement := replacement_index.get(migration.name)) is not None:
+                print("was replaced", migration.name)
+                if not any(
+                    r in completed_migration_names for r in replacement.replaces
+                ):
+                    print("skipping", migration.name)
+                    continue
+
+            # Similarly, if we are looking at a squashed migration, we want to
+            # add it to the plan only if none of the migrations that it replaces
+            # have been completed.
+            if migration.is_squashed_migration():
+                print("squashed", migration.name)
+                if any(r in completed_migration_names for r in migration.replaces):
+                    print("skipping", migration.name)
+                    continue
+
+            # Now here we are in one of three stats:
+            #
+            # 1. The migraiton is some "regular" migration that has not been
+            #       completed.
+            # 2. The migration is a squashed migration that we want to add to
+            #       the plan.
+            # 3. The migration is a migration that has been replaced by a
+            #       squashed migration but we've determined that at least one
+            #       of the migrations that it replaces has not been completed.
+            #
+            # In all of these cases, we want to add the migration to the plan.
+            plan_order.append(migration)
 
         return plan_order
 
-    def _iterative_dfs_traversal(self, start_node: Migration) -> List[Migration]:
+    def _iterative_dfs_traversal(self, *start_node: Migration) -> List[Migration]:
         visited_order = []
         visited_set = set()
-        stack = [(start_node, False)]
+        stack = [(n, False) for n in start_node]
 
         while stack:
             node, processed = stack.pop()
@@ -129,8 +231,8 @@ class MigrationGraph:
 
         return visited_order
 
-    def plan_to_execute_migration(self, migration: Migration) -> List[Migration]:
-        return self._iterative_dfs_traversal(migration)
+    def topological_order(self):
+        return self._iterative_dfs_traversal(*self.get_leaf_migrations())
 
     def all_migrations(self) -> Iterable[Migration]:
         """Iterate over all migrations in the graph."""

--- a/nodestream/schema/migrations/project_migrations.py
+++ b/nodestream/schema/migrations/project_migrations.py
@@ -49,7 +49,7 @@ class ProjectMigrations:
             Each migration and a boolean indicating if it is pending.
         """
         completed_migrations = await migrator.get_completed_migrations(self.graph)
-        for migration in self.graph.get_ordered_migration_plan():
+        for migration in self.graph.topological_order():
             yield migration, migration not in completed_migrations
 
     async def execute_pending(self, migrator: Migrator) -> AsyncIterable[Migration]:

--- a/nodestream/schema/migrations/project_migrations.py
+++ b/nodestream/schema/migrations/project_migrations.py
@@ -114,7 +114,7 @@ class ProjectMigrations:
         return migration, path
 
     def create_squash_between(
-        self, from_migration: Migration, to_migration: Migration
+        self, from_migration: Migration, to_migration: Optional[Migration] = None
     ) -> Tuple[Migration, Path]:
         """Create a squashed migration between two migrations.
 
@@ -125,7 +125,10 @@ class ProjectMigrations:
         Returns:
             The squashed migration and the path to the file.
         """
-        name = "squash_from_{}_to_{}".format(from_migration.name, to_migration.name)
+        if to_migration is None:
+            name = "squash_from_{}".format(from_migration.name)
+        else:
+            name = "squash_from_{}_to_{}".format(from_migration.name, to_migration.name)
         squashed = self.graph.squash_between(name, from_migration, to_migration)
         path = squashed.write_to_file_with_default_name(self.source_directory)
         return squashed, path

--- a/nodestream/schema/migrations/project_migrations.py
+++ b/nodestream/schema/migrations/project_migrations.py
@@ -112,3 +112,20 @@ class ProjectMigrations:
             return None
         path = migration.write_to_file_with_default_name(self.source_directory)
         return migration, path
+
+    def create_squash_between(
+        self, from_migration: Migration, to_migration: Migration
+    ) -> Tuple[Migration, Path]:
+        """Create a squashed migration between two migrations.
+
+        Args:
+            from_migration: The migration to squash from.
+            to_migration: The migration to squash to.
+
+        Returns:
+            The squashed migration and the path to the file.
+        """
+        name = "squash_from_{}_to_{}".format(from_migration.name, to_migration.name)
+        squashed = self.graph.squash_between(name, from_migration, to_migration)
+        path = squashed.write_to_file_with_default_name(self.source_directory)
+        return squashed, path

--- a/nodestream/schema/migrations/state_providers.py
+++ b/nodestream/schema/migrations/state_providers.py
@@ -51,7 +51,7 @@ class MigrationGraphStateProvider(StateProvider):
 
     async def get_schema(self) -> Schema:
         migrator = InMemoryMigrator()
-        for migration in self.migrations.get_ordered_migration_plan():
+        for migration in self.migrations.get_ordered_migration_plan([]):
             await migrator.execute_migration(migration)
         return migrator.schema
 

--- a/tests/unit/cli/commands/test_squash_migrations.py
+++ b/tests/unit/cli/commands/test_squash_migrations.py
@@ -1,0 +1,17 @@
+import pytest
+from hamcrest import assert_that, equal_to
+
+from nodestream.cli.commands import SquashMigration
+
+
+@pytest.mark.asyncio
+async def test_show_handle_async(mocker):
+    squash = SquashMigration()
+    squash.run_operation = mocker.AsyncMock()
+    squash.get_migrations = mocker.Mock()
+    squash.option = mocker.Mock(
+        side_effect=["from_migration_name", "to_migration_name"]
+    )
+    await squash.handle_async()
+
+    assert_that(squash.run_operation.await_count, equal_to(1))

--- a/tests/unit/cli/operations/test_generate_squashed_migration.py
+++ b/tests/unit/cli/operations/test_generate_squashed_migration.py
@@ -1,0 +1,22 @@
+import pytest
+from hamcrest import assert_that, equal_to
+
+from nodestream.cli.commands import NodestreamCommand
+from nodestream.cli.operations import GenerateSquashedMigration
+from nodestream.schema.migrations import Migration
+from nodestream.schema.migrations.operations import CreateNodeType
+
+
+@pytest.mark.asyncio
+async def test_generate_squash_migration_perform(mocker, project_dir):
+    command = mocker.MagicMock(NodestreamCommand)
+    migrations = mocker.Mock()
+    op = CreateNodeType("Person", ["ssn"], [])
+    generated_migration_and_path = Migration("test", [op], []), project_dir
+    migrations.create_squash_between = mocker.Mock(
+        return_value=generated_migration_and_path
+    )
+    subject = GenerateSquashedMigration(migrations, "from", "to")
+    await subject.perform(command)
+
+    assert_that(command.line.call_count, equal_to(5))

--- a/tests/unit/schema/migrations/test_migrations.py
+++ b/tests/unit/schema/migrations/test_migrations.py
@@ -1,5 +1,5 @@
 import pytest
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import assert_that, contains_inanyorder, empty, equal_to, is_
 
 from nodestream.schema.migrations import Migration, MigrationGraph
 from nodestream.schema.migrations.operations import (
@@ -200,16 +200,10 @@ def test_migration_squash_optimizes_operations():
         ),
     ]
 
+    result = Migration.squash("bob", migrations)
     assert_that(
-        Migration.squash("bob", migrations),
-        equal_to(
-            Migration(
-                name="bob",
-                operations=[
-                    CreateNodeType("Team", {"name"}, {"mascot"}),
-                ],
-                dependencies=[],
-                replaces=["a", "d", "b", "c"],
-            )
-        ),
+        result.operations, is_(equal_to([CreateNodeType("Team", {"name"}, {"mascot"})]))
     )
+    assert_that(result.dependencies, empty())
+    assert_that(result.replaces, contains_inanyorder("a", "d", "b", "c"))
+    assert_that(result.name, equal_to("bob"))

--- a/tests/unit/schema/migrations/test_migrations.py
+++ b/tests/unit/schema/migrations/test_migrations.py
@@ -66,7 +66,7 @@ def test_migration_to_and_from_file_data():
     ],
 )
 def test_migration_graph_test_get_ordered_migration_plan(migration_graph):
-    plan = migration_graph.get_ordered_migration_plan()
+    plan = migration_graph.get_ordered_migration_plan([])
     assert_that(len(plan), is_(equal_to(len(migration_graph.migrations_by_name))))
     for i, migration in enumerate(plan):
         migrations_to_current = {m.name for m in plan[0:i]}
@@ -110,3 +110,78 @@ def test_migration_graph_from_directory(tmp_path):
 def test_migration_graph_get_by_name(migration_graph, root_migration):
     result = migration_graph.get_migration("root_migration")
     assert_that(result, equal_to(root_migration))
+
+
+def test_migration_graph_navigates_around_squashed_migrations_when_partially_applied():
+    a = Migration(name="a", operations=[], dependencies=[])
+    b = Migration(name="b", operations=[], dependencies=["a"])
+    c = Migration(name="c", operations=[], dependencies=["b"])
+    squash = Migration(
+        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
+    )
+    d = Migration(name="d", operations=[], dependencies=["squash"])
+
+    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
+
+    plan = graph.get_ordered_migration_plan([a, b])
+    assert_that(plan, is_(equal_to([d, c])))
+
+
+def test_migration_graph_navigates_around_squashed_migrations_when_fully_applied():
+    a = Migration(name="a", operations=[], dependencies=[])
+    b = Migration(name="b", operations=[], dependencies=["a"])
+    c = Migration(name="c", operations=[], dependencies=["b"])
+    squash = Migration(
+        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
+    )
+    d = Migration(name="d", operations=[], dependencies=["squash"])
+
+    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
+
+    plan = graph.get_ordered_migration_plan([a, b, c])
+    assert_that(plan, is_(equal_to([d])))
+
+
+def test_migration_graph_navigates_around_squashed_migrations_when_nothing_applied():
+    a = Migration(name="a", operations=[], dependencies=[])
+    b = Migration(name="b", operations=[], dependencies=["a"])
+    c = Migration(name="c", operations=[], dependencies=["b"])
+    squash = Migration(
+        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
+    )
+    d = Migration(name="d", operations=[], dependencies=["squash"])
+
+    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
+
+    plan = graph.get_ordered_migration_plan([])
+    assert_that(plan, is_(equal_to([a, squash, d])))
+
+
+def test_migration_graph_navigates_around_squashed_migrations_when_nothing_applied():
+    a = Migration(name="a", operations=[], dependencies=[])
+    b = Migration(name="b", operations=[], dependencies=["a"])
+    c = Migration(name="c", operations=[], dependencies=["b"])
+    squash = Migration(
+        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
+    )
+    d = Migration(name="d", operations=[], dependencies=["squash"])
+
+    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
+
+    plan = graph.get_ordered_migration_plan([])
+    assert_that(plan, is_(equal_to([a, squash, d])))
+
+
+def test_migraiton_graph_handles_dependencies_fulfilled_through_squash():
+    a = Migration(name="a", operations=[], dependencies=[])
+    b = Migration(name="b", operations=[], dependencies=["a"])
+    c = Migration(name="c", operations=[], dependencies=["b"])
+    squash = Migration(
+        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
+    )
+    d = Migration(name="d", operations=[], dependencies=["b"])
+
+    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
+
+    plan = graph.get_ordered_migration_plan([a, squash])
+    assert_that(plan, is_(equal_to([d])))

--- a/tests/unit/schema/migrations/test_migrations.py
+++ b/tests/unit/schema/migrations/test_migrations.py
@@ -157,21 +157,6 @@ def test_migration_graph_navigates_around_squashed_migrations_when_nothing_appli
     assert_that(plan, is_(equal_to([a, squash, d])))
 
 
-def test_migration_graph_navigates_around_squashed_migrations_when_nothing_applied():
-    a = Migration(name="a", operations=[], dependencies=[])
-    b = Migration(name="b", operations=[], dependencies=["a"])
-    c = Migration(name="c", operations=[], dependencies=["b"])
-    squash = Migration(
-        name="squash", operations=[], dependencies=["a"], replaces=["b", "c"]
-    )
-    d = Migration(name="d", operations=[], dependencies=["squash"])
-
-    graph = MigrationGraph.from_iterable([a, b, c, squash, d])
-
-    plan = graph.get_ordered_migration_plan([])
-    assert_that(plan, is_(equal_to([a, squash, d])))
-
-
 def test_migraiton_graph_handles_dependencies_fulfilled_through_squash():
     a = Migration(name="a", operations=[], dependencies=[])
     b = Migration(name="b", operations=[], dependencies=["a"])

--- a/tests/unit/schema/migrations/test_operations.py
+++ b/tests/unit/schema/migrations/test_operations.py
@@ -604,11 +604,11 @@ def test_operation_chain_optimization_complex():
     i = DropRelationshipType("Likes")
     j = CreateNodeType("Team", {"name"}, {})
     k = DropNodeProperty("Team", "mascot")
-    l = DropRelationshipProperty("Likes", "since")
+    dl = DropRelationshipProperty("Likes", "since")
     m = DropNodeType("Team")
 
     # Intertwined and shuffled operations
-    operations = [a, f, b, g, c, j, h, d, k, i, e, l, m]
+    operations = [a, f, b, g, c, j, h, d, k, i, e, dl, m]
 
     assert_that(
         Operation.optimize(operations),

--- a/tests/unit/schema/migrations/test_operations.py
+++ b/tests/unit/schema/migrations/test_operations.py
@@ -303,3 +303,314 @@ def test_rename_node_type_new_name():
 def test_drop_node_type_index_name():
     name = DropNodeType("Person").proposed_index_name
     assert_that(name, equal_to("Person_node_key"))
+
+
+def test_create_node_type_reduce():
+    a = CreateNodeType("Person", {"name"}, {"age"})
+    b = DropNodeType("Person")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_create_node_type_reduce_no_match():
+    a = CreateNodeType("Person", {"name"}, {"age"})
+    b = DropNodeType("Human")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_create_node_type_reduce_irrelevant_type():
+    a = CreateNodeType("Person", {"name"}, {"age"})
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_create_relationship_type_reduce():
+    a = CreateRelationshipType("KNOWS", {"since"}, {"since"})
+    b = DropRelationshipType("KNOWS")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_create_relationship_type_reduce_no_match():
+    a = CreateRelationshipType("KNOWS", {"since"}, {"since"})
+    b = DropRelationshipType("LIKES")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_create_relationship_type_reduce_irrelevant_type():
+    a = CreateRelationshipType("KNOWS", {"since"}, {"since"})
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_node_type_reduce():
+    a = DropNodeType("Person")
+    b = CreateNodeType("Person", {"name"}, {"age"})
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_drop_node_type_reduce_no_match():
+    a = DropNodeType("Person")
+    b = CreateNodeType("Human", {"name"}, {"age"})
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_node_type_reduce_irrelevant_type():
+    a = DropNodeType("Person")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a]))
+
+
+def test_drop_relationship_type_reduce():
+    a = DropRelationshipType("KNOWS")
+    b = CreateRelationshipType("KNOWS", {"since"}, {"since"})
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_drop_relationship_type_reduce_no_match():
+    a = DropRelationshipType("KNOWS")
+    b = CreateRelationshipType("LIKES", {"since"}, {"since"})
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_relationship_type_reduce_dropping_added_property():
+    a = DropRelationshipType("KNOWS")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([a]))
+
+
+def test_rename_node_property_reduce_add():
+    a = RenameNodeProperty("Person", "full_name", "fuller_name")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([AddNodeProperty("Person", "fuller_name")]))
+
+
+def test_rename_node_property_reduce_drop():
+    a = RenameNodeProperty("Person", "full_name", "fuller_name")
+    b = DropNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([DropNodeProperty("Person", "full_name")]))
+
+
+def test_rename_node_property_reduce_no_match():
+    a = RenameNodeProperty("Person", "full_name", "fuller_name")
+    b = AddNodeProperty("Person", "name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_node_property_reduce_irrelevant_type():
+    a = RenameNodeProperty("Person", "full_name", "fuller_name")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_relationship_property_reduce_add():
+    a = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(
+        a.reduce(b), equal_to([AddRelationshipProperty("KNOWS", "known_since_date")])
+    )
+
+
+def test_rename_relationship_property_reduce_drop():
+    a = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    b = DropRelationshipProperty("KNOWS", "known_since")
+    assert_that(
+        a.reduce(b), equal_to([DropRelationshipProperty("KNOWS", "known_since")])
+    )
+
+
+def test_rename_relationship_property_reduce_no_match():
+    a = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    b = AddRelationshipProperty("KNOWS", "since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_relationship_property_reduce_irrelevant_type():
+    a = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_node_type_reduce():
+    a = RenameNodeType("Person", "Human")
+    b = CreateNodeType("Person", {"name"}, {"age"})
+    assert_that(a.reduce(b), equal_to([CreateNodeType("Human", {"name"}, {"age"})]))
+
+
+def test_rename_node_type_reduce_drop():
+    a = RenameNodeType("Person", "Human")
+    b = DropNodeType("Human")
+    assert_that(a.reduce(b), equal_to([DropNodeType("Person")]))
+
+
+def test_rename_node_type_reduce_no_match():
+    a = RenameNodeType("Person", "Human")
+    b = CreateNodeType("Human", {"name"}, {"age"})
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_node_type_reduce_irrelevant_type():
+    a = RenameNodeType("Person", "Human")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_relationship_type_reduce():
+    a = RenameRelationshipType("KNOWS", "LIKES")
+    b = CreateRelationshipType("KNOWS", {"since"}, {"since"})
+    assert_that(
+        a.reduce(b), equal_to([CreateRelationshipType("LIKES", {"since"}, {"since"})])
+    )
+
+
+def test_rename_relationship_type_reduce_drop():
+    a = RenameRelationshipType("KNOWS", "LIKES")
+    b = DropRelationshipType("LIKES")
+    assert_that(a.reduce(b), equal_to([DropRelationshipType("KNOWS")]))
+
+
+def test_rename_relationship_type_reduce_no_match():
+    a = RenameRelationshipType("KNOWS", "LIKES")
+    b = CreateRelationshipType("LIKES", {"since"}, {"since"})
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_rename_relationship_type_reduce_irrelevant_type():
+    a = RenameRelationshipType("KNOWS", "LIKES")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_add_node_property_reduce_drop():
+    a = AddNodeProperty("Person", "full_name")
+    b = DropNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_add_node_property_reduce_rename():
+    a = AddNodeProperty("Person", "full_name")
+    b = RenameNodeProperty("Person", "full_name", "fuller_name")
+    assert_that(a.reduce(b), equal_to([AddNodeProperty("Person", "fuller_name")]))
+
+
+def test_add_node_property_reduce_no_match():
+    a = AddNodeProperty("Person", "full_name")
+    b = DropNodeProperty("Person", "name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_add_node_property_reduce_irrelevant_type():
+    a = AddNodeProperty("Person", "full_name")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_add_relationship_property_reduce_drop():
+    a = AddRelationshipProperty("KNOWS", "known_since")
+    b = DropRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_add_relationship_property_reduce_rename():
+    a = AddRelationshipProperty("KNOWS", "known_since")
+    b = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    assert_that(
+        a.reduce(b), equal_to([AddRelationshipProperty("KNOWS", "known_since_date")])
+    )
+
+
+def test_add_relationship_property_reduce_no_match():
+    a = AddRelationshipProperty("KNOWS", "known_since")
+    b = DropRelationshipProperty("KNOWS", "since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_add_relationship_property_reduce_irrelevant_type():
+    a = AddRelationshipProperty("KNOWS", "known_since")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_node_property_reduce():
+    a = DropNodeProperty("Person", "full_name")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_drop_node_property_reduce_rename():
+    a = DropNodeProperty("Person", "full_name")
+    b = RenameNodeProperty("Person", "full_name", "fuller_name")
+    assert_that(a.reduce(b), equal_to([DropNodeProperty("Person", "full_name")]))
+
+
+def test_drop_node_property_reduce_no_match():
+    a = DropNodeProperty("Person", "full_name")
+    b = AddNodeProperty("Person", "name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_node_property_reduce_irrelevant_type():
+    a = DropNodeProperty("Person", "full_name")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_relationship_property_reduce():
+    a = DropRelationshipProperty("KNOWS", "known_since")
+    b = AddRelationshipProperty("KNOWS", "known_since")
+    assert_that(a.reduce(b), equal_to([]))
+
+
+def test_drop_relationship_property_reduce_rename():
+    a = DropRelationshipProperty("KNOWS", "known_since")
+    b = RenameRelationshipProperty("KNOWS", "known_since", "known_since_date")
+    assert_that(
+        a.reduce(b), equal_to([DropRelationshipProperty("KNOWS", "known_since")])
+    )
+
+
+def test_drop_relationship_property_reduce_no_match():
+    a = DropRelationshipProperty("KNOWS", "known_since")
+    b = AddRelationshipProperty("KNOWS", "since")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_drop_relationship_property_reduce_irrelevant_type():
+    a = DropRelationshipProperty("KNOWS", "known_since")
+    b = AddNodeProperty("Person", "full_name")
+    assert_that(a.reduce(b), equal_to([a, b]))
+
+
+def test_operation_chain_optimization():
+    a = CreateNodeType("Person", {"name"}, {"age"})
+    b = CreateNodeType("Sport", {"name"}, {})
+    c = AddNodeProperty("Person", "full_name")
+    d = DropNodeProperty("Person", "age")
+    e = DropNodeType("Person")
+
+    assert_that(
+        Operation.optimize([a, b, c, d, e]),
+        equal_to([CreateNodeType("Sport", {"name"}, {})]),
+    )
+
+
+def test_operation_chain_optimization_complex():
+    a = CreateNodeType("Person", {"name"}, {"age"})
+    b = CreateNodeType("Sport", {"name"}, {})
+    c = AddNodeProperty("Person", "full_name")
+    d = DropNodeProperty("Person", "age")
+    e = DropNodeType("Person")
+    f = CreateRelationshipType("Likes", {}, {})
+    g = AddRelationshipProperty("Likes", "since")
+    h = AddNodeProperty("Team", "mascot")
+    i = DropRelationshipType("Likes")
+    j = CreateNodeType("Team", {"name"}, {})
+    k = DropNodeProperty("Team", "mascot")
+    l = DropRelationshipProperty("Likes", "since")
+    m = DropNodeType("Team")
+
+    # Intertwined and shuffled operations
+    operations = [a, f, b, g, c, j, h, d, k, i, e, l, m]
+
+    assert_that(
+        Operation.optimize(operations),
+        equal_to([CreateNodeType("Sport", {"name"}, {})]),
+    )

--- a/tests/unit/schema/migrations/test_operations.py
+++ b/tests/unit/schema/migrations/test_operations.py
@@ -593,22 +593,21 @@ def test_operation_chain_optimization():
 
 
 def test_operation_chain_optimization_complex():
-    a = CreateNodeType("Person", {"name"}, {"age"})
-    b = CreateNodeType("Sport", {"name"}, {})
-    c = AddNodeProperty("Person", "full_name")
-    d = DropNodeProperty("Person", "age")
-    e = DropNodeType("Person")
-    f = CreateRelationshipType("Likes", {}, {})
-    g = AddRelationshipProperty("Likes", "since")
-    h = AddNodeProperty("Team", "mascot")
-    i = DropRelationshipType("Likes")
-    j = CreateNodeType("Team", {"name"}, {})
-    k = DropNodeProperty("Team", "mascot")
-    dl = DropRelationshipProperty("Likes", "since")
-    m = DropNodeType("Team")
-
-    # Intertwined and shuffled operations
-    operations = [a, f, b, g, c, j, h, d, k, i, e, dl, m]
+    operations = [
+        CreateNodeType("Person", {"name"}, {"age"}),
+        CreateRelationshipType("Likes", {}, {}),
+        CreateNodeType("Sport", {"name"}, {}),
+        AddRelationshipProperty("Likes", "since"),
+        AddNodeProperty("Person", "full_name"),
+        CreateNodeType("Team", {"name"}, {}),
+        DropNodeProperty("Person", "age"),
+        DropRelationshipType("Likes"),
+        DropNodeProperty("Team", "mascot"),
+        DropNodeType("Person"),
+        DropRelationshipProperty("Likes", "since"),
+        AddNodeProperty("Team", "mascot"),
+        DropNodeType("Team"),
+    ]
 
     assert_that(
         Operation.optimize(operations),

--- a/tests/unit/schema/migrations/test_project_migrations.py
+++ b/tests/unit/schema/migrations/test_project_migrations.py
@@ -49,3 +49,9 @@ async def test_detect_changes(subject, basic_schema):
     # mocking out a bunch of stuff.
     result = await subject.detect_changes(MigratorInput(), basic_schema)
     assert_that(result.operations, has_length(4))
+
+
+def test_squash_between(subject, root_migration, leaf_migration):
+    migration, path = subject.create_squash_between(root_migration, leaf_migration)
+    assert_that(migration.replaces, has_length(2))
+    assert_that(path.parent, equal_to(subject.source_directory))

--- a/tests/unit/schema/migrations/test_project_migrations.py
+++ b/tests/unit/schema/migrations/test_project_migrations.py
@@ -55,3 +55,9 @@ def test_squash_between(subject, root_migration, leaf_migration):
     migration, path = subject.create_squash_between(root_migration, leaf_migration)
     assert_that(migration.replaces, has_length(2))
     assert_that(path.parent, equal_to(subject.source_directory))
+
+
+def test_squash_between_no_to_migration(subject, root_migration):
+    migration, path = subject.create_squash_between(root_migration)
+    assert_that(migration.replaces, has_length(2))
+    assert_that(path.parent, equal_to(subject.source_directory))


### PR DESCRIPTION
This feature adds a new `nodestream migrations squash --from x --to y` command. `x` and `y` would be the names of migrations that you want to squash between. If y is left off, then the last migration is specified. 


Closes #299 