### PR TITLE
Reject none values by default in Normalizers

### DIFF
--- a/nodestream/pipeline/normalizers/normalizer.py
+++ b/nodestream/pipeline/normalizers/normalizer.py
@@ -27,6 +27,7 @@ class Normalizer(Pluggable, ABC):
     """
 
     entrypoint_name = "normalizers"
+    rejects_none_values = True
 
     @classmethod
     def setup(cls):
@@ -37,7 +38,7 @@ class Normalizer(Pluggable, ABC):
         if normalizer_args:
             for flag_name, enabled in normalizer_args.items():
                 if enabled:
-                    value = cls.by_flag_name(flag_name).normalize_value(value)
+                    value = cls.by_flag_name(flag_name).normalize(value)
 
         return value
 
@@ -58,6 +59,11 @@ class Normalizer(Pluggable, ABC):
             return cls.from_alias(flag_name[3:])
         except MissingFromRegistryError:
             raise InvalidFlagError(flag_name) from None
+
+    def normalize(self, value: Any) -> Any:
+        if value is None and self.rejects_none_values:
+            return None
+        return self.normalize_value(value)
 
     @abstractmethod
     def normalize_value(self, value: Any) -> Any:

--- a/nodestream/pipeline/value_providers/normalizer_value_provider.py
+++ b/nodestream/pipeline/value_providers/normalizer_value_provider.py
@@ -18,9 +18,7 @@ class NormalizerValueProvider(ValueProvider):
 
     def many_values(self, context: ProviderContext) -> Iterable[Any]:
         try:
-            yield from map(
-                self.normalizer.normalize_value, self.data.many_values(context)
-            )
+            yield from map(self.normalizer.normalize, self.data.many_values(context))
         except Exception as e:
             raise ValueProviderException(str(context.document), self) from e
 

--- a/tests/unit/pipeline/normalizers/test_lowercase_strings.py
+++ b/tests/unit/pipeline/normalizers/test_lowercase_strings.py
@@ -17,4 +17,4 @@ from nodestream.pipeline.normalizers import LowercaseStrings
 )
 def test_lowercase_strings_normalization(input_value, expected_value):
     subject = LowercaseStrings()
-    assert_that(subject.normalize_value(input_value), equal_to(expected_value))
+    assert_that(subject.normalize(input_value), equal_to(expected_value))

--- a/tests/unit/pipeline/normalizers/test_remove_trailing_dots.py
+++ b/tests/unit/pipeline/normalizers/test_remove_trailing_dots.py
@@ -17,4 +17,4 @@ from nodestream.pipeline.normalizers import RemoveTrailingDots
 )
 def test_lowercase_strings_normalization(input_value, expected_value):
     subject = RemoveTrailingDots()
-    assert_that(subject.normalize_value(input_value), equal_to(expected_value))
+    assert_that(subject.normalize(input_value), equal_to(expected_value))

--- a/tests/unit/pipeline/normalizers/test_trim_whitespace.py
+++ b/tests/unit/pipeline/normalizers/test_trim_whitespace.py
@@ -17,4 +17,4 @@ from nodestream.pipeline.normalizers import TrimWhitespace
 )
 def test_lowercase_strings_normalization(input_value, expected_value):
     subject = TrimWhitespace()
-    assert_that(subject.normalize_value(input_value), equal_to(expected_value))
+    assert_that(subject.normalize(input_value), equal_to(expected_value))


### PR DESCRIPTION
Often times `Normalizer` classes need to have a straight `None` check to prevent any issues during normalization. Almost all normalizers would do this. This change makes it so that the default behavior is to reject none values unless the class opts into normalizing the value. 