### PR TITLE
Updating the schema expansion to include additional labels.

### DIFF
--- a/nodestream/interpreting/interpretations/relationship_interpretation.py
+++ b/nodestream/interpreting/interpretations/relationship_interpretation.py
@@ -227,6 +227,19 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
                 node_type=self.node_type.value,
             )
 
+            # Expand schemas for node additional types with the same structure
+            for additional_type in self.node_additional_types:
+                coordinator.on_node_schema(
+                    self.expand_related_node_schema,
+                    node_type=additional_type,
+                )
+
+            # Register additional types so relationships are also connected to them
+            coordinator.register_additional_types(
+                self.node_type.value,
+                self.node_additional_types,
+            )
+
         if self.relationship_type.is_static and self.node_type.is_static:
             source_node = SourceNodeInterpretation.SOURCE_NODE_TYPE_ALIAS
             related_node = self.node_type.value

--- a/nodestream/interpreting/interpretations/source_node_interpretation.py
+++ b/nodestream/interpreting/interpretations/source_node_interpretation.py
@@ -156,3 +156,16 @@ class SourceNodeInterpretation(Interpretation, alias="source_node"):
             alias=self.SOURCE_NODE_TYPE_ALIAS,
             node_type=self.node_type.value,
         )
+
+        # Expand schemas for additional types with the same structure
+        for additional_type in self.additional_types:
+            coordinator.on_node_schema(
+                self.expand_source_node_schema,
+                node_type=additional_type,
+            )
+
+        # Register additional types so relationships are also connected to them
+        coordinator.register_additional_types(
+            self.node_type.value,
+            self.additional_types,
+        )

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -701,6 +701,8 @@ class SchemaExpansionCoordinator:
     unbound_adjacencies: LayeredList[UnboundAdjacency] = field(
         default_factory=LayeredList
     )
+    # Maps node types to their additional types for relationship expansion
+    additional_types_map: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
 
     def on_node_schema(
         self,
@@ -817,9 +819,59 @@ class SchemaExpansionCoordinator:
         self.unbound_aliases.decrement_context_level()
         self.aliases.decrement_context_level()
 
+    def register_additional_types(
+        self, main_type: str, additional_types: Tuple[str, ...]
+    ):
+        """Register additional types for a main type.
+
+        This allows relationships connected to the main type to also be connected
+        to the additional types.
+
+        Args:
+            main_type: The main node type.
+            additional_types: The additional types associated with the main type.
+        """
+        if additional_types:
+            self.additional_types_map[main_type] = additional_types
+
     def clear_aliases(self):
         for unbound_adjacency in self.unbound_adjacencies:
             unbound_adjacency.bind(self.schema, self.aliases)
+
+        # Create duplicate adjacencies for additional types
+        adjacencies_to_add = []
+        for adjacency, cardinality in list(self.schema.cardinalities.items()):
+            from_types = [adjacency.from_node_type]
+            to_types = [adjacency.to_node_type]
+
+            # Add additional types for from_node_type
+            if adjacency.from_node_type in self.additional_types_map:
+                from_types.extend(self.additional_types_map[adjacency.from_node_type])
+
+            # Add additional types for to_node_type
+            if adjacency.to_node_type in self.additional_types_map:
+                to_types.extend(self.additional_types_map[adjacency.to_node_type])
+
+            # Create adjacencies for all combinations (excluding the original)
+            for from_type in from_types:
+                for to_type in to_types:
+                    # Skip the original adjacency (already exists)
+                    if (
+                        from_type == adjacency.from_node_type
+                        and to_type == adjacency.to_node_type
+                    ):
+                        continue
+
+                    new_adjacency = Adjacency(
+                        from_node_type=from_type,
+                        to_node_type=to_type,
+                        relationship_type=adjacency.relationship_type,
+                    )
+                    adjacencies_to_add.append((new_adjacency, cardinality))
+
+        # Add all the new adjacencies
+        for adjacency, cardinality in adjacencies_to_add:
+            self.schema.add_adjacency(adjacency, cardinality)
 
 
 class ExpandsSchema:

--- a/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
+++ b/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
@@ -1,0 +1,109 @@
+- implementation: nodestream.pipeline.extractors.files:FileExtractor
+  factory: local
+  arguments:
+    globs:
+      - tests/data/fifa_2021_player_data.csv
+
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    interpretations:
+      # First pass: Player with Person and Athlete as additional types
+      # This establishes the base schema with player_id as the key
+      - - type: source_node
+          node_type: Player
+          key:
+            player_id: !jmespath player_id
+          properties:
+            name: !jmespath name
+            overall: !jmespath overall
+            age: !jmespath age
+            hits: !jmespath hits
+          additional_types:
+            - Person
+            - Athlete
+        - type: relationship
+          node_type: Country
+          relationship_type: ORIGINATES_FROM
+          node_key:
+            name: !jmespath nationality
+        - type: relationship
+          node_type: Team
+          relationship_type: PLAYS_FOR
+          node_key:
+            name: !jmespath team
+          node_additional_types:
+            - Organization
+            - SportsClub
+
+      # Second pass: Person as main type with same keys but additional properties
+      # This tests that overlapping types (Person was additional in first pass)
+      # merge correctly with consistent keys
+      - - type: source_node
+          node_type: Person
+          key:
+            player_id: !jmespath player_id  # Same key as first pass
+          properties:
+            name: !jmespath name  # Overlaps with Pass 1
+            potential: !jmespath potential  # New property only on Person in this pass
+          additional_types:
+            - Human
+            - Individual
+        - type: relationship
+          node_type: Country
+          relationship_type: LIVES_IN
+          node_key:
+            name: !jmespath nationality
+
+      # Third pass: Athlete as main type with consistent keys
+      # Tests another overlap (Athlete was additional in first pass)
+      - - type: source_node
+          node_type: Athlete
+          key:
+            player_id: !jmespath player_id  # Same key structure
+          properties:
+            overall: !jmespath overall  # Overlaps with Pass 1
+            position: !jmespath position  # New property from Athlete definition
+          additional_types:
+            - Competitor
+            - SportsPerson
+        - type: relationship
+          node_type: Position
+          relationship_type: COMPETES_AT
+          node_key:
+            name: !jmespath position
+
+      # Fourth pass: Test relationship node with additional types where
+      # the related node also appears as a source node
+      - - type: source_node
+          node_type: TeamMember
+          key:
+            member_id: !jmespath player_id
+          properties:
+            name: !jmespath name
+            team_name: !jmespath team
+        - type: relationship
+          node_type: Player
+          relationship_type: IS_PLAYER
+          node_key:
+            player_id: !jmespath player_id
+          node_additional_types:
+            - Person  # Overlap with first pass additional type
+            - Athlete # Overlap with first pass additional type
+
+      # Fifth pass: Test complex multi-level overlaps
+      # Organization (additional type from Team in first pass) gets more types
+      - - type: source_node
+          node_type: Organization
+          key:
+            name: !jmespath team
+          properties:
+            country: !jmespath nationality
+          additional_types:
+            - Entity
+            - LegalEntity
+        - type: relationship
+          node_type: Country
+          relationship_type: BASED_IN
+          node_key:
+            name: !jmespath nationality
+

--- a/tests/integration/fixtures/pipelines/fifa_2021_player_data.yaml
+++ b/tests/integration/fixtures/pipelines/fifa_2021_player_data.yaml
@@ -17,6 +17,8 @@
           hits:  !jmespath hits
           age:  !jmespath age
           potential: !jmespath potential
+        additional_types:
+          - Person
       - type: relationship
         node_type: Country
         relationship_type: ORIGINATES_FROM

--- a/tests/integration/snapshots/interpretation_snapshot_fifa_2021_player_data.yaml.json
+++ b/tests/integration/snapshots/interpretation_snapshot_fifa_2021_player_data.yaml.json
@@ -4,7 +4,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "158023"
                     },
