### PR TITLE
fix: change jmespath single value behavior

### DIFF
--- a/nodestream/pipeline/value_providers/jmespath_value_provider.py
+++ b/nodestream/pipeline/value_providers/jmespath_value_provider.py
@@ -9,6 +9,7 @@ from yaml import SafeDumper, SafeLoader
 from .context import ProviderContext
 from .value_provider import ValueProvider, ValueProviderException
 
+
 # `QueryStrategy` is here to provide the seam for different optimizations
 # for executing jmespath queries. We can either execute a "fully fledged"
 # jmespath query or we can implement some simple access patterns that
@@ -63,8 +64,8 @@ class JmespathValueProvider(ValueProvider):
     def install_yaml_tag(cls, loader: Type[SafeLoader]):
         loader.add_constructor(
             "!jmespath",
-            lambda loader, node: cls.from_string_expression(
-                loader.construct_scalar(node)
+            lambda loader_param, node: cls.from_string_expression(
+                loader_param.construct_scalar(node)
             ),
         )
 

--- a/nodestream/pipeline/value_providers/jmespath_value_provider.py
+++ b/nodestream/pipeline/value_providers/jmespath_value_provider.py
@@ -85,7 +85,12 @@ class JmespathValueProvider(ValueProvider):
 
     def single_value(self, context: ProviderContext) -> Any:
         try:
-            return next(self.search(context), None)
+            result = list(self.search(context))
+            if not result:
+                return None
+            if len(result) == 1:
+                return result[0]
+            return list(result)
         except Exception as e:
             raise ValueProviderException(str(context.document), self) from e
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ markers = [
     "integration: marks the test as an integration test (deselect with '-m \"not integration\"')",
     "e2e: marks the test as an end-to-end test (deselect with '-m \"not e2e\"')",
 ]
+log_cli = false
+log_cli_level = "INFO"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.poetry.scripts]
 nodestream = 'nodestream.cli.application:run'

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ DECENT_DOCUMENT = {
         {"first_name": "Zach", "last_name": "Probst"},
         {"first_name": "Chad", "last_name": "Cloes"},
     ],
-    "project": {"tags": ["graphdb", "python"]},
+    "project": {"tags": ["graphdb", "python"], "name": "project_name"},
 }
 
 

--- a/tests/unit/pipeline/value_providers/test_jmespath_value_provider.py
+++ b/tests/unit/pipeline/value_providers/test_jmespath_value_provider.py
@@ -58,7 +58,7 @@ def test_single_value_is_list(blank_context_with_document):
     assert result == ["graphdb", "python"]
 
 
-def test_multiple_values_missing(blank_context_with_document):
+def test_many_values_missing(blank_context_with_document):
     subject = JmespathValueProvider.from_string_expression("team.description")
     result = list(subject.many_values(blank_context_with_document))
     assert result == []
@@ -85,17 +85,17 @@ def test_many_values_single_level_array():
         {"toplevel": ["test1", "test2", "test3"]}, DesiredIngestion()
     )
     subject = JmespathValueProvider.from_string_expression("toplevel")
-    result = list(subject.single_value(context))
+    result = list(subject.many_values(context))
     assert result == ["test1", "test2", "test3"]
 
 
-def test_multiple_values_returns_one_value(blank_context_with_document):
+def test_many_values_returns_one_value(blank_context_with_document):
     subject = JmespathValueProvider.from_string_expression("team.name")
     result = list(subject.many_values(blank_context_with_document))
     assert result == ["nodestream"]
 
 
-def test_multiple_values_hit(blank_context_with_document):
+def test_many_values_hit(blank_context_with_document):
     subject = JmespathValueProvider.from_string_expression("project.tags")
     result = list(subject.many_values(blank_context_with_document))
     assert result == ["graphdb", "python"]
@@ -115,7 +115,7 @@ def test_single_value_error(blank_context_with_document):
     assert some_text_from_document in error_message
 
 
-def test_multiple_values_error(blank_context_with_document):
+def test_many_values_error(blank_context_with_document):
     # this will error because team2 does not exist causing the join to throw an error
     expression_with_error = "join('/', [team.name || '', team2.name])"
     subject = JmespathValueProvider.from_string_expression(expression_with_error)


### PR DESCRIPTION
Currently jmespath value providers return only the first item in a list.  This causes a lot of confusion, and this PR attempts to address it.