### PR TITLE
Condition Interpretations

### DIFF
--- a/nodestream/interpreting/interpretations/__init__.py
+++ b/nodestream/interpreting/interpretations/__init__.py
@@ -1,5 +1,5 @@
 from .extract_variables_interpretation import ExtractVariablesInterpretation
-from .interpretation import Interpretation, ConditionedInterpretation
+from .interpretation import ConditionedInterpretation, Interpretation
 from .properties_interpretation import PropertiesInterpretation
 from .relationship_interpretation import RelationshipInterpretation
 from .source_node_interpretation import SourceNodeInterpretation

--- a/nodestream/interpreting/interpretations/__init__.py
+++ b/nodestream/interpreting/interpretations/__init__.py
@@ -1,11 +1,12 @@
 from .extract_variables_interpretation import ExtractVariablesInterpretation
-from .interpretation import Interpretation
+from .interpretation import Interpretation, ConditionedInterpretation
 from .properties_interpretation import PropertiesInterpretation
 from .relationship_interpretation import RelationshipInterpretation
 from .source_node_interpretation import SourceNodeInterpretation
 from .switch_interpretation import SwitchInterpretation
 
 __all__ = (
+    "ConditionedInterpretation",
     "ExtractVariablesInterpretation",
     "Interpretation",
     "PropertiesInterpretation",

--- a/nodestream/interpreting/interpretations/conditions.py
+++ b/nodestream/interpreting/interpretations/conditions.py
@@ -1,0 +1,134 @@
+from abc import ABC, abstractmethod
+
+from ...pipeline.value_providers import (
+    ProviderContext,
+    StaticValueOrValueProvider,
+    ValueProvider,
+)
+from ...subclass_registry import SubclassRegistry
+
+CONDITION_SUBCLASS_REGISTRY = SubclassRegistry()
+COMPARISON_OPERATOR_SUBCLASS_REGISTRY = SubclassRegistry()
+
+
+@CONDITION_SUBCLASS_REGISTRY.connect_baseclass
+class Condition(ABC):
+    @abstractmethod
+    def evaluate(self, context: ProviderContext) -> bool:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        pass
+
+    @staticmethod
+    def from_tagged_file_data(**data) -> "Condition":
+        name = data.pop("type", CONDITION_SUBCLASS_REGISTRY.name_for(AlwaysTrue))
+        class_to_load = CONDITION_SUBCLASS_REGISTRY.get(name)
+        return class_to_load.from_file_data(**data)
+
+
+class AlwaysTrue(Condition, alias="true"):
+    def evaluate(self, context: ProviderContext) -> bool:
+        return True
+
+    @classmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        return cls()
+
+
+class Or(Condition, alias="or"):
+    def __init__(self, *conditions: Condition):
+        self.conditions = conditions
+
+    def evaluate(self, context: ProviderContext) -> bool:
+        return any(condition.evaluate(context) for condition in self.conditions)
+
+    @classmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        conditions = [
+            Condition.from_tagged_file_data(**condition)
+            for condition in arguments["conditions"]
+        ]
+        return cls(*conditions)
+
+
+class And(Condition, alias="and"):
+    def __init__(self, *conditions: Condition):
+        self.conditions = conditions
+
+    def evaluate(self, context: ProviderContext) -> bool:
+        return all(condition.evaluate(context) for condition in self.conditions)
+
+    @classmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        conditions = [
+            Condition.from_tagged_file_data(**condition)
+            for condition in arguments["conditions"]
+        ]
+        return cls(*conditions)
+
+
+class Not(Condition, alias="not"):
+    def __init__(self, condition: Condition):
+        self.condition = condition
+
+    def evaluate(self, context: ProviderContext) -> bool:
+        return not self.condition.evaluate(context)
+
+    @classmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        condition = Condition.from_tagged_file_data(**arguments["condition"])
+        return cls(condition)
+
+
+@COMPARISON_OPERATOR_SUBCLASS_REGISTRY.connect_baseclass
+class ComparisonOperator(ABC):
+    @abstractmethod
+    def operate(self, left, right) -> bool:
+        pass
+
+
+class EqualsOperator(ComparisonOperator, alias="equals"):
+    def operate(self, left, right) -> bool:
+        return left == right
+
+
+class GreaterThanOperator(ComparisonOperator, alias="greater_than"):
+    def operate(self, left, right) -> bool:
+        return left > right
+
+
+class LessThanOperator(ComparisonOperator, alias="less_than"):
+    def operate(self, left, right) -> bool:
+        return left < right
+
+
+class ContainsOperator(ComparisonOperator, alias="contains"):
+    def operate(self, left, right) -> bool:
+        return right in left
+
+
+class Comparator(Condition, alias="compare"):
+    def __init__(
+        self,
+        left: StaticValueOrValueProvider,
+        right: StaticValueOrValueProvider,
+        operator: ComparisonOperator,
+    ):
+        self.left = ValueProvider.guarantee_value_provider(left)
+        self.right = ValueProvider.guarantee_value_provider(right)
+        self.operator = operator
+
+    def evaluate(self, context: ProviderContext) -> bool:
+        left = self.left.single_value(context)
+        right = self.right.single_value(context)
+        return self.operator.operate(left, right)
+
+    @classmethod
+    def from_file_data(cls, **arguments) -> "Condition":
+        left = arguments["left"]
+        right = arguments["right"]
+        operator = COMPARISON_OPERATOR_SUBCLASS_REGISTRY.get(arguments["operator"])
+        return cls(left=left, right=right, operator=operator())

--- a/nodestream/interpreting/interpretations/interpretation.py
+++ b/nodestream/interpreting/interpretations/interpretation.py
@@ -4,6 +4,7 @@ from ...pipeline.value_providers import ProviderContext
 from ...pluggable import Pluggable
 from ...schema import ExpandsSchema
 from ...subclass_registry import SubclassRegistry
+from .conditions import Condition
 
 INTERPRETATION_REGISTRY = SubclassRegistry()
 
@@ -20,5 +21,20 @@ class Interpretation(ExpandsSchema, Pluggable, ABC):
     @classmethod
     def from_file_data(cls, **arguments) -> "Interpretation":
         name = arguments.pop("type")
+        condition = arguments.pop("condition", None)
         class_to_load = INTERPRETATION_REGISTRY.get(name)
-        return class_to_load(**arguments)
+        interpretation = class_to_load(**arguments)
+        if condition:
+            condition = Condition.from_tagged_file_data(**condition)
+            return ConditionedInterpretation(condition, interpretation)
+        return interpretation
+
+
+class ConditionedInterpretation(Interpretation):
+    def __init__(self, condition: Condition, interpretation: Interpretation):
+        self.condition = condition
+        self.interpretation = interpretation
+
+    def interpret(self, context: ProviderContext):
+        if self.condition.evaluate(context):
+            self.interpretation.interpret(context)

--- a/tests/unit/interpreting/interpretations/test_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_interpretation.py
@@ -3,6 +3,11 @@ from hamcrest import assert_that, instance_of
 from nodestream.interpreting.interpretations import (
     Interpretation,
     SourceNodeInterpretation,
+    ConditionedInterpretation,
+)
+from nodestream.interpreting.interpretations.conditions import (
+    AlwaysTrue,
+    ProviderContext,
 )
 
 
@@ -11,3 +16,33 @@ def test_from_file_data_gets_right_subclass():
         type="source_node", node_type="Test", key={"key": "value"}
     )
     assert_that(result, instance_of(SourceNodeInterpretation))