@@ -48,7 +50,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "158023"
                     },
@@ -92,7 +96,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "158023"
                     },
@@ -136,7 +142,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "158023"
             },
@@ -159,7 +167,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "20801"
                     },
@@ -203,7 +213,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "20801"
                     },
@@ -247,7 +259,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "20801"
                     },
@@ -291,7 +305,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "20801"
             },
@@ -314,7 +330,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190871"
                     },
@@ -358,7 +376,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190871"
                     },
@@ -402,7 +422,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190871"
                     },
@@ -446,7 +468,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "190871"
             },
@@ -469,7 +493,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "203376"
                     },
@@ -513,7 +539,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "203376"
                     },
@@ -557,7 +585,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "203376"
                     },
@@ -601,7 +631,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "203376"
             },
@@ -624,7 +656,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200389"
                     },
@@ -668,7 +702,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200389"
                     },
@@ -712,7 +748,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200389"
                     },
@@ -756,7 +794,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "200389"
             },
@@ -779,7 +819,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192985"
                     },
@@ -823,7 +865,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192985"
                     },
@@ -867,7 +911,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192985"
                     },
@@ -911,7 +957,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192985"
             },
@@ -934,7 +982,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188545"
                     },
@@ -978,7 +1028,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188545"
                     },
@@ -1022,7 +1074,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188545"
                     },
@@ -1066,7 +1120,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "188545"
             },
@@ -1089,7 +1145,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183277"
                     },
@@ -1133,7 +1191,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183277"
                     },
@@ -1177,7 +1237,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183277"
                     },
@@ -1221,7 +1283,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "183277"
             },
@@ -1244,7 +1308,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212831"
                     },
@@ -1288,7 +1354,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212831"
                     },
@@ -1332,7 +1400,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212831"
                     },
@@ -1376,7 +1446,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212831"
             },
@@ -1399,7 +1471,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209331"
                     },
@@ -1443,7 +1517,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209331"
                     },
@@ -1487,7 +1563,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209331"
                     },
@@ -1531,7 +1609,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "209331"
             },
@@ -1554,7 +1634,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208722"
                     },
@@ -1598,7 +1680,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208722"
                     },
@@ -1642,7 +1726,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208722"
                     },
@@ -1686,7 +1772,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "208722"
             },
@@ -1709,7 +1797,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192448"
                     },
@@ -1753,7 +1843,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192448"
                     },
@@ -1797,7 +1889,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192448"
                     },
@@ -1841,7 +1935,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192448"
             },
@@ -1864,7 +1960,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "153079"
                     },
@@ -1908,7 +2006,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "153079"
                     },
@@ -1952,7 +2052,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "153079"
                     },
@@ -1996,7 +2098,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "153079"
             },
@@ -2019,7 +2123,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231747"
                     },
@@ -2063,7 +2169,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231747"
                     },
@@ -2107,7 +2215,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231747"
                     },
@@ -2151,7 +2261,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "231747"
             },
@@ -2174,7 +2286,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "215914"
                     },
@@ -2218,7 +2332,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "215914"
                     },
@@ -2262,7 +2378,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "215914"
                     },
@@ -2306,7 +2424,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "215914"
             },
@@ -2329,7 +2449,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202126"
                     },
@@ -2373,7 +2495,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202126"
                     },
@@ -2417,7 +2541,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202126"
                     },
@@ -2461,7 +2587,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "202126"
             },
@@ -2484,7 +2612,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "194765"
                     },
@@ -2528,7 +2658,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "194765"
                     },
@@ -2572,7 +2704,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "194765"
                     },
@@ -2616,7 +2750,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "194765"
             },
@@ -2639,7 +2775,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182521"
                     },
@@ -2683,7 +2821,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182521"
                     },
@@ -2727,7 +2867,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182521"
                     },
@@ -2771,7 +2913,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "182521"
             },
@@ -2794,7 +2938,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177003"
                     },
@@ -2838,7 +2984,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177003"
                     },
@@ -2882,7 +3030,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177003"
                     },
@@ -2926,7 +3076,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "177003"
             },
@@ -2949,7 +3101,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "176580"
                     },
@@ -2993,7 +3147,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "176580"
                     },
@@ -3037,7 +3193,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "176580"
                     },
@@ -3081,7 +3239,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "176580"
             },
@@ -3104,7 +3264,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167495"
                     },
@@ -3148,7 +3310,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167495"
                     },
@@ -3192,7 +3356,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167495"
                     },
@@ -3236,7 +3402,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "167495"
             },
@@ -3259,7 +3427,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "155862"
                     },
@@ -3303,7 +3473,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "155862"
                     },
@@ -3347,7 +3519,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "155862"
                     },
@@ -3391,7 +3565,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "155862"
             },
@@ -3414,7 +3590,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "210257"
                     },
@@ -3458,7 +3636,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "210257"
                     },
@@ -3502,7 +3682,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "210257"
                     },
@@ -3546,7 +3728,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "210257"
             },
@@ -3569,7 +3753,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202652"
                     },
@@ -3613,7 +3799,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202652"
                     },
@@ -3657,7 +3845,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "202652"
                     },
@@ -3701,7 +3891,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "202652"
             },
@@ -3724,7 +3916,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201942"
                     },
@@ -3768,7 +3962,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201942"
                     },
@@ -3812,7 +4008,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201942"
                     },
@@ -3856,7 +4054,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "201942"
             },
@@ -3879,7 +4079,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201024"
                     },
@@ -3923,7 +4125,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201024"
                     },
@@ -3967,7 +4171,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201024"
                     },
@@ -4011,7 +4217,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "201024"
             },
@@ -4034,7 +4242,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200145"
                     },
@@ -4078,7 +4288,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200145"
                     },
@@ -4122,7 +4334,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200145"
                     },
@@ -4166,7 +4380,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "200145"
             },
