### PR TITLE
Fix Metric Report for Table Output

### DIFF
--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -198,7 +198,7 @@ class ConsoleMetricHandler(MetricHandler):
         self.metrics[metric] -= value
 
     def stop(self):
-        stats = ((k, str(v)) for k, v in self.metrics.items())
+        stats = ((k.name, str(v)) for k, v in self.metrics.items() if v > 0)
         table = self.command.table(STATS_TABLE_COLS, stats)
         table.render()
 


### PR DESCRIPTION
Provides a small fix to the way we're rendering statistics in table form to be better readable. 