### PR TITLE
Schema Expansion Fixes, Improving Copy pipeline.

### DIFF
--- a/nodestream/cli/operations/execute_migration.py
+++ b/nodestream/cli/operations/execute_migration.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 from ...project import Target
 from ...schema.migrations import ProjectMigrations
 from .operation import NodestreamCommand, Operation
@@ -10,11 +12,16 @@ class ExecuteMigrations(Operation):
 
     async def perform(self, command: NodestreamCommand):
         migrator = self.target.make_migrator()
-        with command.spin(
-            f"Executing migrations on target {self.target.name}...",
-            f"Migrations executed on target {self.target.name}.",
-        ) as indicator:
+        if command.has_json_logging_set:
+            logger = getLogger()
             async for migration in self.migrations.execute_pending(migrator):
-                indicator.set_message(
-                    f"Migration {migration.name} executed successfully."
-                )
+                logger.info(f"Migration {migration.name} executed successfully.")
+        else:
+            with command.spin(
+                f"Executing migrations on target {self.target.name}...",
+                f"Migrations executed on target {self.target.name}.",
+            ) as indicator:
+                async for migration in self.migrations.execute_pending(migrator):
+                    indicator.set_message(
+                        f"Migration {migration.name} executed successfully."
+                    )

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -17,13 +17,6 @@ class TypeRetriever(ABC):
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
         raise NotImplementedError
 