@@ -4189,7 +4405,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193080"
                     },
@@ -4233,7 +4451,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193080"
                     },
@@ -4277,7 +4497,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193080"
                     },
@@ -4321,7 +4543,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "193080"
             },
@@ -4344,7 +4568,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192119"
                     },
@@ -4388,7 +4614,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192119"
                     },
@@ -4432,7 +4660,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192119"
                     },
@@ -4476,7 +4706,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192119"
             },
@@ -4499,7 +4731,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189511"
                     },
@@ -4543,7 +4777,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189511"
                     },
@@ -4587,7 +4823,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189511"
                     },
@@ -4631,7 +4869,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "189511"
             },
@@ -4654,7 +4894,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188567"
                     },
@@ -4698,7 +4940,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188567"
                     },
@@ -4742,7 +4986,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188567"
                     },
@@ -4786,7 +5032,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "188567"
             },
@@ -4809,7 +5057,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "165153"
                     },
@@ -4853,7 +5103,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "165153"
                     },
@@ -4897,7 +5149,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "165153"
                     },
@@ -4941,7 +5195,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "165153"
             },
@@ -4964,7 +5220,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "162835"
                     },
@@ -5008,7 +5266,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "162835"
                     },
@@ -5052,7 +5312,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "162835"
                     },
@@ -5096,7 +5358,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "162835"
             },
@@ -5119,7 +5383,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "152729"
                     },
@@ -5163,7 +5429,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "152729"
                     },
@@ -5207,7 +5475,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "152729"
                     },
@@ -5251,7 +5521,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "152729"
             },
@@ -5274,7 +5546,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "138956"
                     },
@@ -5318,7 +5592,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "138956"
                     },
@@ -5362,7 +5638,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "138956"
                     },
@@ -5406,7 +5684,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "138956"
             },
@@ -5429,7 +5709,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "218667"
                     },
@@ -5473,7 +5755,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "218667"
                     },
@@ -5517,7 +5801,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "218667"
                     },
@@ -5561,7 +5847,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "218667"
             },
@@ -5584,7 +5872,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212622"
                     },
@@ -5628,7 +5918,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212622"
                     },
@@ -5672,7 +5964,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212622"
                     },
@@ -5716,7 +6010,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212622"
             },
@@ -5739,7 +6035,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212218"
                     },
@@ -5783,7 +6081,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212218"
                     },
@@ -5827,7 +6127,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212218"
                     },
@@ -5871,7 +6173,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212218"
             },
@@ -5894,7 +6198,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "211110"
                     },
@@ -5938,7 +6244,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "211110"
                     },
@@ -5982,7 +6290,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "211110"
                     },
@@ -6026,7 +6336,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "211110"
             },
@@ -6049,7 +6361,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200104"
                     },
@@ -6093,7 +6407,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200104"
                     },
@@ -6137,7 +6453,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "200104"
                     },
@@ -6181,7 +6499,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "200104"
             },
@@ -6204,7 +6524,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "199556"
                     },
@@ -6248,7 +6570,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "199556"
                     },
@@ -6292,7 +6616,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "199556"
                     },
@@ -6336,7 +6662,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "199556"
             },
@@ -6359,7 +6687,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "195864"
                     },
@@ -6403,7 +6733,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "195864"
                     },
@@ -6447,7 +6779,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "195864"
                     },
@@ -6491,7 +6825,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "195864"
             },
@@ -6514,7 +6850,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193041"
                     },
@@ -6558,7 +6896,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193041"
                     },
@@ -6602,7 +6942,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193041"
                     },
@@ -6646,7 +6988,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "193041"
             },
@@ -6669,7 +7013,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192387"
                     },
@@ -6713,7 +7059,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192387"
                     },
@@ -6757,7 +7105,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192387"
                     },
@@ -6801,7 +7151,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192387"
             },
@@ -6824,7 +7176,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190460"
                     },
@@ -6868,7 +7222,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190460"
                     },
@@ -6912,7 +7268,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "190460"
                     },
@@ -6956,7 +7314,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "190460"
             },
@@ -6979,7 +7339,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189513"
                     },
@@ -7023,7 +7385,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189513"
                     },
@@ -7067,7 +7431,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189513"
                     },
@@ -7111,7 +7477,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "189513"
             },
@@ -7134,7 +7502,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188350"
                     },
@@ -7178,7 +7548,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188350"
                     },
@@ -7222,7 +7594,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "188350"
                     },
@@ -7266,7 +7640,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "188350"
             },
@@ -7289,7 +7665,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "186153"
                     },
@@ -7333,7 +7711,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "186153"
                     },
@@ -7377,7 +7757,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "186153"
                     },
@@ -7421,7 +7803,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "186153"
             },
@@ -7444,7 +7828,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183898"
                     },
@@ -7488,7 +7874,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183898"
                     },
@@ -7532,7 +7920,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "183898"
                     },
@@ -7576,7 +7966,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "183898"
             },
@@ -7599,7 +7991,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182493"
                     },
@@ -7643,7 +8037,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182493"
                     },
@@ -7687,7 +8083,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "182493"
                     },
@@ -7731,7 +8129,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "182493"
             },
@@ -7754,7 +8154,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "178603"
                     },
@@ -7798,7 +8200,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "178603"
                     },
@@ -7842,7 +8246,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "178603"
                     },
@@ -7886,7 +8292,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "178603"
             },
@@ -7909,7 +8317,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "175943"
                     },
@@ -7953,7 +8363,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "175943"
                     },
@@ -7997,7 +8409,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "175943"
                     },
@@ -8041,7 +8455,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "175943"
             },
@@ -8064,7 +8480,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "168542"
                     },
@@ -8108,7 +8526,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "168542"
                     },
@@ -8152,7 +8572,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "168542"
                     },
@@ -8196,7 +8618,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "168542"
             },
@@ -8219,7 +8643,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167948"
                     },
@@ -8263,7 +8689,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167948"
                     },
@@ -8307,7 +8735,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "167948"
                     },
@@ -8351,7 +8781,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "167948"
             },
@@ -8374,7 +8806,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "164240"
                     },
@@ -8418,7 +8852,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "164240"
                     },
@@ -8462,7 +8898,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "164240"
                     },
@@ -8506,7 +8944,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "164240"
             },
@@ -8529,7 +8969,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "233049"
                     },
@@ -8573,7 +9015,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "233049"
                     },
@@ -8617,7 +9061,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "233049"
                     },
@@ -8661,7 +9107,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "233049"
             },
@@ -8684,7 +9132,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "232363"
                     },
@@ -8728,7 +9178,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "232363"
                     },
@@ -8772,7 +9224,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "232363"
                     },
@@ -8816,7 +9270,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "232363"
             },
@@ -8839,7 +9295,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "228702"
                     },
@@ -8883,7 +9341,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "228702"
                     },
@@ -8927,7 +9387,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "228702"
                     },
