### PR TITLE
Add Cast Value Provider

### DIFF
--- a/nodestream/pipeline/value_providers/__init__.py
+++ b/nodestream/pipeline/value_providers/__init__.py
@@ -1,3 +1,4 @@
+from .cast_value_provider import CastValueProvider
 from .context import ProviderContext
 from .jmespath_value_provider import JmespathValueProvider
 from .mapping_value_provider import MappingValueProvider
@@ -26,4 +27,5 @@ __all__ = (
     "VALUE_PROVIDER_REGISTRY",
     "StaticValueOrValueProvider",
     "RegexValueProvider",
+    "CastValueProvider",
 )

--- a/nodestream/pipeline/value_providers/cast_value_provider.py
+++ b/nodestream/pipeline/value_providers/cast_value_provider.py
@@ -1,0 +1,55 @@
+from decimal import Decimal
+from typing import Any, Iterable, Type
+
+from yaml import SafeDumper, SafeLoader
+
+from .context import ProviderContext
+from .value_provider import ValueProvider, ValueProviderException
+
+
+class CastValueProvider(ValueProvider):
+    CONVERTERS = {
+        "int": int,
+        "float": float,
+        "decimal": Decimal,
+        "string": str,
+        "bool": bool,
+        "bytes": bytes,
+    }
+
+    def __init__(self, data: ValueProvider, to: str):
+        self.data = data
+        self.to = to
+
+    def cast_value(self, value):
+        return self.CONVERTERS[self.to](value)
+
+    def single_value(self, context: ProviderContext) -> Any:
+        try:
+            return self.cast_value(self.data.single_value(context))
+        except Exception as e:
+            raise ValueProviderException(str(context.document), self) from e
+
+    def many_values(self, context: ProviderContext) -> Iterable[Any]:
+        try:
+            return map(self.cast_value, self.data.many_values(context))
+        except Exception as e:
+            raise ValueProviderException(str(context.document), self) from e
+
+    @classmethod
+    def install_yaml_tag(cls, loader: Type[SafeLoader]):
+        loader.add_constructor(
+            "!cast", lambda loader, node: cls(**loader.construct_mapping(node))
+        )
+
+    def __str__(self):
+        return f"CastValueProvider: { {'data': str(self.data), 'to': str(self.to)} }"
+
+
+SafeDumper.add_representer(
+    CastValueProvider,
+    lambda dumper, cast: dumper.represent_mapping(
+        "!cast",
+        {"data": cast.data, "to": cast.to},
+    ),
+)

--- a/nodestream/pipeline/value_providers/cast_value_provider.py
+++ b/nodestream/pipeline/value_providers/cast_value_provider.py
@@ -12,7 +12,7 @@ class CastValueProvider(ValueProvider):
         "int": int,
         "float": float,
         "decimal": Decimal,
-        "string": str,
+        "str": str,
         "bool": bool,
         "bytes": bytes,
     }

--- a/tests/unit/pipeline/value_providers/test_cast_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_cast_value_provider.py
@@ -1,0 +1,62 @@
+from decimal import Decimal
+
+import pytest
+from hamcrest import assert_that, equal_to
+from yaml import safe_dump
+
+from nodestream.pipeline.value_providers import StaticValueProvider
+from nodestream.pipeline.value_providers.cast_value_provider import CastValueProvider
+from nodestream.pipeline.value_providers.value_provider import ValueProviderException
+
+from ...stubs import StubbedValueProvider
+
+
+def test_cast_value_provider_single_value_int(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider("123"), to="int")
+    assert_that(provider.single_value(blank_context), equal_to(123))
+
+
+def test_cast_value_provider_single_value_float(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider("1.09"), to="float")
+    assert_that(provider.single_value(blank_context), equal_to(1.09))
+
+
+def test_cast_value_provider_single_value_bool_true(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider(1), to="bool")
+    assert_that(provider.single_value(blank_context), equal_to(True))
+
+
+def test_cast_value_provider_single_value_bool_false(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider(""), to="bool")
+    assert_that(provider.single_value(blank_context), equal_to(False))
+
+
+def test_cast_value_provider_single_value_string(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider(False), to="str")
+    assert_that(provider.single_value(blank_context), equal_to("False"))
+
+
+def test_cast_value_provider_single_value_decimal(blank_context):
+    provider = CastValueProvider(data=StaticValueProvider(12.34), to="decimal")
+    assert_that(provider.single_value(blank_context), equal_to(Decimal(12.34)))
+
+
+def test_cast_value_provider_many_values(blank_context):
+    provider = CastValueProvider(StubbedValueProvider(["1", "2", "3"]), "int")
+    assert_that(list(provider.many_values(blank_context)), equal_to([1, 2, 3]))
+
+
+def test_cast_value_provider_invalid_cast(blank_context):
+    provider = CastValueProvider(StaticValueProvider("abc"), "int")
+
+    with pytest.raises(ValueProviderException):
+        provider.single_value(blank_context)
+
+
+def test_cast_value_provider_yaml_dump():
+    provider = CastValueProvider(StaticValueProvider("123"), "int")
+
+    assert_that(
+        safe_dump(provider),
+        equal_to("!cast\ndata: !static '123'\nto: int\n"),
+    )


### PR DESCRIPTION
Provides a mechanism for basic data manipulation by casting the provided value to a basic data type.

```
!cast 
    value: !jmespath some.value.here
    to: int
```