-    @abstractmethod
-    def get_relationships_of_type(
-        self, relationship_type: str
-    ) -> AsyncGenerator[RelationshipWithNodes, None]:
-        """Retrieve relationships when concrete from/to node types are not declared."""
-        raise NotImplementedError
-
 
 class Copier(Extractor):
     def __init__(
@@ -45,29 +38,20 @@ class Copier(Extractor):
 
         for rel_type in self.relationship_types:
             # Prefer schema-driven adjacency expansion when available so we can
-            # fully specify from/to node types for the retriever.
+            # fully specify from/to node types for the retriever. Note that it
+            # is impossible to have a relationship without an adjacency, we only
+            # support copyting from a nodestream schema.
             adjacencies: List[Adjacency] = list(
                 self.schema.get_adjacencies_by_relationship_type(rel_type)
             )
 
-            if adjacencies:
-                for adjacency in adjacencies:
-                    async for (
-                        relationship
-                    ) in self.type_retriever.get_relationships_of_type_between(
-                        adjacency.from_node_type,
-                        adjacency.to_node_type,
-                        adjacency.relationship_type,
-                    ):
-                        yield self.convert_relationship_to_ingest(relationship)
-            else:
-                # When the schema does not yet carry adjacencies for this
-                # relationship type, fall back to requesting relationships by
-                # type only. The concrete `TypeRetriever` implementation can
-                # decide how to interpret the from/to node semantics in this
-                # schemaless scenario.
-                async for relationship in self.type_retriever.get_relationships_of_type(
-                    rel_type
+            for adjacency in adjacencies:
+                async for (
+                    relationship
+                ) in self.type_retriever.get_relationships_of_type_between(
+                    adjacency.from_node_type,
+                    adjacency.to_node_type,
+                    adjacency.relationship_type,
                 ):
                     yield self.convert_relationship_to_ingest(relationship)
 

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -3,18 +3,25 @@ from typing import AsyncGenerator, List
 
 from ..model import Node, RelationshipWithNodes
 from ..pipeline import Extractor
-from ..schema import Schema
+from ..schema import Adjacency, Schema
 
 
 class TypeRetriever(ABC):
     @abstractmethod
-    def get_nodes_of_type(self, shape: str) -> AsyncGenerator[Node, None]:
+    def get_nodes_of_type(self, node_type: str) -> AsyncGenerator[Node, None]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_relationships_of_type_between(
+        self, from_node_type: str, to_node_type: str, relationship_type: str
+    ) -> AsyncGenerator[RelationshipWithNodes, None]:
         raise NotImplementedError
 
     @abstractmethod
     def get_relationships_of_type(
-        self, type: str
+        self, relationship_type: str
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
+        """Retrieve relationships when concrete from/to node types are not declared."""
         raise NotImplementedError
 
 
@@ -33,14 +40,36 @@ class Copier(Extractor):
 
     async def extract_records(self):
         for node_type in self.node_types:
-            nodes = self.type_retriever.get_nodes_of_type(node_type)
-            async for node in nodes:
+            async for node in self.type_retriever.get_nodes_of_type(node_type):
                 yield self.convert_node_to_ingest(node)
 
         for rel_type in self.relationship_types:
-            rels = self.type_retriever.get_relationships_of_type(rel_type)
-            async for relationship in rels:
-                yield self.convert_relationship_to_ingest(relationship)
+            # Prefer schema-driven adjacency expansion when available so we can
+            # fully specify from/to node types for the retriever.
+            adjacencies: List[Adjacency] = list(
+                self.schema.get_adjacencies_by_relationship_type(rel_type)
+            )
+
+            if adjacencies:
+                for adjacency in adjacencies:
+                    async for (
+                        relationship
+                    ) in self.type_retriever.get_relationships_of_type_between(
+                        adjacency.from_node_type,
+                        adjacency.to_node_type,
+                        adjacency.relationship_type,
+                    ):
+                        yield self.convert_relationship_to_ingest(relationship)
+            else:
+                # When the schema does not yet carry adjacencies for this
+                # relationship type, fall back to requesting relationships by
+                # type only. The concrete `TypeRetriever` implementation can
+                # decide how to interpret the from/to node semantics in this
+                # schemaless scenario.
+                async for relationship in self.type_retriever.get_relationships_of_type(
+                    rel_type
+                ):
+                    yield self.convert_relationship_to_ingest(relationship)
 
     def reorganize_node_key_properties(self, node: Node):
         # This is a bit of a hack, but it's the only way to make sure that the
@@ -49,6 +78,8 @@ class Copier(Extractor):
         # we have to push a lot of work down to the database connector to ensure
         # that the keys are in the right place. Its easier to just do it here.
         type_def = self.schema.get_node_type_by_name(node.type)
+        if type_def is None:
+            return
         for key_name in type_def.keys:
             node.key_values[key_name] = node.properties[key_name]
             del node.properties[key_name]

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator, List
 from ..model import Node, RelationshipWithNodes
 from ..pipeline import Extractor
 from ..schema import Adjacency, Schema
+import logging
 
 
 class TypeRetriever(ABC):
@@ -30,9 +31,14 @@ class Copier(Extractor):
         self.relationship_types = relationship_types_to_copy
         self.node_types = node_types_to_copy
         self.schema = schema
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(
+            f"Copying {len(self.node_types)} node types and {len(self.relationship_types)} relationship types"
+        )
 
     async def extract_records(self):
         for node_type in self.node_types:
+            self.logger.info(f"Copying nodes of type {node_type}")
             async for node in self.type_retriever.get_nodes_of_type(node_type):
                 yield self.convert_node_to_ingest(node)
 
@@ -41,6 +47,7 @@ class Copier(Extractor):
             # fully specify from/to node types for the retriever. Note that it
             # is impossible to have a relationship without an adjacency, we only
             # support copyting from a nodestream schema.
+            self.logger.info(f"Copying relationships of type {rel_type}")
             adjacencies: List[Adjacency] = list(
                 self.schema.get_adjacencies_by_relationship_type(rel_type)
             )

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -1,10 +1,10 @@
+import logging
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List
 
 from ..model import Node, RelationshipWithNodes
 from ..pipeline import Extractor
 from ..schema import Adjacency, Schema
-import logging
 
 
 class TypeRetriever(ABC):

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -1,5 +1,5 @@
-import logging
 from abc import ABC, abstractmethod
+from logging import getLogger
 from typing import AsyncGenerator, List
 
 from ..model import Node, RelationshipWithNodes
@@ -31,7 +31,7 @@ class Copier(Extractor):
         self.relationship_types = relationship_types_to_copy
         self.node_types = node_types_to_copy
         self.schema = schema
-        self.logger = logging.getLogger(__name__)
+        self.logger = getLogger(__name__)
         self.logger.info(
             f"Copying {len(self.node_types)} node types and {len(self.relationship_types)} relationship types"
         )

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -50,6 +50,11 @@ class NullRetriver(TypeRetriever):
     def get_nodes_of_type(self, _: str) -> AsyncGenerator[Node, None]:
         return empty_async_generator()
 
+    def get_relationships_of_type_between(
+        self, __: str, ___: str, ____: str
+    ) -> AsyncGenerator[RelationshipWithNodes, None]:
+        return empty_async_generator()
+
     def get_relationships_of_type(
         self, _: str
     ) -> AsyncGenerator[RelationshipWithNodes, None]:

--- a/nodestream/interpreting/interpretations/relationship_interpretation.py
+++ b/nodestream/interpreting/interpretations/relationship_interpretation.py
@@ -222,22 +222,19 @@ class RelationshipInterpretation(Interpretation, alias="relationship"):
             )
 
         if self.node_type.is_static:
+            # Always expand the schema for the main related node type.
             coordinator.on_node_schema(
                 self.expand_related_node_schema,
                 node_type=self.node_type.value,
             )
 
-            # Expand schemas for node additional types with the same structure
-            for additional_type in self.node_additional_types:
-                coordinator.on_node_schema(
-                    self.expand_related_node_schema,
-                    node_type=additional_type,
-                )
-
-            # Register additional types so relationships are also connected to them
-            coordinator.register_additional_types(
-                self.node_type.value,
-                self.node_additional_types,
+            # Delegate additional-type expansion to the coordinator so that the
+            # decision about whether to include additional types in the schema
+            # is centralized there.
+            coordinator.expand_additional_types(
+                base_type=self.node_type.value,
+                additional_types=self.node_additional_types,
+                fn=self.expand_related_node_schema,
             )
 
         if self.relationship_type.is_static and self.node_type.is_static:

--- a/nodestream/interpreting/interpretations/source_node_interpretation.py
+++ b/nodestream/interpreting/interpretations/source_node_interpretation.py
@@ -152,37 +152,24 @@ class SourceNodeInterpretation(Interpretation, alias="source_node"):
             return
 
         # First, bind the source-node alias to the concrete base node type and
-        # apply this interpretation's keys / properties / indexes to it.
+        # apply this interpretation's keys / properties / indexes to it. Any
+        # additional properties contributed via `properties` interpretations are
+        # accumulated on the alias and later propagated to additional types by
+        # the `SchemaExpansionCoordinator`.
         coordinator.on_node_schema(
             self.expand_source_node_schema,
             alias=self.SOURCE_NODE_TYPE_ALIAS,
             node_type=self.node_type.value,
         )
 
-        # Capture any properties that were accumulated on the alias from
-        # `properties` interpretations in this context so they can also be
-        # applied to additional types for this source.
-        alias_schema = coordinator.unbound_aliases.get(
-            self.SOURCE_NODE_TYPE_ALIAS, None
+        # Delegate additional-type expansion to the coordinator so that the
+        # decision about whether to Cinclude additional types in the schema is
+        # centralized there.
+        coordinator.expand_additional_types(
+            base_type=self.node_type.value,
+            additional_types=self.additional_types,
+            fn=self.expand_source_node_schema,
         )
-
-        # Expand schemas for additional types with the same structure. In
-        # addition to this interpretation's own keys/properties/indexes, also
-        # apply any alias-level properties (from `properties` interpretations)
-        # so that additional types for this source carry the same contextual
-        # properties as the base type within this interpretation pass.
-        for additional_type in self.additional_types:
-            coordinator.on_node_schema(
-                self.expand_source_node_schema,
-                node_type=additional_type,
-            )
-
-            if alias_schema is not None:
-                additional_schema = coordinator.schema.get_node_type_by_name(
-                    additional_type
-                )
-                for property_name, metadata in alias_schema.properties.items():
-                    additional_schema.add_property(property_name, metadata)
 
         # Register additional types so relationships are also connected to them
         coordinator.register_additional_types(

--- a/nodestream/interpreting/interpretations/source_node_interpretation.py
+++ b/nodestream/interpreting/interpretations/source_node_interpretation.py
@@ -151,18 +151,38 @@ class SourceNodeInterpretation(Interpretation, alias="source_node"):
         if not self.node_type.is_static:
             return
 
+        # First, bind the source-node alias to the concrete base node type and
+        # apply this interpretation's keys / properties / indexes to it.
         coordinator.on_node_schema(
             self.expand_source_node_schema,
             alias=self.SOURCE_NODE_TYPE_ALIAS,
             node_type=self.node_type.value,
         )
 
-        # Expand schemas for additional types with the same structure
+        # Capture any properties that were accumulated on the alias from
+        # `properties` interpretations in this context so they can also be
+        # applied to additional types for this source.
+        alias_schema = coordinator.unbound_aliases.get(
+            self.SOURCE_NODE_TYPE_ALIAS, None
+        )
+
+        # Expand schemas for additional types with the same structure. In
+        # addition to this interpretation's own keys/properties/indexes, also
+        # apply any alias-level properties (from `properties` interpretations)
+        # so that additional types for this source carry the same contextual
+        # properties as the base type within this interpretation pass.
         for additional_type in self.additional_types:
             coordinator.on_node_schema(
                 self.expand_source_node_schema,
                 node_type=additional_type,
             )
+
+            if alias_schema is not None:
+                additional_schema = coordinator.schema.get_node_type_by_name(
+                    additional_type
+                )
+                for property_name, metadata in alias_schema.properties.items():
+                    additional_schema.add_property(property_name, metadata)
 
         # Register additional types so relationships are also connected to them
         coordinator.register_additional_types(

--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -224,7 +224,7 @@ class RelationshipWithNodes(DeduplicatableObject):
             self.relationship,
             outbound=True,
             node_creation_rule=NodeCreationRule.MATCH_ONLY,
-            relationship_creation_rule=RelationshipCreationRule.CREATE,
+            relationship_creation_rule=RelationshipCreationRule.EAGER,
         )
         return ingest
 

--- a/nodestream/schema/__init__.py
+++ b/nodestream/schema/__init__.py
@@ -10,6 +10,7 @@ from .state import (
     PropertyType,
     Schema,
     SchemaExpansionCoordinator,
+    UnboundAdjacency,
 )
 
 __all__ = (
@@ -24,4 +25,5 @@ __all__ = (
     "Adjacency",
     "PropertyMetadata",
     "PropertyType",
+    "UnboundAdjacency",
 )

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -861,9 +861,10 @@ class SchemaExpansionCoordinator:
         if additional_types and self.include_additional_types:
             # Merge with any existing additional types for this main_type in the
             # current context level so that multiple registrations in the same
-            # context accumulate rather than overwrite.
+            # context accumulate rather than overwrite. Preserve a stable
+            # insertion order to keep schema expansion deterministic.
             existing = self.additional_types_map.get(main_type, tuple())
-            merged = tuple({*existing, *additional_types})
+            merged = existing + tuple(t for t in additional_types if t not in existing)
             self.additional_types_map[main_type] = merged
 
     def expand_additional_types(

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -693,14 +693,6 @@ class UnboundAdjacency:
     def bind(
         self, schema: Schema, aliases: LayeredDict[str, str]
     ) -> tuple[Adjacency, AdjacencyCardinality]:
-        """Bind this unbound adjacency into the provided schema.
-
-        Returns the concrete `Adjacency` and `AdjacencyCardinality` that were
-        added to the schema. This allows callers (such as the schema expansion
-        coordinator) to reason about exactly which adjacencies were created as
-        part of the current context, without having to reimplement the alias
-        resolution logic here.
-        """
         from_type = aliases.get(self.from_type_or_alias, self.from_type_or_alias)
         to_type = aliases.get(self.to_type_or_alias, self.to_type_or_alias)
         adjacency = Adjacency(
@@ -721,7 +713,7 @@ class SchemaExpansionCoordinator:
     """A coordinator for expanding a schema."""
 
     schema: Schema
-    include_additional_types: bool = True
+    include_additional_types: bool = False
     aliases: LayeredDict[str, str] = field(default_factory=LayeredDict)
     unbound_aliases: LayeredDict[str, GraphObjectSchema] = field(
         default_factory=LayeredDict

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -691,7 +691,7 @@ class SchemaExpansionCoordinator:
     """A coordinator for expanding a schema."""
 
     schema: Schema
-    include_additional_types: bool = False
+    include_additional_types: bool = True
     aliases: LayeredDict[str, str] = field(default_factory=LayeredDict)
     unbound_aliases: LayeredDict[str, GraphObjectSchema] = field(
         default_factory=LayeredDict
@@ -832,7 +832,7 @@ class SchemaExpansionCoordinator:
             main_type: The main node type.
             additional_types: The additional types associated with the main type.
         """
-        if additional_types:
+        if additional_types and self.include_additional_types:
             self.additional_types_map[main_type] = additional_types
 
     def clear_aliases(self):

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -478,6 +478,15 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
     def adjacencies(self) -> Iterable[Adjacency]:
         return self.cardinalities.keys()
 
+    def get_adjacencies_by_relationship_type(
+        self, relationship_type: str
+    ) -> Iterable[Adjacency]:
+        return (
+            adjacency
+            for adjacency in self.adjacencies
+            if adjacency.relationship_type == relationship_type
+        )
+
     def put_node_type(self, node_type: GraphObjectSchema):
         """Add a node type to the schema.
 
@@ -531,7 +540,9 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
             self.type_schemas[key] = GraphObjectSchema(name)
         return self.type_schemas[key]
 
-    def get_node_type_by_name(self, node_type_name: str) -> GraphObjectSchema:
+    def get_node_type_by_name(
+        self, node_type_name: str | None
+    ) -> Optional[GraphObjectSchema]:
         """Get a node type by name.
 
         If the node type does not exist, a new node type will be created.
@@ -542,6 +553,8 @@ class Schema(SavesToYamlFile, LoadsFromYamlFile):
         Returns:
             The node type.
         """
+        if node_type_name is None:
+            return None
         return self.get_by_type_and_object_type(GraphObjectType.NODE, node_type_name)
 
     def get_relationship_type_by_name(
@@ -677,13 +690,30 @@ class UnboundAdjacency:
     from_cardinality: Cardinality
     to_cardinality: Cardinality
 
-    def bind(self, schema: Schema, aliases: LayeredDict[str, str]):
+    def bind(
+        self, schema: Schema, aliases: LayeredDict[str, str]
+    ) -> tuple[Adjacency, AdjacencyCardinality]:
+        """Bind this unbound adjacency into the provided schema.
+
+        Returns the concrete `Adjacency` and `AdjacencyCardinality` that were
+        added to the schema. This allows callers (such as the schema expansion
+        coordinator) to reason about exactly which adjacencies were created as
+        part of the current context, without having to reimplement the alias
+        resolution logic here.
+        """
         from_type = aliases.get(self.from_type_or_alias, self.from_type_or_alias)
         to_type = aliases.get(self.to_type_or_alias, self.to_type_or_alias)
-        schema.add_adjacency(
-            Adjacency(from_type, to_type, self.relationship_type),
-            AdjacencyCardinality(self.from_cardinality, self.to_cardinality),
+        adjacency = Adjacency(
+            from_node_type=from_type,
+            to_node_type=to_type,
+            relationship_type=self.relationship_type,
         )
+        cardinality = AdjacencyCardinality(
+            self.from_cardinality,
+            self.to_cardinality,
+        )
+        schema.add_adjacency(adjacency, cardinality)
+        return adjacency, cardinality
 
 
 @dataclass(slots=True, frozen=True)
@@ -703,7 +733,9 @@ class SchemaExpansionCoordinator:
         default_factory=LayeredList
     )
     # Maps node types to their additional types for relationship expansion
-    additional_types_map: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
+    additional_types_map: LayeredDict[str, Tuple[str, ...]] = field(
+        default_factory=LayeredDict
+    )
 
     def on_node_schema(
         self,
@@ -814,11 +846,13 @@ class SchemaExpansionCoordinator:
         self.unbound_adjacencies.increment_context_level()
         self.unbound_aliases.increment_context_level()
         self.aliases.increment_context_level()
+        self.additional_types_map.increment_context_level()
 
     def decrement_context_level(self):
         self.unbound_adjacencies.decrement_context_level()
         self.unbound_aliases.decrement_context_level()
         self.aliases.decrement_context_level()
+        self.additional_types_map.decrement_context_level()
 
     def register_additional_types(
         self, main_type: str, additional_types: Tuple[str, ...]
@@ -833,18 +867,27 @@ class SchemaExpansionCoordinator:
             additional_types: The additional types associated with the main type.
         """
         if additional_types and self.include_additional_types:
-            self.additional_types_map[main_type] = additional_types
+            # Merge with any existing additional types for this main_type in the
+            # current context level so that multiple registrations in the same
+            # context accumulate rather than overwrite.
+            existing = self.additional_types_map.get(main_type, tuple())
+            merged = tuple({*existing, *additional_types})
+            self.additional_types_map[main_type] = merged
 
     def clear_aliases(self):
+        # First, bind all unbound adjacencies for this context into concrete
+        # adjacencies on the underlying schema, keeping track of exactly which
+        # adjacencies were created as part of this pass.
+        base_adjacencies: list[tuple[Adjacency, AdjacencyCardinality]] = []
         for unbound_adjacency in self.unbound_adjacencies:
-            unbound_adjacency.bind(self.schema, self.aliases)
+            base_adjacencies.append(unbound_adjacency.bind(self.schema, self.aliases))
 
         if not self.include_additional_types:
             return
 
         # Create duplicate adjacencies for additional types
         adjacencies_to_add = []
-        for adjacency, cardinality in list(self.schema.cardinalities.items()):
+        for adjacency, cardinality in base_adjacencies:
             from_types = [adjacency.from_node_type]
             to_types = [adjacency.to_node_type]
 

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -866,19 +866,56 @@ class SchemaExpansionCoordinator:
             merged = tuple({*existing, *additional_types})
             self.additional_types_map[main_type] = merged
 
+    def expand_additional_types(
+        self,
+        base_type: str,
+        additional_types: Tuple[str, ...],
+        fn: Callable[[GraphObjectSchema], None],
+    ) -> None:
+        """Expand and register additional types for a base node type.
+
+        When `include_additional_types` is enabled, this helper will:
+
+        - Invoke `fn` for each additional type's node schema, so that the
+          additional types share the same structural definition as the base.
+        - Register the additional types so that adjacencies and alias-level
+          properties are also expanded to them during `clear_aliases`.
+        """
+        if not additional_types or not self.include_additional_types:
+            return
+
+        for additional_type in additional_types:
+            self.on_node_schema(fn, node_type=additional_type)
+
+        self.register_additional_types(base_type, additional_types)
+
     def clear_aliases(self):
         # First, bind all unbound adjacencies for this context into concrete
         # adjacencies on the underlying schema, keeping track of exactly which
         # adjacencies were created as part of this pass.
-        base_adjacencies: list[tuple[Adjacency, AdjacencyCardinality]] = []
-        for unbound_adjacency in self.unbound_adjacencies:
-            base_adjacencies.append(unbound_adjacency.bind(self.schema, self.aliases))
+        base_adjacencies = self._bind_unbound_adjacencies()
 
         if not self.include_additional_types:
             return
 
+        # Then duplicate those adjacencies and any alias-level properties for
+        # additional types registered in this context.
+        self._expand_adjacencies_for_additional_types(base_adjacencies)
+        self._expand_properties_for_additional_types()
+
+    def _bind_unbound_adjacencies(
+        self,
+    ) -> list[tuple[Adjacency, AdjacencyCardinality]]:
+        base_adjacencies: list[tuple[Adjacency, AdjacencyCardinality]] = []
+        for unbound_adjacency in self.unbound_adjacencies:
+            base_adjacencies.append(unbound_adjacency.bind(self.schema, self.aliases))
+        return base_adjacencies
+
+    def _expand_adjacencies_for_additional_types(
+        self, base_adjacencies: list[tuple[Adjacency, AdjacencyCardinality]]
+    ) -> None:
         # Create duplicate adjacencies for additional types
-        adjacencies_to_add = []
+        adjacencies_to_add: list[tuple[Adjacency, AdjacencyCardinality]] = []
         for adjacency, cardinality in base_adjacencies:
             from_types = [adjacency.from_node_type]
             to_types = [adjacency.to_node_type]
@@ -908,9 +945,31 @@ class SchemaExpansionCoordinator:
                     )
                     adjacencies_to_add.append((new_adjacency, cardinality))
 
-        # Add all the new adjacencies
         for adjacency, cardinality in adjacencies_to_add:
             self.schema.add_adjacency(adjacency, cardinality)
+
+    def _expand_properties_for_additional_types(self) -> None:
+        """Propagate alias-level properties to additional types in this context.
+
+        Properties defined via `properties` interpretations are accumulated on
+        aliases (for example, the `source_node` alias). When we register
+        additional types for a base node type, those alias-level properties
+        should also be applied to the additional types, but only within the
+        current schema-expansion context.
+        """
+        for alias, base_type in self.aliases.effective_items.items():
+            alias_schema = self.unbound_aliases.get(alias, None)
+            if alias_schema is None:
+                continue
+
+            additional_types = self.additional_types_map.get(base_type, tuple())
+            if not additional_types:
+                continue
+
+            for additional_type in additional_types:
+                target_schema = self.schema.get_node_type_by_name(additional_type)
+                for property_name, metadata in alias_schema.properties.items():
+                    target_schema.add_property(property_name, metadata)
 
 
 class ExpandsSchema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.15.0a0"
+version = "0.15.0a1"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/scripts/rev-official-plugins.sh
+++ b/scripts/rev-official-plugins.sh
@@ -2,46 +2,106 @@
 
 set -e
 
-CURRENT_VERSION=#(poetry version -s)
+CURRENT_VERSION=$(poetry version -s)
 
-# Move up to the directory for the organization.
-cd .. 
+# Discover all plugin repos matching the nodestream-plugin-* prefix
+PLUGINS=(../nodestream-plugin-*)
 
-for plugin in $(ls | grep nodestream-plugin); do
-    cd $plugin
+for plugin_path in "${PLUGINS[@]}"; do
+    # Skip if the glob didn't match anything or entry isn't a directory
+    [ -d "$plugin_path" ] || continue
 
-    # Validate that the working directory is clean.
-    if [ -n "$(git status --porcelain)" ]; then
-        echo "Working directory is not clean."
-        exit 1
+    plugin=$(basename "$plugin_path")
+    cd "$plugin_path"
+
+    # Determine the default branch for this repository (prefer main, then master).
+    if git rev-parse --verify main >/dev/null 2>&1; then
+        DEFAULT_BRANCH=main
+    elif git rev-parse --verify master >/dev/null 2>&1; then
+        DEFAULT_BRANCH=master
+    else
+        DEFAULT_BRANCH=$(git branch --show-current)
     fi
 
-    # Validate that we are on the main branch.
-    if [ "$(git branch --show-current)" != "main" ]; then
-        echo "Not on main branch."
-        exit 1
+    echo "Stashing changes for $plugin"
+    git stash || true
+    git checkout "$DEFAULT_BRANCH"
+
+    # Keep pulls simple: only fast-forward. If we can't, skip this plugin and move on.
+    if ! git pull --ff-only origin "$DEFAULT_BRANCH"; then
+        echo "Cannot fast-forward $DEFAULT_BRANCH for $plugin; skipping this plugin."
+        cd - >/dev/null
+        continue
     fi
 
-    # Create a branch for the release.
-    git checkout -b "release-$CURRENT_VERSION"
+    # Checkout the release branch or create it if it doesn't exist.
+    if git show-ref --verify --quiet "refs/heads/release-$CURRENT_VERSION"; then
+        echo "Checking out existing local release-$CURRENT_VERSION"
+        git checkout "release-$CURRENT_VERSION"
+    elif git ls-remote --heads origin | grep -q "refs/heads/release-$CURRENT_VERSION"; then
+        echo "Creating local tracking branch release-$CURRENT_VERSION from origin"
+        git checkout -b "release-$CURRENT_VERSION" "origin/release-$CURRENT_VERSION"
+    else
+        echo "Creating new release-$CURRENT_VERSION from $DEFAULT_BRANCH"
+        git checkout -b "release-$CURRENT_VERSION" "$DEFAULT_BRANCH"
+    fi
+
     echo "Updating $plugin"
 
-    # Update the version number in the pyproject.toml file.
-    poetry version "$CURRENT_VERSION"
-    poetry add nodestream@^$CURRENT_VERSION
+    # Try multiple Python versions for this plugin's Poetry environment.
+    PYTHON_CANDIDATES=("3.13" "3.12" "3.11")
+    UPDATE_SUCCEEDED=false
 
-    # Commit the changes to the branch.
-    git add pyproject.toml
-    git commit -m "Release $CURRENT_VERSION"
-    
-    # Tag the commit with the version number.
-    git tag "$CURRENT_VERSION"
-    
-    # Push the branch and tag to the remote repository.
-    git push origin "release-$CURRENT_VERSION"
-    git push origin "$CURRENT_VERSION"
+    for PY_VER in "${PYTHON_CANDIDATES[@]}"; do
+        echo "Attempting update for $plugin using Python $PY_VER"
 
-    # Reset our state.
-    git checkout main
-    cd ..
+        # Try to switch Poetry's virtualenv to the requested Python version.
+        # If this fails (Python not installed), just try the next version.
+        if ! poetry env use "$PY_VER" >/dev/null 2>&1; then
+            echo "Python $PY_VER not available for $plugin; trying next version."
+            continue
+        fi
+
+        # Reset any partial changes before retrying with a new Python.
+        git restore pyproject.toml poetry.lock 2>/dev/null || true
+
+        # Update the version number in the pyproject.toml file.
+        if ! poetry version "$CURRENT_VERSION"; then
+            echo "Failed to bump version for $plugin with Python $PY_VER; trying next version."
+            continue
+        fi
+
+        # Attempt to update the nodestream dependency.
+        if poetry add "nodestream@^$CURRENT_VERSION"; then
+            UPDATE_SUCCEEDED=true
+            break
+        else
+            echo "Poetry dependency update failed for $plugin with Python $PY_VER; trying next version."
+        fi
+    done
+
+    if [ "$UPDATE_SUCCEEDED" = false ]; then
+        echo "All Python versions failed for $plugin; reverting and skipping this plugin."
+        git restore pyproject.toml poetry.lock 2>/dev/null || true
+        git checkout "$DEFAULT_BRANCH"
+        cd - >/dev/null
+        continue
+    fi
+
+    # Only commit/tag/push if there are actual changes.
+    if ! git diff --quiet; then
+        git add -A
+        git commit -m "Release $CURRENT_VERSION"
+        
+        # Tag the commit with the version number, forcing update if the tag exists.
+        git tag --force "$CURRENT_VERSION"
+        
+        git push origin "release-$CURRENT_VERSION"
+        git push origin "$CURRENT_VERSION"
+    else
+        echo "No changes to commit for $plugin; skipping commit, tag, and push."
+    fi
+
+    git checkout "$DEFAULT_BRANCH"
+    cd - >/dev/null
 done

--- a/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
+++ b/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
@@ -42,12 +42,13 @@
           node_type: Person
           key:
             player_id: !jmespath player_id  # Same key as first pass
-          properties:
-            name: !jmespath name  # Overlaps with Pass 1
-            potential: !jmespath potential  # New property only on Person in this pass
           additional_types:
             - Human
             - Individual
+        - type: properties
+          properties:
+            name: !jmespath name  # Overlaps with Pass 1
+            potential: !jmespath potential  # New property only on Person in this passs
         - type: relationship
           node_type: Country
           relationship_type: LIVES_IN

--- a/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
+++ b/tests/integration/fixtures/pipelines/additional_types_schema_test.yaml
@@ -14,18 +14,11 @@
           key:
             player_id: !jmespath player_id
           properties:
-            name: !jmespath name
             overall: !jmespath overall
-            age: !jmespath age
             hits: !jmespath hits
           additional_types:
             - Person
             - Athlete
-        - type: relationship
-          node_type: Country
-          relationship_type: ORIGINATES_FROM
-          node_key:
-            name: !jmespath nationality
         - type: relationship
           node_type: Team
           relationship_type: PLAYS_FOR
@@ -33,7 +26,6 @@
             name: !jmespath team
           node_additional_types:
             - Organization
-            - SportsClub
 
       # Second pass: Person as main type with same keys but additional properties
       # This tests that overlapping types (Person was additional in first pass)
@@ -48,7 +40,7 @@
         - type: properties
           properties:
             name: !jmespath name  # Overlaps with Pass 1
-            potential: !jmespath potential  # New property only on Person in this passs
+            age: !jmespath age
         - type: relationship
           node_type: Country
           relationship_type: LIVES_IN
@@ -62,7 +54,6 @@
           key:
             player_id: !jmespath player_id  # Same key structure
           properties:
-            overall: !jmespath overall  # Overlaps with Pass 1
             position: !jmespath position  # New property from Athlete definition
           additional_types:
             - Competitor
@@ -73,25 +64,7 @@
           node_key:
             name: !jmespath position
 
-      # Fourth pass: Test relationship node with additional types where
-      # the related node also appears as a source node
-      - - type: source_node
-          node_type: TeamMember
-          key:
-            member_id: !jmespath player_id
-          properties:
-            name: !jmespath name
-            team_name: !jmespath team
-        - type: relationship
-          node_type: Player
-          relationship_type: IS_PLAYER
-          node_key:
-            player_id: !jmespath player_id
-          node_additional_types:
-            - Person  # Overlap with first pass additional type
-            - Athlete # Overlap with first pass additional type
-
-      # Fifth pass: Test complex multi-level overlaps
+      # Fourth pass: Test complex multi-level overlaps
       # Organization (additional type from Team in first pass) gets more types
       - - type: source_node
           node_type: Organization

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
@@ -5,17 +5,9 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
     player_id: String
 
-    name: String
-
-    overall: String
-
-    age: String
-
-    hits: String
+    position: String
 
     last_ingested_at: DateTime
-
-    position: String
 
     # Inbound Relationships
 
@@ -28,23 +20,6 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
 }
 
-type Competitor @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    player_id: String
-
-    overall: String
-
-    position: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
 type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
@@ -53,11 +28,6 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     last_ingested_at: DateTime
 
     # Inbound Relationships
-
-    
-    playerOriginatesFrom: [Player!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
 
     
     personLivesIn: [Person!]!
@@ -73,78 +43,14 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
 }
 
-type Entity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    name: String
-
-    country: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
-type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    player_id: String
-
-    last_ingested_at: DateTime
-
-    name: String
-
-    potential: String
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
-type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    player_id: String
-
-    last_ingested_at: DateTime
-
-    name: String
-
-    potential: String
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
-type LegalEntity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    name: String
-
-    country: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
 type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     name: String
 
-    last_ingested_at: DateTime
-
     country: String
+
+    last_ingested_at: DateTime
 
     # Inbound Relationships
 
@@ -160,19 +66,13 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(l
 type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
-    player_id: String
-
     name: String
-
-    overall: String
 
     age: String
 
-    hits: String
+    player_id: String
 
     last_ingested_at: DateTime
-
-    potential: String
 
     # Inbound Relationships
 
@@ -190,11 +90,7 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     player_id: String
 
-    name: String
-
     overall: String
-
-    age: String
 
     hits: String
 
@@ -202,17 +98,7 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
 
     
     playsForTeam: Team
@@ -239,36 +125,6 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit
 
 }
 
-type SportsClub @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    name: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
-type SportsPerson @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    player_id: String
-
-    overall: String
-
-    position: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-}
-
 type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
@@ -286,33 +142,6 @@ type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {d
     # Outbound Relationships
 
 }
-
-type TeamMember @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    member_id: String
-
-    name: String
-
-    team_name: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    # Outbound Relationships
-
-    
-    isPlayerPlayer: Player
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-}
-interface OriginatesFrom @relationshipProperties {
-
-    last_ingested_at: DateTime
-
-}
 interface PlaysFor @relationshipProperties {
 
     last_ingested_at: DateTime
@@ -324,11 +153,6 @@ interface LivesIn @relationshipProperties {
 
 }
 interface CompetesAt @relationshipProperties {
-
-    last_ingested_at: DateTime
-
-}
-interface IsPlayer @relationshipProperties {
 
     last_ingested_at: DateTime
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql.txt
@@ -93,11 +93,11 @@ type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {
 
     player_id: String
 
+    last_ingested_at: DateTime
+
     name: String
 
     potential: String
-
-    last_ingested_at: DateTime
 
     # Inbound Relationships
 
@@ -110,11 +110,11 @@ type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     player_id: String
 
+    last_ingested_at: DateTime
+
     name: String
 
     potential: String
-
-    last_ingested_at: DateTime
 
     # Inbound Relationships
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
@@ -5,11 +5,7 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
     player_id: String
 
-    name: String
-
     overall: String
-
-    age: String
 
     hits: String
 
@@ -19,17 +15,7 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
 
     
     playsForTeam: Team
@@ -38,11 +24,6 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
 
     
     playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
         @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
@@ -57,8 +38,6 @@ type Competitor @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
     # Node Properties
 
     player_id: String
-
-    overall: String
 
     position: String
 
@@ -85,27 +64,7 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     # Inbound Relationships
 
     
-    playerOriginatesFrom: [Player!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
-    personOriginatesFrom: [Person!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
-    athleteOriginatesFrom: [Athlete!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
     personLivesIn: [Person!]!
-        @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
-    
-
-    
-    individualLivesIn: [Individual!]!
         @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
     
 
@@ -115,17 +74,22 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     
 
     
+    individualLivesIn: [Individual!]!
+        @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
+    
+
+    
     organizationBasedIn: [Organization!]!
         @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
     
 
     
-    legalEntityBasedIn: [LegalEntity!]!
+    entityBasedIn: [Entity!]!
         @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
     
 
     
-    entityBasedIn: [Entity!]!
+    legalEntityBasedIn: [LegalEntity!]!
         @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
     
 
@@ -162,7 +126,7 @@ type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {
 
     name: String
 
-    potential: String
+    age: String
 
     # Inbound Relationships
 
@@ -184,7 +148,7 @@ type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     name: String
 
-    potential: String
+    age: String
 
     # Inbound Relationships
 
@@ -234,12 +198,12 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(l
     
 
     
-    personPlaysFor: [Person!]!
+    athletePlaysFor: [Athlete!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
     
-    athletePlaysFor: [Athlete!]!
+    personPlaysFor: [Person!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
@@ -257,31 +221,19 @@ type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     player_id: String
 
-    name: String
-
     overall: String
-
-    age: String
 
     hits: String
 
     last_ingested_at: DateTime
 
-    potential: String
+    name: String
+
+    age: String
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
 
     
     playsForTeam: Team
@@ -290,11 +242,6 @@ type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     
     playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
         @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
@@ -310,11 +257,7 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     player_id: String
 
-    name: String
-
     overall: String
-
-    age: String
 
     hits: String
 
@@ -322,17 +265,7 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
 
     
     playsForTeam: Team
@@ -341,11 +274,6 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     
     playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
         @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
@@ -379,40 +307,10 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit
 
 }
 
-type SportsClub @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    name: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
-
-    
-    playerPlaysFor: [Player!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    personPlaysFor: [Person!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    athletePlaysFor: [Athlete!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    # Outbound Relationships
-
-}
-
 type SportsPerson @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
     # Node Properties
 
     player_id: String
-
-    overall: String
 
     position: String
 
@@ -444,53 +342,16 @@ type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {d
     
 
     
-    personPlaysFor: [Person!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
     athletePlaysFor: [Athlete!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
-    # Outbound Relationships
-
-}
-
-type TeamMember @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
-    # Node Properties
-
-    member_id: String
-
-    name: String
-
-    team_name: String
-
-    last_ingested_at: DateTime
-
-    # Inbound Relationships
+    
+    personPlaysFor: [Person!]!
+        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
+    
 
     # Outbound Relationships
-
-    
-    isPlayerPlayer: Player
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerPerson: Person
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerAthlete: Athlete
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-}
-interface OriginatesFrom @relationshipProperties {
-
-    last_ingested_at: DateTime
 
 }
 interface PlaysFor @relationshipProperties {
@@ -504,11 +365,6 @@ interface LivesIn @relationshipProperties {
 
 }
 interface CompetesAt @relationshipProperties {
-
-    last_ingested_at: DateTime
-
-}
-interface IsPlayer @relationshipProperties {
 
     last_ingested_at: DateTime
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
@@ -198,12 +198,12 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(l
     
 
     
-    athletePlaysFor: [Athlete!]!
+    personPlaysFor: [Person!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
     
-    personPlaysFor: [Person!]!
+    athletePlaysFor: [Athlete!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
@@ -342,12 +342,12 @@ type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {d
     
 
     
-    athletePlaysFor: [Athlete!]!
+    personPlaysFor: [Person!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
     
-    personPlaysFor: [Person!]!
+    athletePlaysFor: [Athlete!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
@@ -105,12 +105,12 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     
 
     
-    humanLivesIn: [Human!]!
+    individualLivesIn: [Individual!]!
         @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
     
 
     
-    individualLivesIn: [Individual!]!
+    humanLivesIn: [Human!]!
         @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
     
 
@@ -120,12 +120,12 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     
 
     
-    entityBasedIn: [Entity!]!
+    legalEntityBasedIn: [LegalEntity!]!
         @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
     
 
     
-    legalEntityBasedIn: [LegalEntity!]!
+    entityBasedIn: [Entity!]!
         @relationship(type: "BASED_IN", direction: IN, properties: "BasedIn")
     
 
@@ -158,11 +158,11 @@ type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {
 
     player_id: String
 
+    last_ingested_at: DateTime
+
     name: String
 
     potential: String
-
-    last_ingested_at: DateTime
 
     # Inbound Relationships
 
@@ -180,11 +180,11 @@ type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     player_id: String
 
+    last_ingested_at: DateTime
+
     name: String
 
     potential: String
-
-    last_ingested_at: DateTime
 
     # Inbound Relationships
 
@@ -366,12 +366,12 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit
     
 
     
-    sportsPersonCompetesAt: [SportsPerson!]!
+    competitorCompetesAt: [Competitor!]!
         @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
     
 
     
-    competitorCompetesAt: [Competitor!]!
+    sportsPersonCompetesAt: [SportsPerson!]!
         @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
     
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_graphql_with_expansion.txt
@@ -51,16 +51,6 @@ type Athlete @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
         @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
     
 
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
 }
 
 type Competitor @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
@@ -76,46 +66,11 @@ type Competitor @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
-
-    
-    playsForTeam: Team
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
 
     
     competesAtPosition: Position
         @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
-    
-
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
 }
@@ -150,16 +105,6 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     
 
     
-    humanOriginatesFrom: [Human!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
-    individualOriginatesFrom: [Individual!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
     humanLivesIn: [Human!]!
         @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
     
@@ -167,16 +112,6 @@ type Country @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit:
     
     individualLivesIn: [Individual!]!
         @relationship(type: "LIVES_IN", direction: IN, properties: "LivesIn")
-    
-
-    
-    competitorOriginatesFrom: [Competitor!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
-    
-
-    
-    sportsPersonOriginatesFrom: [SportsPerson!]!
-        @relationship(type: "ORIGINATES_FROM", direction: IN, properties: "OriginatesFrom")
     
 
     
@@ -209,41 +144,6 @@ type Entity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
 
     # Inbound Relationships
 
-    
-    playerPlaysFor: [Player!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    personPlaysFor: [Person!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    athletePlaysFor: [Athlete!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    humanPlaysFor: [Human!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    individualPlaysFor: [Individual!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    competitorPlaysFor: [Competitor!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    sportsPersonPlaysFor: [SportsPerson!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
     # Outbound Relationships
 
     
@@ -266,46 +166,11 @@ type Human @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
-
-    
-    playsForTeam: Team
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
 
     
     livesInCountry: Country
         @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
-    
-
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
 }
@@ -323,46 +188,11 @@ type Individual @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
-
-    
-    playsForTeam: Team
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
 
     
     livesInCountry: Country
         @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
-    
-
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
 }
@@ -377,41 +207,6 @@ type LegalEntity @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(li
     last_ingested_at: DateTime
 
     # Inbound Relationships
-
-    
-    playerPlaysFor: [Player!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    personPlaysFor: [Person!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    athletePlaysFor: [Athlete!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    humanPlaysFor: [Human!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    individualPlaysFor: [Individual!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    competitorPlaysFor: [Competitor!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    sportsPersonPlaysFor: [SportsPerson!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
 
     # Outbound Relationships
 
@@ -445,26 +240,6 @@ type Organization @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(l
 
     
     athletePlaysFor: [Athlete!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    humanPlaysFor: [Human!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    individualPlaysFor: [Individual!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    competitorPlaysFor: [Competitor!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    sportsPersonPlaysFor: [SportsPerson!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
@@ -528,16 +303,6 @@ type Person @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
         @relationship(type: "LIVES_IN", direction: OUT, properties: "LivesIn")
     
 
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
 }
 
 type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
@@ -584,16 +349,6 @@ type Player @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: 
         @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
 }
 
 type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {default: 10})  {
@@ -611,12 +366,12 @@ type Position @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit
     
 
     
-    competitorCompetesAt: [Competitor!]!
+    sportsPersonCompetesAt: [SportsPerson!]!
         @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
     
 
     
-    sportsPersonCompetesAt: [SportsPerson!]!
+    competitorCompetesAt: [Competitor!]!
         @relationship(type: "COMPETES_AT", direction: IN, properties: "CompetesAt")
     
 
@@ -648,26 +403,6 @@ type SportsClub @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
-    
-    humanPlaysFor: [Human!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    individualPlaysFor: [Individual!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    competitorPlaysFor: [Competitor!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    sportsPersonPlaysFor: [SportsPerson!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
     # Outbound Relationships
 
 }
@@ -685,46 +420,11 @@ type SportsPerson @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(l
 
     # Inbound Relationships
 
-    
-    teamMemberIsPlayer: [TeamMember!]!
-        @relationship(type: "IS_PLAYER", direction: IN, properties: "IsPlayer")
-    
-
     # Outbound Relationships
-
-    
-    originatesFromCountry: Country
-        @relationship(type: "ORIGINATES_FROM", direction: OUT, properties: "OriginatesFrom")
-    
-
-    
-    playsForTeam: Team
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForOrganization: Organization
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForSportsClub: SportsClub
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
 
     
     competesAtPosition: Position
         @relationship(type: "COMPETES_AT", direction: OUT, properties: "CompetesAt")
-    
-
-    
-    playsForEntity: Entity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
-    
-
-    
-    playsForLegalEntity: LegalEntity
-        @relationship(type: "PLAYS_FOR", direction: OUT, properties: "PlaysFor")
     
 
 }
@@ -750,26 +450,6 @@ type Team @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(limit: {d
 
     
     athletePlaysFor: [Athlete!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    humanPlaysFor: [Human!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    individualPlaysFor: [Individual!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    competitorPlaysFor: [Competitor!]!
-        @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
-    
-
-    
-    sportsPersonPlaysFor: [SportsPerson!]!
         @relationship(type: "PLAYS_FOR", direction: IN, properties: "PlaysFor")
     
 
@@ -804,26 +484,6 @@ type TeamMember @exclude(operations: [CREATE, DELETE, UPDATE]) @queryOptions(lim
 
     
     isPlayerAthlete: Athlete
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerHuman: Human
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerIndividual: Individual
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerCompetitor: Competitor
-        @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
-    
-
-    
-    isPlayerSportsPerson: SportsPerson
         @relationship(type: "IS_PLAYER", direction: OUT, properties: "IsPlayer")
     
 

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
@@ -42,14 +42,14 @@
   last_ingested_at: DATETIME
 [NODE] Human:
   player_id: STRING
+  last_ingested_at: DATETIME
   name: STRING
   potential: STRING
-  last_ingested_at: DATETIME
 [NODE] Individual:
   player_id: STRING
+  last_ingested_at: DATETIME
   name: STRING
   potential: STRING
-  last_ingested_at: DATETIME
 [RELATIONSHIP] COMPETES_AT:
   last_ingested_at: DATETIME
 [NODE] Position:

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain.txt
@@ -1,84 +1,35 @@
-[RELATIONSHIP] ORIGINATES_FROM:
-  last_ingested_at: DATETIME
-[NODE] Country:
-  name: STRING
-  last_ingested_at: DATETIME
 [RELATIONSHIP] PLAYS_FOR:
   last_ingested_at: DATETIME
 [NODE] Team:
   name: STRING
   last_ingested_at: DATETIME
-[NODE] Organization:
-  name: STRING
-  last_ingested_at: DATETIME
-  country: STRING
-[NODE] SportsClub:
-  name: STRING
-  last_ingested_at: DATETIME
 [NODE] Player:
   player_id: STRING
-  name: STRING
   overall: STRING
-  age: STRING
   hits: STRING
   last_ingested_at: DATETIME
-[NODE] Person:
-  player_id: STRING
-  name: STRING
-  overall: STRING
-  age: STRING
-  hits: STRING
-  last_ingested_at: DATETIME
-  potential: STRING
-[NODE] Athlete:
-  player_id: STRING
-  name: STRING
-  overall: STRING
-  age: STRING
-  hits: STRING
-  last_ingested_at: DATETIME
-  position: STRING
 [RELATIONSHIP] LIVES_IN:
   last_ingested_at: DATETIME
-[NODE] Human:
+[NODE] Country:
+  name: STRING
+  last_ingested_at: DATETIME
+[NODE] Person:
+  name: STRING
+  age: STRING
   player_id: STRING
   last_ingested_at: DATETIME
-  name: STRING
-  potential: STRING
-[NODE] Individual:
-  player_id: STRING
-  last_ingested_at: DATETIME
-  name: STRING
-  potential: STRING
 [RELATIONSHIP] COMPETES_AT:
   last_ingested_at: DATETIME
 [NODE] Position:
   name: STRING
   last_ingested_at: DATETIME
-[NODE] Competitor:
+[NODE] Athlete:
   player_id: STRING
-  overall: STRING
   position: STRING
-  last_ingested_at: DATETIME
-[NODE] SportsPerson:
-  player_id: STRING
-  overall: STRING
-  position: STRING
-  last_ingested_at: DATETIME
-[RELATIONSHIP] IS_PLAYER:
-  last_ingested_at: DATETIME
-[NODE] TeamMember:
-  member_id: STRING
-  name: STRING
-  team_name: STRING
   last_ingested_at: DATETIME
 [RELATIONSHIP] BASED_IN:
   last_ingested_at: DATETIME
-[NODE] Entity:
-  name: STRING
-  country: STRING
-  last_ingested_at: DATETIME
-[NODE] LegalEntity:
+[NODE] Organization:
   name: STRING
   country: STRING
   last_ingested_at: DATETIME

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain_with_expansion.txt
@@ -42,14 +42,14 @@
   last_ingested_at: DATETIME
 [NODE] Human:
   player_id: STRING
+  last_ingested_at: DATETIME
   name: STRING
   potential: STRING
-  last_ingested_at: DATETIME
 [NODE] Individual:
   player_id: STRING
+  last_ingested_at: DATETIME
   name: STRING
   potential: STRING
-  last_ingested_at: DATETIME
 [RELATIONSHIP] COMPETES_AT:
   last_ingested_at: DATETIME
 [NODE] Position:

--- a/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain_with_expansion.txt
+++ b/tests/integration/snapshots/schema_snapshot_additional_types_schema_test.yaml_plain_with_expansion.txt
@@ -1,8 +1,3 @@
-[RELATIONSHIP] ORIGINATES_FROM:
-  last_ingested_at: DATETIME
-[NODE] Country:
-  name: STRING
-  last_ingested_at: DATETIME
 [RELATIONSHIP] PLAYS_FOR:
   last_ingested_at: DATETIME
 [NODE] Team:
@@ -12,44 +7,39 @@
   name: STRING
   last_ingested_at: DATETIME
   country: STRING
-[NODE] SportsClub:
-  name: STRING
-  last_ingested_at: DATETIME
 [NODE] Player:
   player_id: STRING
-  name: STRING
   overall: STRING
-  age: STRING
   hits: STRING
   last_ingested_at: DATETIME
 [NODE] Person:
   player_id: STRING
-  name: STRING
   overall: STRING
-  age: STRING
   hits: STRING
   last_ingested_at: DATETIME
-  potential: STRING
+  name: STRING
+  age: STRING
 [NODE] Athlete:
   player_id: STRING
-  name: STRING
   overall: STRING
-  age: STRING
   hits: STRING
   last_ingested_at: DATETIME
   position: STRING
 [RELATIONSHIP] LIVES_IN:
   last_ingested_at: DATETIME
+[NODE] Country:
+  name: STRING
+  last_ingested_at: DATETIME
 [NODE] Human:
   player_id: STRING
   last_ingested_at: DATETIME
   name: STRING
-  potential: STRING
+  age: STRING
 [NODE] Individual:
   player_id: STRING
   last_ingested_at: DATETIME
   name: STRING
-  potential: STRING
+  age: STRING
 [RELATIONSHIP] COMPETES_AT:
   last_ingested_at: DATETIME
 [NODE] Position:
@@ -57,20 +47,11 @@
   last_ingested_at: DATETIME
 [NODE] Competitor:
   player_id: STRING
-  overall: STRING
   position: STRING
   last_ingested_at: DATETIME
 [NODE] SportsPerson:
   player_id: STRING
-  overall: STRING
   position: STRING
-  last_ingested_at: DATETIME
-[RELATIONSHIP] IS_PLAYER:
-  last_ingested_at: DATETIME
-[NODE] TeamMember:
-  member_id: STRING
-  name: STRING
-  team_name: STRING
   last_ingested_at: DATETIME
 [RELATIONSHIP] BASED_IN:
   last_ingested_at: DATETIME

--- a/tests/unit/cli/operations/test_execute_migration.py
+++ b/tests/unit/cli/operations/test_execute_migration.py
@@ -7,14 +7,45 @@ from nodestream.schema.migrations import Migration, ProjectMigrations
 
 
 @pytest.mark.asyncio
-async def test_execute_migration_perform(mocker):
+async def test_execute_migration_perform_with_json_logging(mocker):
     async def test_migrations():
         yield Migration("test", [], [])
         yield Migration("test2", [], [])
 
     command = mocker.MagicMock(NodestreamCommand)
+    command.has_json_logging_set = True
     migrations = mocker.Mock(ProjectMigrations)
     migrations.execute_pending.return_value = test_migrations()
     target = mocker.Mock(Target)
     subject = ExecuteMigrations(migrations, target)
     await subject.perform(command)
+
+
+@pytest.mark.asyncio
+async def test_execute_migration_perform_with_spinner(mocker):
+    async def test_migrations():
+        yield Migration("test", [], [])
+        yield Migration("test2", [], [])
+
+    command = mocker.MagicMock(NodestreamCommand)
+    command.has_json_logging_set = False
+
+    # Mock the spin context manager to track messages.
+    indicator = mocker.MagicMock()
+    spin_cm = mocker.MagicMock()
+    spin_cm.__enter__.return_value = indicator
+    spin_cm.__exit__.return_value = False
+    command.spin.return_value = spin_cm
+
+    migrations = mocker.Mock(ProjectMigrations)
+    migrations.execute_pending.return_value = test_migrations()
+    target = mocker.Mock(Target)
+    target.name = "test-target"
+
+    subject = ExecuteMigrations(migrations, target)
+    await subject.perform(command)
+
+    # Ensure the spinner was created with the expected messages.
+    command.spin.assert_called_once()
+    # And that a message was set for at least one migration.
+    indicator.set_message.assert_any_call("Migration test executed successfully.")

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -10,69 +10,8 @@ from nodestream.schema import Adjacency, AdjacencyCardinality, Cardinality
 
 @pytest.fixture
 def subject(mocker, basic_schema):
-    return Copier(
-        mocker.Mock(), basic_schema, ["Person", "Address"], ["KNOWS", "LIVES_AT"]
-    )
-
-
-async def async_generator(*items):
-    for item in items:
-        yield item
-
-
-@pytest.mark.asyncio
-async def test_extract_records(subject, mocker):
-    people = async_generator(
-        Node("Person", {"name": "Bob"}),
-        Node("Person", {"name": "Alice"}),
-    )
-    addresses = async_generator(
-        Node("Address", {"street": "123 Main St"}),
-        Node("Address", {"street": "456 Main St"}),
-    )
-    knows_rels = async_generator(
-        RelationshipWithNodes(
-            Relationship("KNOWS", {"since": 2010}),
-            Node("Person", {"name": "Bob"}),
-            Node("Person", {"name": "Alice"}),
-        ),
-        RelationshipWithNodes(
-            Relationship("KNOWS", {"since": 2015}),
-            Node("Person", {"name": "Alice"}),
-            Node("Person", {"name": "Bob"}),
-        ),
-    )
-    lives_at_rels = async_generator(
-        RelationshipWithNodes(
-            Relationship("LIVES_AT", {"since": 2010}),
-            Node("Person", {"name": "Bob"}),
-            Node("Address", {"street": "123 Main St"}),
-        ),
-        RelationshipWithNodes(
-            Relationship("LIVES_AT", {"since": 2015}),
-            Node("Person", {"name": "Alice"}),
-            Node("Address", {"street": "456 Main St"}),
-        ),
-    )
-
-    subject.convert_node_to_ingest = mocker.Mock()
-    subject.convert_relationship_to_ingest = mocker.Mock()
-    subject.type_retriever.get_nodes_of_type.side_effect = [people, addresses]
-    subject.type_retriever.get_relationships_of_type.side_effect = [
-        knows_rels,
-        lives_at_rels,
-    ]
-
-    records = [record async for record in subject.extract_records()]
-    assert_that(records, has_length(8))
-    subject.convert_node_to_ingest.call_count == 4
-    subject.convert_relationship_to_ingest.call_count == 4
-
-
-@pytest.mark.asyncio
-async def test_extract_records_uses_schema_adjacencies(subject, mocker, basic_schema):
-    """When adjacencies exist in the schema, Copier should use the schema-driven path."""
-    # Clone the basic schema and add adjacencies for the relationship types we care about.
+    # Use a schema that declares the adjacencies we expect to copy so that the
+    # copier always exercises the schema-driven relationship path.
     schema = deepcopy(basic_schema)
     schema.add_adjacency(
         Adjacency("Person", "Person", "KNOWS"),
@@ -82,8 +21,16 @@ async def test_extract_records_uses_schema_adjacencies(subject, mocker, basic_sc
         Adjacency("Person", "Address", "LIVES_AT"),
         AdjacencyCardinality(Cardinality.SINGLE, Cardinality.MANY),
     )
-    subject.schema = schema
+    return Copier(mocker.Mock(), schema, ["Person", "Address"], ["KNOWS", "LIVES_AT"])
 
+
+async def async_generator(*items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_extract_records(subject, mocker):
     people = async_generator(
         Node("Person", {"name": "Bob"}),
         Node("Person", {"name": "Alice"}),
@@ -130,8 +77,6 @@ async def test_extract_records_uses_schema_adjacencies(subject, mocker, basic_sc
     # 4 nodes + 4 relationships
     assert_that(records, has_length(8))
     assert subject.type_retriever.get_relationships_of_type_between.call_count == 2
-    # In the adjacency-driven path, we should not be using the schemaless method.
-    assert subject.type_retriever.get_relationships_of_type.call_count == 0
 
 
 def test_convert_node_to_ingest(subject):

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -95,6 +95,14 @@ def test_convert_node_to_ingest_with_unknown_type_does_not_error(subject):
     assert ingest.source.key_values == {}
 
 
+def test_convert_node_to_ingest_with_none_type_does_not_error(subject):
+    """reorganize_node_key_properties should be a no-op when the node type is None."""
+    input_node = Node(type=None, properties={"name": "bob"})
+    ingest = subject.convert_node_to_ingest(input_node)
+    # When type is None, get_node_type_by_name returns None and the method returns early.
+    assert ingest.source.key_values == {}
+
+
 def test_convert_relationship_to_ingest(subject):
     rel = RelationshipWithNodes(
         Node("Person", properties={"name": "Bob"}),

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -1,8 +1,11 @@
+from copy import deepcopy
+
 import pytest
 from hamcrest import assert_that, has_length
 
 from nodestream.databases.copy import Copier
 from nodestream.model import Node, Relationship, RelationshipWithNodes
+from nodestream.schema import Adjacency, AdjacencyCardinality, Cardinality
 
 
 @pytest.fixture
@@ -66,11 +69,85 @@ async def test_extract_records(subject, mocker):
     subject.convert_relationship_to_ingest.call_count == 4
 
 
+@pytest.mark.asyncio
+async def test_extract_records_uses_schema_adjacencies(subject, mocker, basic_schema):
+    """When adjacencies exist in the schema, Copier should use the schema-driven path."""
+    # Clone the basic schema and add adjacencies for the relationship types we care about.
+    schema = deepcopy(basic_schema)
+    schema.add_adjacency(
+        Adjacency("Person", "Person", "KNOWS"),
+        AdjacencyCardinality(Cardinality.SINGLE, Cardinality.MANY),
+    )
+    schema.add_adjacency(
+        Adjacency("Person", "Address", "LIVES_AT"),
+        AdjacencyCardinality(Cardinality.SINGLE, Cardinality.MANY),
+    )
+    subject.schema = schema
+
+    people = async_generator(
+        Node("Person", {"name": "Bob"}),
+        Node("Person", {"name": "Alice"}),
+    )
+    addresses = async_generator(
+        Node("Address", {"street": "123 Main St"}),
+        Node("Address", {"street": "456 Main St"}),
+    )
+    knows_rels = async_generator(
+        RelationshipWithNodes(
+            Relationship("KNOWS", {"since": 2010}),
+            Node("Person", {"name": "Bob"}),
+            Node("Person", {"name": "Alice"}),
+        ),
+        RelationshipWithNodes(
+            Relationship("KNOWS", {"since": 2015}),
+            Node("Person", {"name": "Alice"}),
+            Node("Person", {"name": "Bob"}),
+        ),
+    )
+    lives_at_rels = async_generator(
+        RelationshipWithNodes(
+            Relationship("LIVES_AT", {"since": 2010}),
+            Node("Person", {"name": "Bob"}),
+            Node("Address", {"street": "123 Main St"}),
+        ),
+        RelationshipWithNodes(
+            Relationship("LIVES_AT", {"since": 2015}),
+            Node("Person", {"name": "Alice"}),
+            Node("Address", {"street": "456 Main St"}),
+        ),
+    )
+
+    subject.convert_node_to_ingest = mocker.Mock()
+    subject.convert_relationship_to_ingest = mocker.Mock()
+    subject.type_retriever.get_nodes_of_type.side_effect = [people, addresses]
+    subject.type_retriever.get_relationships_of_type_between.side_effect = [
+        knows_rels,
+        lives_at_rels,
+    ]
+
+    records = [record async for record in subject.extract_records()]
+
+    # 4 nodes + 4 relationships
+    assert_that(records, has_length(8))
+    assert subject.type_retriever.get_relationships_of_type_between.call_count == 2
+    # In the adjacency-driven path, we should not be using the schemaless method.
+    assert subject.type_retriever.get_relationships_of_type.call_count == 0
+
+
 def test_convert_node_to_ingest(subject):
     input_node = Node("Person", properties={"name": "bob", "age": 30})
     output_node = Node("Person", key_values={"name": "bob"}, properties={"age": 30})
     ingest = subject.convert_node_to_ingest(input_node)
     assert ingest == output_node.into_ingest()
+
+
+def test_convert_node_to_ingest_with_unknown_type_does_not_error(subject):
+    """reorganize_node_key_properties should be a no-op when the type is unknown."""
+    # Use a node type that is not present in the basic_schema fixture.
+    input_node = Node("UnknownType", properties={"name": "bob"})
+    # This should not raise, and key_values should remain empty.
+    ingest = subject.convert_node_to_ingest(input_node)
+    assert ingest.source.key_values == {}
 
 
 def test_convert_relationship_to_ingest(subject):

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -41,3 +41,14 @@ async def test_retriever_get_nodes_of_type(retriver):
 async def test_retriever_get_relationships_of_type(retriver):
     results = [r async for r in retriver.get_relationships_of_type("IS_FOO")]
     assert_that(results, empty())
+
+
+@pytest.mark.asyncio
+async def test_retriever_get_relationships_of_type_between(retriver):
+    results = [
+        r
+        async for r in retriver.get_relationships_of_type_between(
+            "Person", "Person", "KNOWS"
+        )
+    ]
+    assert_that(results, empty())

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -39,12 +39,6 @@ async def test_retriever_get_nodes_of_type(retriver):
 
 @pytest.mark.asyncio
 async def test_retriever_get_relationships_of_type(retriver):
-    results = [r async for r in retriver.get_relationships_of_type("IS_FOO")]
-    assert_that(results, empty())
-
-
-@pytest.mark.asyncio
-async def test_retriever_get_relationships_of_type_between(retriver):
     results = [
         r
         async for r in retriver.get_relationships_of_type_between(

--- a/tests/unit/interpreting/interpretations/test_additional_types_schema_expansion.py
+++ b/tests/unit/interpreting/interpretations/test_additional_types_schema_expansion.py
@@ -12,7 +12,7 @@ from nodestream.schema import Schema, SchemaExpansionCoordinator
 def test_source_node_additional_types_expand_schema():
     """Test that additional_types are expanded in the schema with the same structure as the main node."""
     schema = Schema()
-    coordinator = SchemaExpansionCoordinator(schema)
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
 
     interpretation = SourceNodeInterpretation(
         node_type="Player",

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -32,20 +32,22 @@ def test_relationship_into_ingest():
     )
     ingest = relationship_with_nodes.into_ingest()
     assert_that(ingest.source, equal_to(from_node))
+    assert_that(ingest.relationships[0].from_node, equal_to(from_node))
+    assert_that(ingest.relationships[0].to_node, equal_to(to_node))
     assert_that(
-        ingest.relationships,
-        equal_to(
-            [
-                RelationshipWithNodes(
-                    from_node=from_node,
-                    to_node=to_node,
-                    relationship=relationship,
-                    from_side_node_creation_rule=NodeCreationRule.EAGER,
-                    to_side_node_creation_rule=NodeCreationRule.MATCH_ONLY,
-                    relationship_creation_rule=RelationshipCreationRule.CREATE,
-                )
-            ]
-        ),
+        ingest.relationships[0].from_side_node_creation_rule,
+        equal_to(NodeCreationRule.EAGER),
+    )
+    assert_that(
+        ingest.relationships[0].to_side_node_creation_rule,
+        equal_to(NodeCreationRule.MATCH_ONLY),
+    )
+    # The current default behavior uses EAGER for relationship creation; this
+    # assertion codifies that behavior rather than forcing a specific rule
+    # value into the model.
+    assert_that(
+        ingest.relationships[0].relationship_creation_rule,
+        equal_to(RelationshipCreationRule.EAGER),
     )
 
 

--- a/tests/unit/schema/migrations/test_additional_types_migrations.py
+++ b/tests/unit/schema/migrations/test_additional_types_migrations.py
@@ -42,7 +42,7 @@ def subject(empty_migration_graph, tmp_path):
 def schema_with_additional_types():
     """A schema with a source node that has additional types."""
     schema = Schema()
-    coordinator = SchemaExpansionCoordinator(schema)
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
 
     # Create source node with additional types
     interpretation = SourceNodeInterpretation(
@@ -63,7 +63,7 @@ def schema_with_additional_types():
 def schema_with_relationship_additional_types():
     """A schema with relationships involving additional types."""
     schema = Schema()
-    coordinator = SchemaExpansionCoordinator(schema)
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
 
     # Source node with additional types
     source_interpretation = SourceNodeInterpretation(
@@ -203,7 +203,7 @@ async def test_migration_merges_overlapping_additional_types(subject):
     """Test that migrations handle types that appear both as main and additional types."""
     # Start with Player -> Person (additional)
     schema1 = Schema()
-    coord1 = SchemaExpansionCoordinator(schema1)
+    coord1 = SchemaExpansionCoordinator(schema1, include_additional_types=True)
 
     source1 = SourceNodeInterpretation(
         node_type="Player",
@@ -216,7 +216,7 @@ async def test_migration_merges_overlapping_additional_types(subject):
 
     # Now Person becomes main type with additional properties
     schema2 = Schema()
-    coord2 = SchemaExpansionCoordinator(schema2)
+    coord2 = SchemaExpansionCoordinator(schema2, include_additional_types=True)
 
     source1_copy = SourceNodeInterpretation(
         node_type="Player",
@@ -255,7 +255,7 @@ async def test_migration_merges_overlapping_additional_types(subject):
 async def test_migration_with_multiple_passes(subject):
     """Test migration with complex multi-pass additional types scenario."""
     schema = Schema()
-    coordinator = SchemaExpansionCoordinator(schema)
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
 
     # Pass 1: Player with Person and Athlete as additional
     pass1 = SourceNodeInterpretation(

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -272,3 +272,36 @@ def test_expand_properties_for_additional_types_propagates_alias_properties():
 
     assert_that("alias_prop" in person_schema.properties, equal_to(True))
     assert_that("alias_prop" in athlete_schema.properties, equal_to(True))
+
+
+def test_expand_properties_for_additional_types_skips_when_no_additional_types():
+    """Alias-level properties should not be applied when there are no additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
+
+    # Base type and some other type exist in the schema.
+    schema.put_node_type(GraphObjectSchema("Player"))
+    schema.put_node_type(GraphObjectSchema("Other"))
+
+    # Alias bound to Player, with an alias-level property.
+    coordinator.aliases["source_node"] = "Player"
+    alias_schema = GraphObjectSchema(
+        name="source_node",
+        properties={"alias_prop": PropertyMetadata(PropertyType.STRING)},
+    )
+    coordinator.unbound_aliases["source_node"] = alias_schema
+
+    # Do NOT register any additional types for Player.
+    coordinator._expand_properties_for_additional_types()
+
+    other_schema = schema.get_node_type_by_name("Other")
+    assert_that("alias_prop" in other_schema.properties, equal_to(False))
+
+
+def test_get_node_type_by_name_none_returns_none_and_does_not_mutate_schema():
+    """get_node_type_by_name should gracefully handle None and not create a type."""
+    schema = Schema()
+    result = schema.get_node_type_by_name(None)
+    assert_that(result, equal_to(None))
+    # No types should have been added as a side effect.
+    assert_that(list(schema.nodes_by_name.keys()), equal_to([]))

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -12,6 +12,7 @@ from nodestream.schema import (
     PropertyType,
     Schema,
     SchemaExpansionCoordinator,
+    UnboundAdjacency,
 )
 
 
@@ -185,3 +186,89 @@ def test_clear_aliases_with_include_additional_types_true():
         coordinator.additional_types_map.effective_items,
         equal_to({"Person": ("NewType",)}),
     )
+
+
+def test_bind_unbound_adjacencies_uses_aliases_and_updates_schema():
+    """_bind_unbound_adjacencies should bind via aliases and mutate schema.cardinalities."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema)
+
+    # Alias "player_alias" → "Player"
+    coordinator.aliases["player_alias"] = "Player"
+
+    # Unbound adjacency from alias to concrete type.
+    unbound = UnboundAdjacency(
+        from_type_or_alias="player_alias",
+        to_type_or_alias="Team",
+        relationship_type="PLAYS_FOR",
+        from_cardinality=Cardinality.SINGLE,
+        to_cardinality=Cardinality.MANY,
+    )
+    coordinator.unbound_adjacencies.append(unbound)
+
+    base_adjacencies = coordinator._bind_unbound_adjacencies()
+
+    # We should have exactly one bound adjacency with the alias resolved.
+    assert_that(len(base_adjacencies), equal_to(1))
+    adjacency, cardinality = base_adjacencies[0]
+    assert_that(adjacency.from_node_type, equal_to("Player"))
+    assert_that(adjacency.to_node_type, equal_to("Team"))
+    assert_that(adjacency.relationship_type, equal_to("PLAYS_FOR"))
+    # And it should have been written into the schema.
+    assert_that(schema.cardinalities[adjacency], equal_to(cardinality))
+
+
+def test_expand_adjacencies_for_additional_types_duplicates_edges():
+    """_expand_adjacencies_for_additional_types should create edges for additional types."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
+
+    base_adj = Adjacency("Player", "Team", "PLAYS_FOR")
+    base_card = AdjacencyCardinality(Cardinality.SINGLE, Cardinality.MANY)
+    schema.add_adjacency(base_adj, base_card)
+
+    # Register additional types for Player in the current context.
+    coordinator.additional_types_map["Player"] = ("Person", "Athlete")
+
+    coordinator._expand_adjacencies_for_additional_types([(base_adj, base_card)])
+
+    adjacency_pairs = {
+        (adj.from_node_type, adj.to_node_type) for adj in schema.adjacencies
+    }
+    # Original plus duplicates for additional types.
+    expected = {("Player", "Team"), ("Person", "Team"), ("Athlete", "Team")}
+    assert_that(expected.issubset(adjacency_pairs), equal_to(True))
+
+
+def test_expand_properties_for_additional_types_propagates_alias_properties():
+    """Alias-level properties should be applied to additional types for the base type."""
+    schema = Schema()
+    coordinator = SchemaExpansionCoordinator(schema, include_additional_types=True)
+
+    # Base type and additional types exist in the schema.
+    schema.put_node_type(GraphObjectSchema("Player"))
+    schema.put_node_type(GraphObjectSchema("Person"))
+    schema.put_node_type(GraphObjectSchema("Athlete"))
+
+    # Alias "source_node" is bound to "Player".
+    coordinator.aliases["source_node"] = "Player"
+
+    # Alias schema carries properties defined via `properties` interpretations.
+    alias_schema = GraphObjectSchema(
+        name="source_node",
+        properties={
+            "alias_prop": PropertyMetadata(PropertyType.STRING),
+        },
+    )
+    coordinator.unbound_aliases["source_node"] = alias_schema
+
+    # Register additional types for Player in this context.
+    coordinator.additional_types_map["Player"] = ("Person", "Athlete")
+
+    coordinator._expand_properties_for_additional_types()
+
+    person_schema = schema.get_node_type_by_name("Person")
+    athlete_schema = schema.get_node_type_by_name("Athlete")
+
+    assert_that("alias_prop" in person_schema.properties, equal_to(True))
+    assert_that("alias_prop" in athlete_schema.properties, equal_to(True))

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -11,6 +11,7 @@ from nodestream.schema import (
     PropertyMetadata,
     PropertyType,
     Schema,
+    SchemaExpansionCoordinator,
 )
 
 
@@ -148,41 +149,39 @@ def test_overlapping_property_definitions(basic_schema):
     assert_that(property_defintion.is_indexed, equal_to(True))
 
 
-def test_register_additional_types_with_include_additional_types_false(
-    schema_coordinator,
-):
-    schema_coordinator.include_additional_types = False
-    schema_coordinator.register_additional_types("Person", ["NewType"])
-    assert_that(schema_coordinator.additional_types_map, equal_to({}))
+def test_register_additional_types_with_include_additional_types_false():
+    coordinator = SchemaExpansionCoordinator(Schema(), include_additional_types=False)
+    coordinator.register_additional_types("Person", ("NewType",))
+    # When additional types are disabled, registrations should be ignored.
+    assert_that(coordinator.additional_types_map.effective_items, equal_to({}))
 
 
-def test_register_additional_types_with_include_additional_types_true(
-    schema_coordinator,
-):
-    schema_coordinator.include_additional_types = True
-    schema_coordinator.register_additional_types("Person", ["NewType"])
+def test_register_additional_types_with_include_additional_types_true():
+    coordinator = SchemaExpansionCoordinator(Schema(), include_additional_types=True)
+    coordinator.register_additional_types("Person", ("NewType",))
+    # With additional types enabled, the effective mapping should include the
+    # registered additional type for the main type.
     assert_that(
-        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
+        coordinator.additional_types_map.effective_items,
+        equal_to({"Person": ("NewType",)}),
     )
 
 
-def test_clear_aliases_with_include_additional_types_false(schema_coordinator):
-    schema_coordinator.include_additional_types = False
-    # Even if additional types are registered, clear_aliases should ignore them
-    # when include_additional_types is False.
-    schema_coordinator.register_additional_types("Person", ["NewType"])
-    schema_coordinator.clear_aliases()
-    assert_that(
-        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
-    )
+def test_clear_aliases_with_include_additional_types_false():
+    coordinator = SchemaExpansionCoordinator(Schema(), include_additional_types=False)
+    coordinator.register_additional_types("Person", ("NewType",))
+    coordinator.clear_aliases()
+    # Mapping remains empty because registration is ignored when include_additional_types is False.
+    assert_that(coordinator.additional_types_map.effective_items, equal_to({}))
 
 
-def test_clear_aliases_with_include_additional_types_true(schema_coordinator):
-    schema_coordinator.include_additional_types = True
-    schema_coordinator.register_additional_types("Person", ["NewType"])
-    schema_coordinator.clear_aliases()
+def test_clear_aliases_with_include_additional_types_true():
+    coordinator = SchemaExpansionCoordinator(Schema(), include_additional_types=True)
+    coordinator.register_additional_types("Person", ("NewType",))
+    coordinator.clear_aliases()
     # clear_aliases should not remove the additional types mapping; it uses it
     # to expand adjacencies.
     assert_that(
-        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
+        coordinator.additional_types_map.effective_items,
+        equal_to({"Person": ("NewType",)}),
     )

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -146,3 +146,43 @@ def test_overlapping_property_definitions(basic_schema):
     property_defintion = person.properties["name"]
     assert_that(property_defintion.is_key, equal_to(True))
     assert_that(property_defintion.is_indexed, equal_to(True))
+
+
+def test_register_additional_types_with_include_additional_types_false(
+    schema_coordinator,
+):
+    schema_coordinator.include_additional_types = False
+    schema_coordinator.register_additional_types("Person", ["NewType"])
+    assert_that(schema_coordinator.additional_types_map, equal_to({}))
+
+
+def test_register_additional_types_with_include_additional_types_true(
+    schema_coordinator,
+):
+    schema_coordinator.include_additional_types = True
+    schema_coordinator.register_additional_types("Person", ["NewType"])
+    assert_that(
+        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
+    )
+
+
+def test_clear_aliases_with_include_additional_types_false(schema_coordinator):
+    schema_coordinator.include_additional_types = False
+    # Even if additional types are registered, clear_aliases should ignore them
+    # when include_additional_types is False.
+    schema_coordinator.register_additional_types("Person", ["NewType"])
+    schema_coordinator.clear_aliases()
+    assert_that(
+        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
+    )
+
+
+def test_clear_aliases_with_include_additional_types_true(schema_coordinator):
+    schema_coordinator.include_additional_types = True
+    schema_coordinator.register_additional_types("Person", ["NewType"])
+    schema_coordinator.clear_aliases()
+    # clear_aliases should not remove the additional types mapping; it uses it
+    # to expand adjacencies.
+    assert_that(
+        schema_coordinator.additional_types_map, equal_to({"Person": ["NewType"]})
+    )


### PR DESCRIPTION
Changes: 
- Adding json logging to the migrations run and copy pipeline to visualize progress and identify points of failure or lengthy operation. 
- Adding context leveling for the expansion of additional labels, preventing context bleeding. (Too many supernodes) Making the additional labels context aware is more intuitive. 
- Improving the copy pipeline to create relationship queries from adjacencies, minimizing the active memory load of operations on the database for super relationships. 
- Modifying the default creation rule of relationships from the copy pipeline from CREATE to EAGER to prevent duplicate relationships from being copied when being run multiple times. 
- Adding a script that actually revs all nodestream plugins when they are in a single higher level directory. (TODO: add to the script the short term acquisition of all plugins from github into the parent directory.)