@@ -8971,7 +9433,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "228702"
             },
@@ -8994,7 +9458,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "222492"
                     },
@@ -9038,7 +9504,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "222492"
                     },
@@ -9082,7 +9550,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "222492"
                     },
@@ -9126,7 +9596,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "222492"
             },
@@ -9149,7 +9621,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "220440"
                     },
@@ -9193,7 +9667,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "220440"
                     },
@@ -9237,7 +9713,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "220440"
                     },
@@ -9281,7 +9759,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "220440"
             },
@@ -9304,7 +9784,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216267"
                     },
@@ -9348,7 +9830,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216267"
                     },
@@ -9392,7 +9876,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216267"
                     },
@@ -9436,7 +9922,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "216267"
             },
@@ -9459,7 +9947,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212198"
                     },
@@ -9503,7 +9993,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212198"
                     },
@@ -9547,7 +10039,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212198"
                     },
@@ -9591,7 +10085,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212198"
             },
@@ -9614,7 +10110,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212188"
                     },
@@ -9658,7 +10156,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212188"
                     },
@@ -9702,7 +10202,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212188"
                     },
@@ -9746,7 +10248,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212188"
             },
@@ -9769,7 +10273,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209499"
                     },
@@ -9813,7 +10319,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209499"
                     },
@@ -9857,7 +10365,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "209499"
                     },
@@ -9901,7 +10411,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "209499"
             },
@@ -9924,7 +10436,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208830"
                     },
@@ -9968,7 +10482,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208830"
                     },
@@ -10012,7 +10528,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208830"
                     },
@@ -10056,7 +10574,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "208830"
             },
@@ -10079,7 +10599,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208670"
                     },
@@ -10123,7 +10645,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208670"
                     },
@@ -10167,7 +10691,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208670"
                     },
@@ -10211,7 +10737,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "208670"
             },
@@ -10234,7 +10762,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "207865"
                     },
@@ -10278,7 +10808,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "207865"
                     },
@@ -10322,7 +10854,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "207865"
                     },
@@ -10366,7 +10900,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "207865"
             },
@@ -10389,7 +10925,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204485"
                     },
@@ -10433,7 +10971,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204485"
                     },
@@ -10477,7 +11017,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204485"
                     },
@@ -10521,7 +11063,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "204485"
             },
@@ -10544,7 +11088,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201535"
                     },
@@ -10588,7 +11134,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201535"
                     },
@@ -10632,7 +11180,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201535"
                     },
@@ -10676,7 +11226,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "201535"
             },
@@ -10699,7 +11251,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201399"
                     },
@@ -10743,7 +11297,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201399"
                     },
@@ -10787,7 +11343,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "201399"
                     },
@@ -10831,7 +11389,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "201399"
             },
@@ -10854,7 +11414,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198219"
                     },
@@ -10898,7 +11460,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198219"
                     },
@@ -10942,7 +11506,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198219"
                     },
@@ -10986,7 +11552,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "198219"
             },
@@ -11009,7 +11577,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193747"
                     },
@@ -11053,7 +11623,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193747"
                     },
@@ -11097,7 +11669,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "193747"
                     },
@@ -11141,7 +11715,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "193747"
             },
@@ -11164,7 +11740,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192505"
                     },
@@ -11208,7 +11786,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192505"
                     },
@@ -11252,7 +11832,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192505"
                     },
@@ -11296,7 +11878,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192505"
             },
@@ -11319,7 +11903,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189509"
                     },
@@ -11363,7 +11949,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189509"
                     },
@@ -11407,7 +11995,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189509"
                     },
@@ -11451,7 +12041,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "189509"
             },
@@ -11474,7 +12066,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189332"
                     },
@@ -11518,7 +12112,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189332"
                     },
@@ -11562,7 +12158,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "189332"
                     },
@@ -11606,7 +12204,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "189332"
             },
@@ -11629,7 +12229,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184344"
                     },
@@ -11673,7 +12275,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184344"
                     },
@@ -11717,7 +12321,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184344"
                     },
@@ -11761,7 +12367,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "184344"
             },
@@ -11784,7 +12392,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184087"
                     },
@@ -11828,7 +12438,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184087"
                     },
@@ -11872,7 +12484,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "184087"
                     },
@@ -11916,7 +12530,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "184087"
             },
@@ -11939,7 +12555,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "180206"
                     },
@@ -11983,7 +12601,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "180206"
                     },
@@ -12027,7 +12647,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "180206"
                     },
@@ -12071,7 +12693,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "180206"
             },
@@ -12094,7 +12718,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "179813"
                     },
@@ -12138,7 +12764,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "179813"
                     },
@@ -12182,7 +12810,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "179813"
                     },
@@ -12226,7 +12856,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "179813"
             },
@@ -12249,7 +12881,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177683"
                     },
@@ -12293,7 +12927,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177683"
                     },
@@ -12337,7 +12973,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "177683"
                     },
@@ -12381,7 +13019,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "177683"
             },
@@ -12404,7 +13044,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "143076"
                     },
@@ -12448,7 +13090,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "143076"
                     },
@@ -12492,7 +13136,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "143076"
                     },
@@ -12536,7 +13182,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "143076"
             },
@@ -12559,7 +13207,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "235243"
                     },
@@ -12603,7 +13253,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "235243"
                     },
@@ -12647,7 +13299,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "235243"
                     },
@@ -12691,7 +13345,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "235243"
             },
@@ -12714,7 +13370,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231866"
                     },
@@ -12758,7 +13416,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231866"
                     },
@@ -12802,7 +13462,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231866"
                     },
@@ -12846,7 +13508,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "231866"
             },
@@ -12869,7 +13533,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231281"
                     },
@@ -12913,7 +13579,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231281"
                     },
@@ -12957,7 +13625,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "231281"
                     },
@@ -13001,7 +13671,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "231281"
             },
@@ -13024,7 +13696,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230658"
                     },
@@ -13068,7 +13742,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230658"
                     },
@@ -13112,7 +13788,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230658"
                     },
@@ -13156,7 +13834,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "230658"
             },
@@ -13179,7 +13859,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230621"
                     },
@@ -13223,7 +13905,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230621"
                     },
@@ -13267,7 +13951,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "230621"
                     },
@@ -13311,7 +13997,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "230621"
             },
@@ -13334,7 +14022,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "226753"
                     },
@@ -13378,7 +14068,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "226753"
                     },
@@ -13422,7 +14114,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "226753"
                     },
@@ -13466,7 +14160,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "226753"
             },
@@ -13489,7 +14185,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "223848"
                     },
@@ -13533,7 +14231,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "223848"
                     },
@@ -13577,7 +14277,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "223848"
                     },
@@ -13621,7 +14323,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "223848"
             },
@@ -13644,7 +14348,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216594"
                     },
@@ -13688,7 +14394,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216594"
                     },
