### PR TITLE
Fix queues __init__.py missing imports causing AttributeError on Queu…

### DIFF
--- a/nodestream/pipeline/extractors/queues/__init__.py
+++ b/nodestream/pipeline/extractors/queues/__init__.py
@@ -1,6 +1,8 @@
+from .extractor import QueueConnector, QueueExtractor
+from .sqs import SQSQueueConnector
+
 __all__ = (
     "QueueConnector",
-    "QueueRecordFormat",
     "QueueExtractor",
-    "SqsQueueConnector",
+    "SQSQueueConnector",
 )


### PR DESCRIPTION
The queues package declared names in __all__ but never imported them,                                                                                                                                     
  so getattr(module, 'QueueExtractor') failed at runtime. Also fixed                                                                                                                                        
  incorrect class name SqsQueueConnector -> SQSQueueConnector and removed                                                                                                                                   
  non-existent QueueRecordFormat from __all__. 