+
+
+def test_from_file_data_gets_condition_handled():
+    result = Interpretation.from_file_data(
+        type="source_node",
+        node_type="Test",
+        key={"key": "value"},
+        condition={"type": "true"},
+    )
+    assert_that(result, instance_of(ConditionedInterpretation))
+    assert_that(result.condition, instance_of(AlwaysTrue))
+    assert_that(result.interpretation, instance_of(SourceNodeInterpretation))
+
+
+def test_conditioned_interpretation_continues_on_condition_matched(mocker):
+    context = mocker.Mock(spec=ProviderContext)
+    interpretation = mocker.Mock(spec=SourceNodeInterpretation)
+    conditioned = ConditionedInterpretation(AlwaysTrue(), interpretation)
+    conditioned.interpret(context)
+    interpretation.interpret.assert_called_once_with(context)
+
+
+def test_conditioned_interpretation_breaks_on_missing_condition(mocker):
+    context = mocker.Mock(spec=ProviderContext)
+    interpretation = mocker.Mock(spec=SourceNodeInterpretation)
+    definitely_totally_true = mocker.Mock(spec=AlwaysTrue)
+    definitely_totally_true.evaluate.return_value = False
+    conditioned = ConditionedInterpretation(definitely_totally_true, interpretation)
+    conditioned.interpret(context)
+    interpretation.interpret.assert_not_called()