@@ -13732,7 +14440,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216594"
                     },
@@ -13776,7 +14486,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "216594"
             },
@@ -13799,7 +14511,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216460"
                     },
@@ -13843,7 +14557,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216460"
                     },
@@ -13887,7 +14603,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "216460"
                     },
@@ -13931,7 +14649,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "216460"
             },
@@ -13954,7 +14674,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212190"
                     },
@@ -13998,7 +14720,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212190"
                     },
@@ -14042,7 +14766,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "212190"
                     },
@@ -14086,7 +14812,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "212190"
             },
@@ -14109,7 +14837,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208421"
                     },
@@ -14153,7 +14883,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208421"
                     },
@@ -14197,7 +14929,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "208421"
                     },
@@ -14241,7 +14975,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "208421"
             },
@@ -14264,7 +15000,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "206113"
                     },
@@ -14308,7 +15046,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "206113"
                     },
@@ -14352,7 +15092,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "206113"
                     },
@@ -14396,7 +15138,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "206113"
             },
@@ -14419,7 +15163,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "205600"
                     },
@@ -14463,7 +15209,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "205600"
                     },
@@ -14507,7 +15255,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "205600"
                     },
@@ -14551,7 +15301,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "205600"
             },
@@ -14574,7 +15326,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204963"
                     },
@@ -14618,7 +15372,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204963"
                     },
@@ -14662,7 +15418,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "204963"
                     },
@@ -14706,7 +15464,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "204963"
             },
@@ -14729,7 +15489,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198706"
                     },
@@ -14773,7 +15535,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198706"
                     },
@@ -14817,7 +15581,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198706"
                     },
@@ -14861,7 +15627,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "198706"
             },
@@ -14884,7 +15652,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198176"
                     },
@@ -14928,7 +15698,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198176"
                     },
@@ -14972,7 +15744,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "198176"
                     },
@@ -15016,7 +15790,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "198176"
             },
@@ -15039,7 +15815,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197965"
                     },
@@ -15083,7 +15861,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197965"
                     },
@@ -15127,7 +15907,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197965"
                     },
@@ -15171,7 +15953,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "197965"
             },
@@ -15194,7 +15978,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197781"
                     },
@@ -15238,7 +16024,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197781"
                     },
@@ -15282,7 +16070,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "197781"
                     },
@@ -15326,7 +16116,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "197781"
             },
@@ -15349,7 +16141,9 @@
         "relationships": [
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192629"
                     },
@@ -15393,7 +16187,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192629"
                     },
