### PR TITLE
Updating channel metric accumulation logic, fixed snapshots.

### DIFF
--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -214,7 +214,6 @@ class ConsoleMetricHandler(MetricHandler):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
-        # Decrementing metrics that are accumulated doesn't help.
         if not metric.accumulate:
             self.metrics[metric] = self.metrics.get(metric, 0) - value
 
@@ -250,7 +249,6 @@ class JsonLogMetricHandler(MetricHandler):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
-        # Decrementing metrics that are accumulated doesn't help.
         if not metric.accumulate:
             self.metrics[metric] = self.metrics.get(metric, 0) - value
 

--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -214,7 +214,9 @@ class ConsoleMetricHandler(MetricHandler):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
-        self.metrics[metric] = self.metrics.get(metric, 0) - value
+        # Decrementing metrics that are accumulated doesn't help.
+        if not metric.accumulate:
+            self.metrics[metric] = self.metrics.get(metric, 0) - value
 
     def discharge(self) -> dict[Metric, Number]:
         metrics = {}
@@ -248,7 +250,9 @@ class JsonLogMetricHandler(MetricHandler):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
-        self.metrics[metric] = self.metrics.get(metric, 0) - value
+        # Decrementing metrics that are accumulated doesn't help.
+        if not metric.accumulate:
+            self.metrics[metric] = self.metrics.get(metric, 0) - value
 
     def discharge(self) -> dict[Metric, Number]:
         metrics = {}

--- a/nodestream/pipeline/channel.py
+++ b/nodestream/pipeline/channel.py
@@ -51,6 +51,7 @@ class Channel:
         metric = Metric(
             f"buffered_{input_name}_to_{output_name}",
             f"Records buffered: {input_name} → {output_name}",
+            accumulate=True,
         )
         return cls(size, metric)
 

--- a/nodestream/pipeline/progress_reporter.py
+++ b/nodestream/pipeline/progress_reporter.py
@@ -68,7 +68,7 @@ class PipelineProgressReporter:
             on_start_callback=no_op,
             on_finish_callback=no_op,
             on_fatal_error_callback=raise_exception,
-            observability_callback=lambda _: lambda record: results_list.append(record),
+            observability_callback=lambda record: results_list.append(record),
         )
 
     def report(self, index, metrics: Metrics):

--- a/nodestream/pipeline/progress_reporter.py
+++ b/nodestream/pipeline/progress_reporter.py
@@ -64,10 +64,11 @@ class PipelineProgressReporter:
         return cls(
             reporting_frequency=1,
             logger=getLogger("test"),
-            callback=lambda _, record: results_list.append(record),
+            callback=no_op,
             on_start_callback=no_op,
             on_finish_callback=no_op,
             on_fatal_error_callback=raise_exception,
+            observability_callback=lambda _: lambda record: results_list.append(record),
         )
 
     def report(self, index, metrics: Metrics):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.14.12"
+version = "0.14.13"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -202,3 +202,40 @@ def test_json_log_metric_handler_discharge_with_accumulate(mocker):
     # Accumulating metric should be reset to 0, non-accumulating should remain
     assert handler.metrics[accumulating_metric] == 0
     assert handler.metrics[non_accumulating_metric] == 7
+
+
+def test_json_log_metric_handler_discharge_with_accumulate_and_decrement(mocker):
+    """Test that JsonLogMetricHandler does not decrement accumulating metrics"""
+    handler = JsonLogMetricHandler()
+
+    accumulating_metric = Metric("test_accumulate", accumulate=True)
+    non_accumulating_metric = Metric("test_no_accumulate", accumulate=False)
+
+    handler.increment(accumulating_metric, 10)
+    handler.decrement(accumulating_metric, 7)
+
+    handler.increment(non_accumulating_metric, 10)
+    handler.decrement(non_accumulating_metric, 7)
+
+    # Accumulating metric should be reset to 0, non-accumulating should remain
+    assert handler.metrics[accumulating_metric] == 10
+    assert handler.metrics[non_accumulating_metric] == 3
+
+
+def test_console_metric_handler_discharge_with_accumulate_and_decrement(mocker):
+    """Test that ConsoleMetricHandler does not decrement accumulating metrics"""
+    mock_command = mocker.Mock()
+    handler = ConsoleMetricHandler(mock_command)
+
+    accumulating_metric = Metric("test_accumulate", accumulate=True)
+    non_accumulating_metric = Metric("test_no_accumulate", accumulate=False)
+
+    handler.increment(accumulating_metric, 10)
+    handler.decrement(accumulating_metric, 7)
+
+    handler.increment(non_accumulating_metric, 10)
+    handler.decrement(non_accumulating_metric, 7)
+
+    # Accumulating metric should be reset to 0, non-accumulating should remain
+    assert handler.metrics[accumulating_metric] == 10
+    assert handler.metrics[non_accumulating_metric] == 3


### PR DESCRIPTION
For metrics like the amount of records within an outbox at a given time, it makes sense to increment and decrement them in real time for prometheus metrics since we may be able to see passing of records in real time through async prometheus reporting intervals. However, with logging, these values are meaningless since the amount of data that flows in between will always either be tied to the time-based or record modulo based frequencies. Here I am suggesting that it becomes an accumulator metric. And for all accumulator metrics, we omit the decrement command only on the Json and Console handlers.

Also implementing the observability check for snapshot functionality.