--- a/tests/unit/interpreting/interpretations/test_interpretation.py
+++ b/tests/unit/interpreting/interpretations/test_interpretation.py
@@ -1,9 +1,9 @@
 from hamcrest import assert_that, instance_of
 
 from nodestream.interpreting.interpretations import (
+    ConditionedInterpretation,
     Interpretation,
     SourceNodeInterpretation,
-    ConditionedInterpretation,
 )
 from nodestream.interpreting.interpretations.conditions import (
     AlwaysTrue,

--- a/tests/unit/interpreting/test_conditions.py
+++ b/tests/unit/interpreting/test_conditions.py
@@ -1,23 +1,22 @@
 import pytest
-from hamcrest import assert_that, is_, instance_of, has_length
-
-from nodestream.pipeline.value_providers import (
-    ProviderContext,
-    ValueProvider,
-    JmespathValueProvider,
-)
+from hamcrest import assert_that, has_length, instance_of, is_
 
 from nodestream.interpreting.interpretations.conditions import (
     AlwaysTrue,
-    Or,
     And,
-    Not,
+    Comparator,
+    Condition,
+    ContainsOperator,
     EqualsOperator,
     GreaterThanOperator,
     LessThanOperator,
-    ContainsOperator,
-    Comparator,
-    Condition,
+    Not,
+    Or,
+)
+from nodestream.pipeline.value_providers import (
+    JmespathValueProvider,
+    ProviderContext,
+    ValueProvider,
 )
 
 

--- a/tests/unit/interpreting/test_conditions.py
+++ b/tests/unit/interpreting/test_conditions.py
@@ -1,0 +1,140 @@
+import pytest
+from hamcrest import assert_that, is_, instance_of, has_length
+
+from nodestream.pipeline.value_providers import (
+    ProviderContext,
+    ValueProvider,
+    JmespathValueProvider,
+)
+
+from nodestream.interpreting.interpretations.conditions import (
+    AlwaysTrue,
+    Or,
+    And,
+    Not,
+    EqualsOperator,
+    GreaterThanOperator,
+    LessThanOperator,
+    ContainsOperator,
+    Comparator,
+    Condition,
+)
+
+
+@pytest.fixture
+def mock_context(mocker):
+    return mocker.Mock(spec=ProviderContext)
+
+
+def test_always_true(mock_context):
+    condition = AlwaysTrue()
+    assert_that(condition.evaluate(mock_context), is_(True))
+
+
+def test_or_condition(mocker, mock_context):
+    true_condition = AlwaysTrue()
+    false_condition = mocker.Mock(spec=AlwaysTrue)
+    false_condition.evaluate.return_value = False
+
+    condition = Or(true_condition, false_condition)
+    assert_that(condition.evaluate(mock_context), is_(True))
+
+    condition = Or(false_condition, false_condition)
+    assert_that(condition.evaluate(mock_context), is_(False))
+
+
+def test_and_condition(mocker, mock_context):
+    true_condition = AlwaysTrue()
+    false_condition = mocker.Mock(spec=AlwaysTrue)
+    false_condition.evaluate.return_value = False
+
+    condition = And(true_condition, false_condition)
+    assert_that(condition.evaluate(mock_context), is_(False))
+
+    condition = And(true_condition, true_condition)
+    assert_that(condition.evaluate(mock_context), is_(True))
+
+
+def test_not_condition(mocker, mock_context):
+    true_condition = AlwaysTrue()
+    false_condition = mocker.Mock(spec=AlwaysTrue)
+    false_condition.evaluate.return_value = False
+
+    condition = Not(true_condition)
+    assert_that(condition.evaluate(mock_context), is_(False))
+
+    condition = Not(false_condition)
+    assert_that(condition.evaluate(mock_context), is_(True))
+
+
+def test_equals_operator():
+    operator = EqualsOperator()
+    assert_that(operator.operate(1, 1), is_(True))
+    assert_that(operator.operate(1, 2), is_(False))
+
+
+def test_greater_than_operator():
+    operator = GreaterThanOperator()
+    assert_that(operator.operate(2, 1), is_(True))
+    assert_that(operator.operate(1, 2), is_(False))
+
+
+def test_less_than_operator():
+    operator = LessThanOperator()
+    assert_that(operator.operate(1, 2), is_(True))
+    assert_that(operator.operate(2, 1), is_(False))
+
+
+def test_contains_operator():
+    operator = ContainsOperator()
+    assert_that(operator.operate([1, 2, 3], 2), is_(True))
+    assert_that(operator.operate([1, 2, 3], 4), is_(False))
+
+
+def test_comparator(mocker, mock_context):
+    left_value = mocker.Mock(spec=ValueProvider)
+    right_value = mocker.Mock(spec=ValueProvider)
+    left_value.single_value.return_value = 1
+    right_value.single_value.return_value = 1
+
+    operator = EqualsOperator()
+    condition = Comparator(left_value, right_value, operator)
+    assert_that(condition.evaluate(mock_context), is_(True))
+
+    right_value.single_value.return_value = 2
+    assert_that(condition.evaluate(mock_context), is_(False))
+
+
+def test_from_file_data_or():
+    data = {"type": "or", "conditions": [{"type": "true"}, {"type": "true"}]}
+    condition = Condition.from_tagged_file_data(**data)
+    assert_that(condition, instance_of(Or))
+    assert_that(condition.conditions, has_length(2))
+
+
+def test_from_file_data_and():
+    data = {"type": "and", "conditions": [{"type": "true"}, {"type": "true"}]}
+    condition = Condition.from_tagged_file_data(**data)
+    assert_that(condition, instance_of(And))
+    assert_that(condition.conditions, has_length(2))
+
+
+def test_from_file_data_not():
+    data = {"type": "not", "condition": {"type": "true"}}
+    condition = Condition.from_tagged_file_data(**data)
+    assert_that(condition, instance_of(Not))
+    assert_that(condition.condition, instance_of(AlwaysTrue))
+
+
+def test_from_file_data_comparator():
+    data = {
+        "type": "compare",
+        "left": 1,
+        "right": JmespathValueProvider.from_string_expression("foo"),
+        "operator": "equals",
+    }
+    condition = Condition.from_tagged_file_data(**data)
+    assert_that(condition, instance_of(Comparator))
+    assert_that(condition.left, instance_of(ValueProvider))
+    assert_that(condition.right, instance_of(ValueProvider))
+    assert_that(condition.operator, instance_of(EqualsOperator))


### PR DESCRIPTION
Prior to migration to OSS, we had a `only_when` field that allowed a comparator between two providers to trigger the actual evaluation. This is reintroducing and turbo-charging that feature. 