@@ -15437,7 +16233,9 @@
             },
             {
                 "from_node": {
-                    "additional_types": [],
+                    "additional_types": [
+                        "Person"
+                    ],
                     "key_values": {
                         "player_id": "192629"
                     },
@@ -15481,7 +16279,9 @@
             }
         ],
         "source": {
-            "additional_types": [],
+            "additional_types": [
+                "Person"
+            ],
             "key_values": {
                 "player_id": "192629"
             },

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
@@ -1,0 +1,860 @@
+
+
+type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    overall: String
+
+    age: String
+
+    hits: String
+
+    last_ingested_at: DateTime
+
+    position: String
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    competesAtPosition: Position
+        @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Competitor @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    overall: String
+
+    position: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    competesAtPosition: Position
+        @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    playerOriginatesFrom: [Player!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    personOriginatesFrom: [Person!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    athleteOriginatesFrom: [Athlete!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    personLivesIn: [Person!]!
+        @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
+    
+
+    
+    humanOriginatesFrom: [Human!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    individualOriginatesFrom: [Individual!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    humanLivesIn: [Human!]!
+        @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
+    
+
+    
+    individualLivesIn: [Individual!]!
+        @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
+    
+
+    
+    competitorOriginatesFrom: [Competitor!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    sportsPersonOriginatesFrom: [SportsPerson!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
+    
+    organizationBasedIn: [Organization!]!
+        @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
+    
+
+    
+    entityBasedIn: [Entity!]!
+        @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
+    
+
+    
+    legalEntityBasedIn: [LegalEntity!]!
+        @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
+    
+
+    # Outbound Relationships
+
+}
+
+type Entity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    country: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    athletePlaysFor: [Athlete!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    humanPlaysFor: [Human!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    individualPlaysFor: [Individual!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    competitorPlaysFor: [Competitor!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    sportsPersonPlaysFor: [SportsPerson!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    # Outbound Relationships
+
+    
+    basedInCountry: Country
+        @relationship(type: "BASED_IN", direction: OUT, properties: "BasedIn")
+    
+
+}
+
+type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    potential: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    livesInCountry: Country
+        @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    potential: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    livesInCountry: Country
+        @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type LegalEntity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    country: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    athletePlaysFor: [Athlete!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    humanPlaysFor: [Human!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    individualPlaysFor: [Individual!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    competitorPlaysFor: [Competitor!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    sportsPersonPlaysFor: [SportsPerson!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    # Outbound Relationships
+
+    
+    basedInCountry: Country
+        @relationship(type: "BASED_IN", direction: OUT, properties: "BasedIn")
+    
+
+}
+
+type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: DateTime
+
+    country: String
+
+    # Inbound Relationships
+
+    
+    playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    athletePlaysFor: [Athlete!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    humanPlaysFor: [Human!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    individualPlaysFor: [Individual!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    competitorPlaysFor: [Competitor!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    sportsPersonPlaysFor: [SportsPerson!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    # Outbound Relationships
+
+    
+    basedInCountry: Country
+        @relationship(type: "BASED_IN", direction: OUT, properties: "BasedIn")
+    
+
+}
+
+type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    overall: String
+
+    age: String
+
+    hits: String
+
+    last_ingested_at: DateTime
+
+    potential: String
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    livesInCountry: Country
+        @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    overall: String
+
+    age: String
+
+    hits: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    athleteCompetesAt: [Athlete!]!
+        @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
+    
+
+    
+    competitorCompetesAt: [Competitor!]!
+        @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
+    
+
+    
+    sportsPersonCompetesAt: [SportsPerson!]!
+        @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
+    
+
+    # Outbound Relationships
+
+}
+
+type SportsClub @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    athletePlaysFor: [Athlete!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    humanPlaysFor: [Human!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    individualPlaysFor: [Individual!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    competitorPlaysFor: [Competitor!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    sportsPersonPlaysFor: [SportsPerson!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    # Outbound Relationships
+
+}
+
+type SportsPerson @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    overall: String
+
+    position: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    teamMemberIsPlayer: [TeamMember!]!
+        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
+    
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForOrganization: Organization
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForSportsClub: SportsClub
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    competesAtPosition: Position
+        @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
+    
+
+    
+    playsForEntity: Entity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+    
+    playsForLegalEntity: LegalEntity
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
+
+}
+
+type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    name: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    
+    playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    athletePlaysFor: [Athlete!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    humanPlaysFor: [Human!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    individualPlaysFor: [Individual!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    competitorPlaysFor: [Competitor!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    sportsPersonPlaysFor: [SportsPerson!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    # Outbound Relationships
+
+}
+
+type TeamMember @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    member_id: String
+
+    name: String
+
+    team_name: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    # Outbound Relationships
+
+    
+    isPlayerPlayer: Player
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerPerson: Person
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerAthlete: Athlete
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerHuman: Human
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerIndividual: Individual
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerCompetitor: Competitor
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+    
+    isPlayerSportsPerson: SportsPerson
+        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
+    
+
+}
+interface OriginatesFrom @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}
+interface PlaysFor @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}
+interface LivesIn @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}
+interface CompetesAt @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}
+interface IsPlayer @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}
+interface BasedIn @relationshipProperties {
+
+    last_ingested_at: DateTime
+
+}

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
@@ -1,0 +1,84 @@
+[RELATIONSHIP] ORIGINATES_FROM:
+  last_ingested_at: DATETIME
+[NODE] Country:
+  name: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] PLAYS_FOR:
+  last_ingested_at: DATETIME
+[NODE] Team:
+  name: STRING
+  last_ingested_at: DATETIME
+[NODE] Organization:
+  name: STRING
+  last_ingested_at: DATETIME
+  country: STRING
+[NODE] SportsClub:
+  name: STRING
+  last_ingested_at: DATETIME
+[NODE] Player:
+  player_id: STRING
+  name: STRING
+  overall: STRING
+  age: STRING
+  hits: STRING
+  last_ingested_at: DATETIME
+[NODE] Person:
+  player_id: STRING
+  name: STRING
+  overall: STRING
+  age: STRING
+  hits: STRING
+  last_ingested_at: DATETIME
+  potential: STRING
+[NODE] Athlete:
+  player_id: STRING
+  name: STRING
+  overall: STRING
+  age: STRING
+  hits: STRING
+  last_ingested_at: DATETIME
+  position: STRING
+[RELATIONSHIP] LIVES_IN:
+  last_ingested_at: DATETIME
+[NODE] Human:
+  player_id: STRING
+  name: STRING
+  potential: STRING
+  last_ingested_at: DATETIME
+[NODE] Individual:
+  player_id: STRING
+  name: STRING
+  potential: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] COMPETES_AT:
+  last_ingested_at: DATETIME
+[NODE] Position:
+  name: STRING
+  last_ingested_at: DATETIME
+[NODE] Competitor:
+  player_id: STRING
+  overall: STRING
+  position: STRING
+  last_ingested_at: DATETIME
+[NODE] SportsPerson:
+  player_id: STRING
+  overall: STRING
+  position: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] IS_PLAYER:
+  last_ingested_at: DATETIME
+[NODE] TeamMember:
+  member_id: STRING
+  name: STRING
+  team_name: STRING
+  last_ingested_at: DATETIME
+[RELATIONSHIP] BASED_IN:
+  last_ingested_at: DATETIME
+[NODE] Entity:
+  name: STRING
+  country: STRING
+  last_ingested_at: DATETIME
+[NODE] LegalEntity:
+  name: STRING
+  country: STRING
+  last_ingested_at: DATETIME

--- a/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_graphql.txt
@@ -14,7 +14,50 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
         @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
     
 
+    
+    personOriginatesFrom: [Person!]!
+        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
+    
+
     # Outbound Relationships
+
+}
+
+type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
+    # Node Properties
+
+    player_id: String
+
+    name: String
+
+    overall: String
+
+    hits: String
+
+    age: String
+
+    potential: String
+
+    last_ingested_at: DateTime
+
+    # Inbound Relationships
+
+    # Outbound Relationships
+
+    
+    originatesFromCountry: Country
+        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
+    
+
+    
+    linesUpAtPosition: Position
+        @relationship(type: "LINES_UP_AT", direction: OUT, properties: "LinesUpAt")
+    
+
+    
+    playsForTeam: Team
+        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
+    
 
 }
 
@@ -70,6 +113,11 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit
         @relationship(type: "LINES_UP_AT", direction: IN, properties: "LinesUpAt")
     
 
+    
+    personLinesUpAt: [Person!]!
+        @relationship(type: "LINES_UP_AT", direction: IN, properties: "LinesUpAt")
+    
+
     # Outbound Relationships
 
 }
@@ -85,6 +133,11 @@ type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {d
 
     
     playerPlaysFor: [Player!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
+
+    
+    personPlaysFor: [Person!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 

--- a/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_fifa_2021_player_data.yaml_plain.txt
@@ -21,3 +21,11 @@
   age: STRING
   potential: STRING
   last_ingested_at: DATETIME
+[NODE] Person:
+  player_id: STRING
+  name: STRING
+  overall: STRING
+  hits: STRING
+  age: STRING
+  potential: STRING
+  last_ingested_at: DATETIME

--- a/tests/integration/test_pipeline_and_data_interpretation.py
+++ b/tests/integration/test_pipeline_and_data_interpretation.py
@@ -88,6 +88,8 @@ async def test_pipeline_interpretation_snapshot(
         ("dns.yaml", "graphql"),
         ("multiple_passes.yaml", "plain"),
         ("multiple_passes.yaml", "graphql"),
+        ("additional_types_schema_test.yaml", "plain"),
+        ("additional_types_schema_test.yaml", "graphql"),
     ],
 )
 async def test_pipeline_schema_inference(pipeline_name, format, snapshot):

--- a/tests/unit/interpreting/interpretations/test_additional_types_schema_expansion.py
+++ b/tests/unit/interpreting/interpretations/test_additional_types_schema_expansion.py
@@ -1,0 +1,173 @@
+"""Tests for additional_types schema expansion feature."""
+
+from hamcrest import assert_that, equal_to, has_items
+
+from nodestream.interpreting.interpretations import (
+    RelationshipInterpretation,
+    SourceNodeInterpretation,
+)
+from nodestream.schema import Schema, SchemaExpansionCoordinator
+
+
+def test_source_node_additional_types_expand_schema():
+    """Test that additional_types are expanded in the schema with the same structure as the main node."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        properties={"name": "test_name", "age": 25},
+        additional_types=["Person", "Athlete"],
+    )
+
+    interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    # Check that all three node types exist
+    assert_that(schema.has_node_of_type("Player"), equal_to(True))
+    assert_that(schema.has_node_of_type("Person"), equal_to(True))
+    assert_that(schema.has_node_of_type("Athlete"), equal_to(True))
+
+    # Check that Person has the same properties as Player
+    player_schema = schema.get_node_type_by_name("Player")
+    person_schema = schema.get_node_type_by_name("Person")
+    athlete_schema = schema.get_node_type_by_name("Athlete")
+
+    assert_that(person_schema.keys, equal_to(player_schema.keys))
+    assert_that(athlete_schema.keys, equal_to(player_schema.keys))
+    assert_that(
+        set(person_schema.properties.keys()),
+        equal_to(set(player_schema.properties.keys())),
+    )
+    assert_that(
+        set(athlete_schema.properties.keys()),
+        equal_to(set(player_schema.properties.keys())),
+    )
+
+
+def test_source_node_and_relationship_additional_types_create_adjacencies():
+    """Test that relationships are created for both main node and additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Create source node with additional types
+    source_interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        additional_types=["Person"],
+    )
+
+    # Create relationship
+    rel_interpretation = RelationshipInterpretation(
+        node_type="Team",
+        relationship_type="PLAYS_FOR",
+        node_key={"team_id": "test_team"},
+    )
+
+    source_interpretation.expand_schema(coordinator)
+    rel_interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    # Check that adjacencies exist for both Player and Person
+    adjacency_pairs = [
+        (adj.from_node_type, adj.to_node_type) for adj in schema.adjacencies
+    ]
+
+    assert_that(
+        adjacency_pairs,
+        has_items(
+            ("Player", "Team"),
+            ("Person", "Team"),
+        ),
+    )
+
+
+def test_relationship_node_additional_types_create_adjacencies():
+    """Test that related nodes with additional types also get relationships."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Create source node
+    source_interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+    )
+
+    # Create relationship with node that has additional types
+    rel_interpretation = RelationshipInterpretation(
+        node_type="Team",
+        relationship_type="PLAYS_FOR",
+        node_key={"team_id": "test_team"},
+        node_additional_types=["Organization"],
+    )
+
+    source_interpretation.expand_schema(coordinator)
+    rel_interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    # Check that adjacencies exist for both Team and Organization
+    adjacency_pairs = [
+        (adj.from_node_type, adj.to_node_type) for adj in schema.adjacencies
+    ]
+
+    assert_that(
+        adjacency_pairs,
+        has_items(
+            ("Player", "Team"),
+            ("Player", "Organization"),
+        ),
+    )
+
+    # Check that both Team and Organization have the same schema
+    team_schema = schema.get_node_type_by_name("Team")
+    org_schema = schema.get_node_type_by_name("Organization")
+
+    assert_that(
+        set(team_schema.properties.keys()), equal_to(set(org_schema.properties.keys()))
+    )
+
+
+def test_both_source_and_related_node_have_additional_types():
+    """Test the full feature with both source and related nodes having additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Create source node with additional types
+    source_interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        additional_types=["Person", "Athlete"],
+    )
+
+    # Create relationship with node that has additional types
+    rel_interpretation = RelationshipInterpretation(
+        node_type="Team",
+        relationship_type="PLAYS_FOR",
+        node_key={"team_id": "test_team"},
+        node_additional_types=["Organization"],
+    )
+
+    source_interpretation.expand_schema(coordinator)
+    rel_interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    # Check that all adjacencies exist
+    adjacency_pairs = [
+        (adj.from_node_type, adj.to_node_type) for adj in schema.adjacencies
+    ]
+
+    # Player -> Team, Player -> Organization
+    # Person -> Team, Person -> Organization
+    # Athlete -> Team, Athlete -> Organization
+    assert_that(
+        adjacency_pairs,
+        has_items(
+            ("Player", "Team"),
+            ("Player", "Organization"),
+            ("Person", "Team"),
+            ("Person", "Organization"),
+            ("Athlete", "Team"),
+            ("Athlete", "Organization"),
+        ),
+    )

--- a/tests/unit/schema/migrations/test_additional_types_migrations.py
+++ b/tests/unit/schema/migrations/test_additional_types_migrations.py
@@ -1,0 +1,312 @@
+"""Tests for migration generation with additional_types feature."""
+
+import pytest
+from hamcrest import (
+    assert_that,
+    contains_inanyorder,
+    equal_to,
+    greater_than,
+    has_item,
+    has_length,
+)
+
+from nodestream.interpreting.interpretations import (
+    RelationshipInterpretation,
+    SourceNodeInterpretation,
+)
+from nodestream.schema import Schema, SchemaExpansionCoordinator
+from nodestream.schema.migrations import (
+    MigrationGraph,
+    MigratorInput,
+    ProjectMigrations,
+)
+from nodestream.schema.migrations.operations import (
+    AddAdditionalNodePropertyIndex,
+    CreateNodeType,
+)
+
+
+@pytest.fixture
+def empty_migration_graph():
+    """An empty migration graph (starting state with no migrations)."""
+    return MigrationGraph.from_iterable([])
+
+
+@pytest.fixture
+def subject(empty_migration_graph, tmp_path):
+    """A ProjectMigrations instance for testing."""
+    return ProjectMigrations(empty_migration_graph, tmp_path)
+
+
+@pytest.fixture
+def schema_with_additional_types():
+    """A schema with a source node that has additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Create source node with additional types
+    interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        properties={"name": "test_name", "age": 25},
+        additional_indexes=["name"],  # Index on name property
+        additional_types=["Person", "Athlete"],
+    )
+
+    interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    return schema
+
+
+@pytest.fixture
+def schema_with_relationship_additional_types():
+    """A schema with relationships involving additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Source node with additional types
+    source_interpretation = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        additional_types=["Person"],
+    )
+
+    # Relationship where related node has additional types
+    rel_interpretation = RelationshipInterpretation(
+        node_type="Team",
+        relationship_type="PLAYS_FOR",
+        node_key={"team_id": "test_team"},
+        node_additional_types=["Organization", "SportsClub"],
+    )
+
+    source_interpretation.expand_schema(coordinator)
+    rel_interpretation.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    return schema
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_additional_node_types(
+    subject, schema_with_additional_types
+):
+    """Test that migrations are created for additional node types."""
+    migration = await subject.detect_changes(
+        MigratorInput(), schema_with_additional_types
+    )
+
+    # Should have operations for Player, Person, and Athlete
+    assert_that(migration.operations, has_length(greater_than(0)))
+
+    # Find all CreateNodeType operations
+    create_node_ops = [
+        op for op in migration.operations if isinstance(op, CreateNodeType)
+    ]
+
+    # Should have CreateNodeType for all three types
+    assert_that(create_node_ops, has_length(3))
+
+    node_names = [op.name for op in create_node_ops]
+    assert_that(node_names, contains_inanyorder("Player", "Person", "Athlete"))
+
+    # All three should have the same keys
+    for op in create_node_ops:
+        assert_that(set(op.keys), equal_to({"player_id"}))
+
+    # All three should have the same properties (keys are separate from properties)
+    for op in create_node_ops:
+        assert_that(set(op.properties), equal_to({"name", "age", "last_ingested_at"}))
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_indexes_for_additional_types(
+    subject, schema_with_additional_types
+):
+    """Test that index operations are created for additional types."""
+    migration = await subject.detect_changes(
+        MigratorInput(), schema_with_additional_types
+    )
+
+    # Find all AddAdditionalNodePropertyIndex operations
+    index_ops = [
+        op
+        for op in migration.operations
+        if isinstance(op, AddAdditionalNodePropertyIndex)
+    ]
+
+    # Should have index operations for all three types (Player, Person, Athlete)
+    # Each should have indexes on: name, last_ingested_at
+    assert_that(index_ops, has_length(greater_than(0)))
+
+    # Check that indexes are created for additional types
+    index_node_types = [op.node_type for op in index_ops]
+    assert_that(index_node_types, has_item("Person"))
+    assert_that(index_node_types, has_item("Athlete"))
+
+    # Check that the name index exists for Person
+    person_name_index = next(
+        (
+            op
+            for op in index_ops
+            if op.node_type == "Person" and op.field_name == "name"
+        ),
+        None,
+    )
+    assert_that(person_name_index is not None, equal_to(True))
+
+    # Check that the name index exists for Athlete
+    athlete_name_index = next(
+        (
+            op
+            for op in index_ops
+            if op.node_type == "Athlete" and op.field_name == "name"
+        ),
+        None,
+    )
+    assert_that(athlete_name_index is not None, equal_to(True))
+
+
+@pytest.mark.asyncio
+async def test_migration_handles_relationship_additional_types(
+    subject, schema_with_relationship_additional_types
+):
+    """Test that migrations handle additional types on related nodes."""
+    migration = await subject.detect_changes(
+        MigratorInput(), schema_with_relationship_additional_types
+    )
+
+    create_node_ops = [
+        op for op in migration.operations if isinstance(op, CreateNodeType)
+    ]
+
+    node_names = [op.name for op in create_node_ops]
+
+    # Should create nodes for: Player, Person (additional), Team, Organization (additional), SportsClub (additional)
+    assert_that(
+        node_names,
+        contains_inanyorder("Player", "Person", "Team", "Organization", "SportsClub"),
+    )
+
+    # Team, Organization, and SportsClub should all have same keys
+    team_ops = [
+        op
+        for op in create_node_ops
+        if op.name in ("Team", "Organization", "SportsClub")
+    ]
+    for op in team_ops:
+        assert_that(set(op.keys), equal_to({"team_id"}))
+
+
+@pytest.mark.asyncio
+async def test_migration_merges_overlapping_additional_types(subject):
+    """Test that migrations handle types that appear both as main and additional types."""
+    # Start with Player -> Person (additional)
+    schema1 = Schema()
+    coord1 = SchemaExpansionCoordinator(schema1)
+
+    source1 = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        properties={"name": "test"},
+        additional_types=["Person"],
+    )
+    source1.expand_schema(coord1)
+    coord1.clear_aliases()
+
+    # Now Person becomes main type with additional properties
+    schema2 = Schema()
+    coord2 = SchemaExpansionCoordinator(schema2)
+
+    source1_copy = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "test_id"},
+        properties={"name": "test"},
+        additional_types=["Person"],
+    )
+
+    source2 = SourceNodeInterpretation(
+        node_type="Person",
+        key={"player_id": "test_id"},  # Same key!
+        properties={"age": 30},  # Additional property
+    )
+
+    source1_copy.expand_schema(coord2)
+    source2.expand_schema(coord2)
+    coord2.clear_aliases()
+
+    # Generate migration from schema1 to schema2
+    migration = await subject.detect_changes(MigratorInput(), schema2)
+
+    # Person should have properties from both contexts
+    create_node_ops = [
+        op for op in migration.operations if isinstance(op, CreateNodeType)
+    ]
+
+    person_op = next((op for op in create_node_ops if op.name == "Person"), None)
+    assert_that(person_op is not None, equal_to(True))
+
+    # Person should have both 'name' (from Player) and 'age' (from Person definition)
+    assert_that("name" in person_op.properties, equal_to(True))
+    assert_that("age" in person_op.properties, equal_to(True))
+
+
+@pytest.mark.asyncio
+async def test_migration_with_multiple_passes(subject):
+    """Test migration with complex multi-pass additional types scenario."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Pass 1: Player with Person and Athlete as additional
+    pass1 = SourceNodeInterpretation(
+        node_type="Player",
+        key={"player_id": "id1"},
+        properties={"name": "test", "score": 100},
+        additional_types=["Person", "Athlete"],
+    )
+
+    # Pass 2: Person as main with Human as additional
+    pass2 = SourceNodeInterpretation(
+        node_type="Person",
+        key={"player_id": "id1"},
+        properties={"birth_year": 1990},
+        additional_types=["Human"],
+    )
+
+    # Pass 3: Athlete as main with Competitor as additional
+    pass3 = SourceNodeInterpretation(
+        node_type="Athlete",
+        key={"player_id": "id1"},
+        properties={"sport": "football"},
+        additional_types=["Competitor"],
+    )
+
+    pass1.expand_schema(coordinator)
+    pass2.expand_schema(coordinator)
+    pass3.expand_schema(coordinator)
+    coordinator.clear_aliases()
+
+    migration = await subject.detect_changes(MigratorInput(), schema)
+
+    create_node_ops = [
+        op for op in migration.operations if isinstance(op, CreateNodeType)
+    ]
+
+    node_names = [op.name for op in create_node_ops]
+
+    # Should have all node types
+    assert_that(
+        node_names,
+        contains_inanyorder("Player", "Person", "Athlete", "Human", "Competitor"),
+    )
+
+    # Verify merged properties
+    person_op = next((op for op in create_node_ops if op.name == "Person"), None)
+    assert_that("name" in person_op.properties, equal_to(True))  # From Player
+    assert_that("score" in person_op.properties, equal_to(True))  # From Player
+    assert_that("birth_year" in person_op.properties, equal_to(True))  # From Person
+
+    athlete_op = next((op for op in create_node_ops if op.name == "Athlete"), None)
+    assert_that("name" in athlete_op.properties, equal_to(True))  # From Player
+    assert_that("score" in athlete_op.properties, equal_to(True))  # From Player
+    assert_that("sport" in athlete_op.properties, equal_to(True))  # From Athlete


### PR DESCRIPTION
Schema Generation Change: 
- Additional labels within an ingest will now expose all the relationships and properties available to the original node_type or related_node_type.


For example: 

```
      - - type: source_node
          node_type: Player
          key:
            player_id: !jmespath player_id
          properties:
            name: !jmespath name
            overall: !jmespath overall
          additional_types:
            - Person
        - type: relationship
          node_type: Country
          relationship_type: ORIGINATES_FROM
          node_key:
            name: !jmespath nationality
```

Will expand into a Player -ORIGINATES_FROM> Country and Person - ORIGINATES_FROM > Country
Player and Person will also share and expose the same properties and keys when the schema is expanded. 

This has the side effect of creating indexes for additional labels with the same keys, and checks for key consistency across additional labels.