### PR TITLE
Implement Object Storage APIs

### DIFF
--- a/nodestream/pipeline/object_storage.py
+++ b/nodestream/pipeline/object_storage.py
@@ -1,0 +1,298 @@
+import base64
+import hmac
+import hashlib
+import pickle
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, TypeVar
+from pathlib import Path
+
+
+from ..subclass_registry import SubclassRegistry
+from ..pluggable import Pluggable
+
+
+OBJECT_STORE_REGISTRY = SubclassRegistry(ignore_overrides=True)
+T = TypeVar("T")
+
+
+class InvalidSignatureError(ValueError):
+    """An error that is raised when a signature is invalid."""
+
+    def __init__(self, expected: bytes, actual: bytes):
+        expected = base64.b64encode(expected).decode("utf-8")
+        actual = base64.b64encode(actual).decode("utf-8")
+        super().__init__(
+            f"Invalid signature. Expected: {expected}, Actual: {actual}",
+        )
+
+
+class MalformedSignedObjectError(ValueError):
+    """An error that is raised when a signed object is malformed."""
+
+    def __init__(self):
+        super().__init__("Malformed signed object.")
+
+
+@dataclass(frozen=True, slots=True)
+class SignedObject:
+    """A signed object is an object that has been signed by a signer."""
+
+    signature: bytes
+    data: bytes
+
+    def into_bytes(self) -> bytes:
+        """Convert the signed object to a bytestring."""
+        return self.signature + b"\n" + self.data
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "SignedObject":
+        """Create a signed object from a bytestring."""
+        try:
+            signature, data = data.split(b"\n", 1)
+            return SignedObject(signature, data)
+        except ValueError:
+            raise MalformedSignedObjectError
+
+
+class Signer(ABC):
+    """A signer is used to sign and verify objects in an object store."""
+
+    @abstractmethod
+    def sign(self, data: bytes) -> SignedObject:
+        """Sign an object.
+
+        This method should sign the given object and return a signed object
+        that contains the signature and the data. The signature should be
+        a bytestring.
+        """
+        pass
+
+    @abstractmethod
+    def verify(self, signed: SignedObject):
+        """Verify a signed object.
+
+        This method should verify the given signed object. If the signature is
+        invalid, this should raise an InvalidSignatureError. If the signature
+        is valid, this should do nothing.
+        """
+        pass
+
+
+class HmacSigner(Signer):
+    """A signer that uses HMAC to sign objects.
+
+    This signer uses HMAC with SHA-256 to sign objects. The key used for
+    signing is provided when the signer is created. The key should be a
+    bytestring. The signer will use the key to sign objects using HMAC with
+    SHA-256.
+    """
+
+    def __init__(self, key: bytes):
+        self.key = key
+
+    @staticmethod
+    def from_base64(key: str):
+        """Create the signer from a base64-encoded key."""
+        return HmacSigner(base64.b64decode(key))
+
+    def _get_digest(self, data: bytes) -> bytes:
+        return hmac.new(self.key, data, hashlib.sha256).digest()
+
+    def sign(self, data: bytes) -> SignedObject:
+        return SignedObject(self._get_digest(data), data)
+
+    def verify(self, signed: SignedObject):
+        expected = self._get_digest(signed.data)
+        if not hmac.compare_digest(signed.signature, expected):
+            raise InvalidSignatureError(expected, signed.signature)
+
+
+class Namespace(ABC):
+    """A namespace is a way to scope keys in an object store."""
+
+    def scope(self, key: str) -> str:
+        """Scope a key.
+
+        This method should return a new key that is scoped by the namespace.
+        The new key should be unique for the given key and namespace.
+        """
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class StaticNamespace(Namespace):
+    """A namespace that is static and does not change."""
+
+    prefix: str
+
+    def scope(self, key: str) -> str:
+        return f"{self.prefix}/{key}"
+
+
+@OBJECT_STORE_REGISTRY.connect_baseclass
+class ObjectStore(ABC, Pluggable):
+    entrypoint_name = "object_stores"
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[bytes]:
+        """Get an object from the object store.
+
+        The object store should return a path to the object that can be read.
+        If an error is encountered, this should raise an exception.
+        If the object is not found, this should return None.
+        """
+        pass
+
+    @abstractmethod
+    def put(self, key: str, path: bytes):
+        """Put an object into the object store.
+
+        The object store should store the object at the given path under the
+        given key. If an error is encountered, this should raise an exception.
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, key: str):
+        """Delete an object from the object store.
+
+        If the object is not found, this should do nothing.
+        """
+        pass
+
+    def get_pickled(self, key: str) -> T:
+        """Get an object from the object store that has been pickled."""
+        if (data := self.get(key)) is None:
+            return None
+
+        return pickle.loads(data)
+
+    def put_picklable(self, key: str, value: T):
+        """Put an object from the object store that has can be pickled."""
+        self.put(key, pickle.dumps(value))
+
+    def namespaced(self, namespace: Namespace | str) -> "ObjectStore":
+        """Return a new object store with a namespace applied.
+
+        This method should return a new object store that is the same as the
+        current object store, but with the given namespace applied. The new
+        object store should be able to retrieve and store objects with keys
+        that are scoped by the namespace.
+
+        Note that `namespaced` can be called multiple times to apply multiple
+        namespaces to the same object store. The namespaces will be applied in
+        a stack-like manner, with the most recent namespace being the
+        outermost.
+
+        Args:
+            namespace: The namespace to apply to the object store.
+        """
+        if isinstance(namespace, str):
+            namespace = StaticNamespace(namespace)
+        return NamespacedObjectStore(self, namespace)
+
+    def signed(self, signer: "Signer") -> "ObjectStore":
+        """Return a new object store with a signer applied.
+
+        This method should return a new object store that is the same as the
+        current object store, but with the given signer applied. The new object
+        store should be able to retrieve and store signed objects.
+
+        Args:
+            signer: The signer to apply to the object store.
+        """
+        return SignedObjectStore(self, signer)
+
+
+class DirectoryObjectStore(ObjectStore, alias="directory"):
+    """An object store that stores objects in a directory on a file system."""
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    @staticmethod
+    def in_current_directory():
+        return DirectoryObjectStore(Path.cwd() / ".nodestream" / "objects")
+
+    def get(self, key: str) -> Optional[bytes]:
+        path = self.root / key
+        if not path.exists():
+            return None
+
+        with path.open("rb") as f:
+            return f.read()
+
+    def put(self, key: str, path: bytes):
+        target = self.root / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("wb") as f:
+            f.write(path)
+
+    def delete(self, key: str):
+        target = self.root / key
+        target.unlink(missing_ok=True)
+
+
+class NullObjectStore(ObjectStore, alias="null"):
+    """An object store that does not store any objects."""
+
+    def get(self, _: str) -> Optional[bytes]:
+        return None
+
+    def put(self, _path: str, _data: bytes):
+        pass
+
+    def delete(self, _path: str):
+        pass
+
+
+@dataclass(frozen=True, slots=True)
+class NamespacedObjectStore(ObjectStore):
+    """An object store that stores objects with a namespace applied.
+
+    This object store wraps another object store and scopes keys with a
+    provided namespace. This is used for ensuring that keys are sufficiently
+    unique when they are stored and read from the object store.
+    """
+
+    store: ObjectStore
+    namespace: Namespace
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.store.get(self.namespace.scope(key))
+
+    def put(self, key: str, path: bytes):
+        self.store.put(self.namespace.scope(key), path)
+
+    def delete(self, key: str):
+        self.store.delete(self.namespace.scope(key))
+
+
+@dataclass(frozen=True, slots=True)
+class SignedObjectStore(ObjectStore):
+    """An object store that stores signed objects.
+
+    This object store wraps another object store and signs and verifies objects
+    that are stored and retrieved from that object store. This is used for
+    ensuring that objects are not tampered with when they are stored and read
+    from the object store.
+    """
+
+    store: ObjectStore
+    signer: Signer
+
+    def get(self, key: str) -> Optional[bytes]:
+        if (data := self.store.get(key)) is None:
+            return None
+
+        signed = SignedObject.from_bytes(data)
+        self.signer.verify(signed)
+        return signed.data
+
+    def put(self, key: str, path: bytes):
+        signed = self.signer.sign(path)
+        self.store.put(key, signed.into_bytes())
+
+    def delete(self, key: str):
+        self.store.delete(key)

--- a/nodestream/pipeline/object_storage.py
+++ b/nodestream/pipeline/object_storage.py
@@ -1,16 +1,14 @@
 import base64
-import hmac
 import hashlib
+import hmac
 import pickle
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, TypeVar
 from pathlib import Path
+from typing import Optional, TypeVar
 
-
-from ..subclass_registry import SubclassRegistry
 from ..pluggable import Pluggable
-
+from ..subclass_registry import SubclassRegistry
 
 OBJECT_STORE_REGISTRY = SubclassRegistry(ignore_overrides=True)
 T = TypeVar("T")

--- a/tests/unit/pipeline/test_object_storage.py
+++ b/tests/unit/pipeline/test_object_storage.py
@@ -2,16 +2,16 @@ import base64
 from pathlib import Path
 
 import pytest
-from hamcrest import assert_that, none, is_, equal_to, not_none
+from hamcrest import assert_that, equal_to, is_, none, not_none
 
 from nodestream.pipeline.object_storage import (
-    InvalidSignatureError,
-    SignedObject,
-    HmacSigner,
-    StaticNamespace,
     DirectoryObjectStore,
-    NullObjectStore,
+    HmacSigner,
+    InvalidSignatureError,
     MalformedSignedObjectError,
+    NullObjectStore,
+    SignedObject,
+    StaticNamespace,
 )
 
 SOME_KEY = "some_key"
@@ -86,10 +86,12 @@ def test_directory_object_store_missing_object(directory_object_store):
     retrieved_data = directory_object_store.get(SOME_KEY)
     assert_that(retrieved_data, is_(none()))
 
+
 def test_directory_object_store_delete(directory_object_store):
     directory_object_store.put(SOME_KEY, SOME_DATA)
     directory_object_store.delete(SOME_KEY)
     assert_that(directory_object_store.get(SOME_KEY), is_(none()))
+
 
 def test_directory_object_store_default_directory():
     store = DirectoryObjectStore.in_current_directory()

--- a/tests/unit/pipeline/test_object_storage.py
+++ b/tests/unit/pipeline/test_object_storage.py
@@ -1,0 +1,158 @@
+import base64
+from pathlib import Path
+
+import pytest
+from hamcrest import assert_that, none, is_, equal_to, not_none
+
+from nodestream.pipeline.object_storage import (
+    InvalidSignatureError,
+    SignedObject,
+    HmacSigner,
+    StaticNamespace,
+    DirectoryObjectStore,
+    NullObjectStore,
+    MalformedSignedObjectError,
+)
+
+SOME_KEY = "some_key"
+SOME_DATA = b"some_data"
+
+
+@pytest.fixture
+def data():
+    return b"test_data"
+
+
+@pytest.fixture
+def directory_object_store(tmp_path):
+    return DirectoryObjectStore(tmp_path)
+
+
+@pytest.fixture
+def namespaced_object_store(directory_object_store):
+    return directory_object_store.namespaced("prefix")
+
+
+@pytest.fixture
+def hmac_signer():
+    return HmacSigner.from_base64("waPmETwMNZlVLq/VY3i0yg==")
+
+
+@pytest.fixture
+def signed_object_store(directory_object_store, hmac_signer):
+    return directory_object_store.signed(hmac_signer)
+
+
+def test_signed_object():
+    data = b"data"
+    signature = b"signature"
+    signed_object = SignedObject(signature, data)
+    assert signed_object.signature == signature
+    assert signed_object.data == data
+
+    bytes_data = signed_object.into_bytes()
+    assert bytes_data == signature + b"\n" + data
+
+    parsed_object = SignedObject.from_bytes(bytes_data)
+    assert_that(parsed_object, is_(not_none()))
+    assert_that(parsed_object.signature, equal_to(signature))
+    assert_that(parsed_object.data, equal_to(data))
+
+
+def test_hmac_signer_correct(hmac_signer):
+    signed_object = hmac_signer.sign(SOME_DATA)
+    assert_that(signed_object.data, equal_to(SOME_DATA))
+    hmac_signer.verify(signed_object)
+
+
+def test_hmac_signer_incorrect(hmac_signer):
+    with pytest.raises(InvalidSignatureError):
+        hmac_signer.verify(SignedObject(b"invalid_signature", SOME_DATA))
+
+
+def test_static_namespace():
+    namespace = StaticNamespace("prefix")
+    scoped_key = namespace.scope("key")
+    assert_that(scoped_key, equal_to("prefix/key"))
+
+
+def test_directory_object_store_found_object(directory_object_store):
+    directory_object_store.put(SOME_KEY, SOME_DATA)
+    retrieved_data = directory_object_store.get(SOME_KEY)
+    assert_that(retrieved_data, equal_to(SOME_DATA))
+
+
+def test_directory_object_store_missing_object(directory_object_store):
+    retrieved_data = directory_object_store.get(SOME_KEY)
+    assert_that(retrieved_data, is_(none()))
+
+def test_directory_object_store_delete(directory_object_store):
+    directory_object_store.put(SOME_KEY, SOME_DATA)
+    directory_object_store.delete(SOME_KEY)
+    assert_that(directory_object_store.get(SOME_KEY), is_(none()))
+
+def test_directory_object_store_default_directory():
+    store = DirectoryObjectStore.in_current_directory()
+    assert_that(store.root, equal_to(Path.cwd() / ".nodestream" / "objects"))
+
+
+def test_null_object_store():
+    store = NullObjectStore()
+    store.put(SOME_KEY, SOME_DATA)
+    retrieved_data = store.get(SOME_KEY)
+    assert_that(retrieved_data, is_(none()))
+
+
+def test_namespaced_object_store(namespaced_object_store):
+    namespaced_object_store.put(SOME_KEY, SOME_DATA)
+    retrieved_data = namespaced_object_store.get(SOME_KEY)
+    assert retrieved_data == SOME_DATA
+
+
+def test_namespaced_object_store_delete(namespaced_object_store):
+    namespaced_object_store.put(SOME_KEY, SOME_DATA)
+    namespaced_object_store.delete(SOME_KEY)
+    assert_that(namespaced_object_store.get(SOME_KEY), is_(none()))
+
+
+def test_signed_object_store(signed_object_store):
+    signed_object_store.put(SOME_KEY, SOME_DATA)
+    retrieved_data = signed_object_store.get(SOME_KEY)
+    assert_that(retrieved_data, equal_to(SOME_DATA))
+
+
+def test_signed_object_store_detects_tampering(tmp_path, signed_object_store):
+    signed_object_store.put(SOME_KEY, SOME_DATA)
+
+    # Tamper with the data
+    obj_path = Path(tmp_path) / SOME_KEY
+    with open(obj_path, "rb") as f:
+        signed_data = f.read()
+
+    signature, _ = signed_data.split(b"\n")
+    tampered_data = base64.b64encode(b"tampered_data")
+    tampered_signed_data = signature + b"\n" + tampered_data
+
+    with open(obj_path, "wb") as f:
+        f.write(tampered_signed_data)
+
+    with pytest.raises(InvalidSignatureError):
+        signed_object_store.get(SOME_KEY)
+
+
+def test_signed_object_store_detects_missing_signature(
+    directory_object_store, signed_object_store
+):
+    directory_object_store.put(SOME_KEY, SOME_DATA)
+    with pytest.raises(MalformedSignedObjectError):
+        signed_object_store.get(SOME_KEY)
+
+
+def test_signed_object_store_missing_object(signed_object_store):
+    assert_that(signed_object_store.get(SOME_KEY), is_(none()))
+
+
+def test_signed_object_store_delete(signed_object_store):
+    signed_object_store.put(SOME_KEY, SOME_DATA)
+    signed_object_store.delete(SOME_KEY)
+    assert_that(signed_object_store.get(SOME_KEY), is_(none()))

--- a/tests/unit/pipeline/test_object_storage.py
+++ b/tests/unit/pipeline/test_object_storage.py
@@ -93,6 +93,13 @@ def test_directory_object_store_delete(directory_object_store):
     assert_that(directory_object_store.get(SOME_KEY), is_(none()))
 
 
+def test_directory_object_store_get_pickled(directory_object_store):
+    data = {"data": SOME_DATA}
+    directory_object_store.put_picklable(SOME_KEY, data)
+    retrieved_data = directory_object_store.get_pickled(SOME_KEY)
+    assert_that(retrieved_data, equal_to(data))
+
+
 def test_directory_object_store_default_directory():
     store = DirectoryObjectStore.in_current_directory()
     assert_that(store.root, equal_to(Path.cwd() / ".nodestream" / "objects"))

--- a/tests/unit/pipeline/test_object_storage.py
+++ b/tests/unit/pipeline/test_object_storage.py
@@ -100,6 +100,11 @@ def test_directory_object_store_get_pickled(directory_object_store):
     assert_that(retrieved_data, equal_to(data))
 
 
+def test_get_pickled_missing_object(directory_object_store):
+    retrieved_data = directory_object_store.get_pickled(SOME_KEY)
+    assert_that(retrieved_data, is_(none()))
+
+
 def test_directory_object_store_default_directory():
     store = DirectoryObjectStore.in_current_directory()
     assert_that(store.root, equal_to(Path.cwd() / ".nodestream" / "objects"))


### PR DESCRIPTION
This is the first in a series of PRs intended to address #301. NOTE: Target branch is `0.14` - not `main`.

This PR (on its own) introduces only dead code into the library. As described in the issue description, in order to have extractor checkpoints we need to describe storage apis for the contents of those checkpoints. This PR introduces that core behavior and APIs including:

- Namespacing (which will be used to different checkpoints for different pipelines and versions of that pipeline. 
- Signature Verification - to prevent tampering of those checkpoints
- Object storage itself

