### PR TITLE
0.16 - Copy Command Rework

### DIFF
--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -188,19 +188,23 @@ class Copy(NodestreamCommand):
         node_filter = []
         rel_filter = []
 
-        all_node_names = {n.name for n in schema.nodes}
-        for n in self.option("node") or []:
-            if n in all_node_names:
-                node_filter.append(n)
+        all_node_names = {nodeType.name for nodeType in schema.nodes}
+        for nodeTypeName in self.option("node") or []:
+            if nodeTypeName in all_node_names:
+                node_filter.append(nodeTypeName)
             else:
-                logger.warning("Unknown node type %r — skipping", n)
+                logger.warning("Unknown node type %r — skipping", nodeTypeName)
 
-        all_rel_names = {r.name for r in schema.relationships}
-        for r in self.option("relationship") or []:
-            if r in all_rel_names:
-                rel_filter.append(r)
+        all_rel_names = {
+            relationshipType.name for relationshipType in schema.relationships
+        }
+        for relationshipTypeName in self.option("relationship") or []:
+            if relationshipTypeName in all_rel_names:
+                rel_filter.append(relationshipTypeName)
             else:
-                logger.warning("Unknown relationship type %r — skipping", r)
+                logger.warning(
+                    "Unknown relationship type %r — skipping", relationshipTypeName
+                )
 
         return schema.filtered(node_filter=node_filter, relationship_filter=rel_filter)
 

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -104,10 +104,10 @@ class Copy(NodestreamCommand):
             flag=False,
         ),
         option(
-            "node-only",
+            "preload-nodes",
             description=(
-                "Copy only nodes — skip relationship fetching entirely. "
-                "Useful when you want to seed nodes without their adjacencies."
+                "Copy nodes first, then relationships. "
+                "Useful when the destination needs nodes seeded before adjacencies are written."
             ),
             flag=True,
         ),
@@ -123,7 +123,7 @@ class Copy(NodestreamCommand):
             try:
                 from_target = self.get_taget_from_user(project, "from")
                 to_target = self.get_taget_from_user(project, "to")
-                node_only = bool(self.option("node-only"))
+                preloadNodes = bool(self.option("preload-nodes"))
 
                 full_schema = project.make_schema_for_copy(
                     include_additional_types=False
@@ -134,13 +134,13 @@ class Copy(NodestreamCommand):
                 step_outbox_size = int(self.option("step-outbox-size"))
                 flush_concurrency = int(self.option("flush-concurrency"))
                 concurrency_limit = int(self.option("concurrency-limit"))
-                shard_size_raw = self.option("shard-size")
+                shardSizeRaw = self.option("shard-size")
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
 
-                retriever_overrides.setdefault("node_only", node_only)
-                if shard_size_raw is not None:
-                    retriever_overrides.setdefault("shard_size", int(shard_size_raw))
+                retriever_overrides.setdefault("preload_nodes", preloadNodes)
+                if shardSizeRaw is not None:
+                    retriever_overrides.setdefault("shard_size", int(shardSizeRaw))
             except UnknownTargetError:
                 return 1
 
@@ -149,9 +149,12 @@ class Copy(NodestreamCommand):
                 extra={
                     "from": from_target.name,
                     "to": to_target.name,
-                    "node_only": node_only,
-                    "node_types": [n.name for n in schema.nodes],
-                    "relationship_types": [r.name for r in schema.relationships],
+                    "preload_nodes": preloadNodes,
+                    "node_types": [nodeType.name for nodeType in schema.nodes],
+                    "relationship_types": [
+                        relationshipType.name
+                        for relationshipType in schema.relationships
+                    ],
                     "retriever_overrides": retriever_overrides,
                     "connector_overrides": connector_overrides,
                 },

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -1,11 +1,11 @@
 from logging import getLogger
-from typing import Dict, List
+from typing import Dict, Optional, Set
 
 from cleo.helpers import option
 
 from ...metrics import Metrics
 from ...project import Project, Target
-from ...schema import GraphObjectSchema
+from ...schema import Schema
 from ..operations import (
     InitializeLogger,
     InitializeMetricsHandler,
@@ -31,16 +31,15 @@ class Copy(NodestreamCommand):
         JSON_OPTION,
         option("from", "f", "The target to copy from", flag=False),
         option("to", "t", "The target to copy to", flag=False),
-        option("all", "a", "Copy all node and relationship types", flag=True),
         option(
             "node",
-            description="Specify a node type to copy",
+            description="Filter to these node types (omit for all)",
             flag=False,
             multiple=True,
         ),
         option(
             "relationship",
-            description="Specify a relationship type to copy",
+            description="Filter to these relationship types (omit for all)",
             flag=False,
             multiple=True,
         ),
@@ -126,35 +125,10 @@ class Copy(NodestreamCommand):
                 to_target = self.get_taget_from_user(project, "to")
                 node_only = bool(self.option("node-only"))
 
-                # Always build the schema so type filters can be validated
-                # against it and the retriever has full type metadata.
-                schema = project.make_schema_for_copy(include_additional_types=False)
-                node_types = self.resolve_type_filter(schema.nodes, "node")
-
-                # When node types are explicitly filtered (not --all and not
-                # interactive-all), narrow relationships to those whose
-                # adjacency involves at least one selected node type — unless
-                # the user also provided explicit --relationship filters.
-                explicit_nodes = self.option("node")
-                if (
-                    explicit_nodes
-                    and not self.option("relationship")
-                    and not self.option("all")
-                ):
-                    node_set = set(node_types)
-                    rel_types = [
-                        adj.relationship_type
-                        for adj in schema.adjacencies
-                        if adj.from_node_type in node_set
-                        or adj.to_node_type in node_set
-                    ]
-                    # deduplicate while preserving order
-                    seen: set = set()
-                    rel_types = [r for r in rel_types if not (r in seen or seen.add(r))]
-                else:
-                    rel_types = self.resolve_type_filter(
-                        schema.relationships, "relationship"
-                    )
+                full_schema = project.make_schema_for_copy(
+                    include_additional_types=False
+                )
+                schema = self.apply_schema_filter(full_schema)
 
                 batch_size = int(self.option("batch-size"))
                 step_outbox_size = int(self.option("step-outbox-size"))
@@ -164,10 +138,6 @@ class Copy(NodestreamCommand):
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
 
-                # Merge CLI-level retriever knobs into retriever_overrides so that
-                # make_type_retriever receives a single flat dict. Plugins pop what
-                # they understand and ignore the rest — no plugin-specific kwargs
-                # leak from core into the retriever contract.
                 retriever_overrides.setdefault("concurrency_limit", concurrency_limit)
                 retriever_overrides.setdefault(
                     "orchestrator_queue_size", step_outbox_size
@@ -184,8 +154,8 @@ class Copy(NodestreamCommand):
                     "from": from_target.name,
                     "to": to_target.name,
                     "node_only": node_only,
-                    "node_types": node_types,
-                    "relationship_types": rel_types,
+                    "node_types": [n.name for n in schema.nodes],
+                    "relationship_types": [r.name for r in schema.relationships],
                     "retriever_overrides": retriever_overrides,
                     "connector_overrides": connector_overrides,
                 },
@@ -196,8 +166,6 @@ class Copy(NodestreamCommand):
                     from_target=from_target,
                     to_target=to_target,
                     schema=schema,
-                    node_types=node_types,
-                    relationship_types=rel_types,
                     progress_reporter=reporter,
                     batch_size=batch_size,
                     step_outbox_size=step_outbox_size,
@@ -207,6 +175,48 @@ class Copy(NodestreamCommand):
                 )
             )
         return 0
+
+    def apply_schema_filter(self, schema: Schema) -> Schema:
+        """Return a filtered schema based on --node and --relationship flags.
+
+        No flags: full schema (all nodes + all adjacencies).
+        --node A B: nodes A and B plus all adjacencies touching either,
+                    restricted by --relationship if also provided.
+        --relationship X Y: all adjacencies of type X or Y (and their endpoint nodes),
+                            restricted to nodes in --node if also provided.
+        """
+        node_filter: Optional[Set[str]] = None
+        rel_filter: Optional[Set[str]] = None
+
+        explicit_nodes = self.option("node")
+        explicit_rels = self.option("relationship")
+
+        if explicit_nodes:
+            all_node_names = {n.name for n in schema.nodes}
+            unknown = [n for n in explicit_nodes if n not in all_node_names]
+            if unknown:
+                self.line_error(
+                    f"Unknown node type(s): {', '.join(unknown)}. "
+                    f"Valid options are: {', '.join(sorted(all_node_names))}"
+                )
+                raise UnknownTargetError
+            node_filter = set(explicit_nodes)
+
+        if explicit_rels:
+            all_rel_names = {r.name for r in schema.relationships}
+            unknown = [r for r in explicit_rels if r not in all_rel_names]
+            if unknown:
+                self.line_error(
+                    f"Unknown relationship type(s): {', '.join(unknown)}. "
+                    f"Valid options are: {', '.join(sorted(all_rel_names))}"
+                )
+                raise UnknownTargetError
+            rel_filter = set(explicit_rels)
+
+        if node_filter is None and rel_filter is None:
+            return schema
+
+        return schema.filtered(node_filter=node_filter, relationship_filter=rel_filter)
 
     def parse_key_value_options(self, option_name: str) -> Dict[str, object]:
         raw = self.option(option_name) or []
@@ -229,47 +239,13 @@ class Copy(NodestreamCommand):
         return overrides
 
     def get_taget_from_user(self, project: Project, action: str) -> Target:
-        # If the user has specified the target in the options, we don't need to prompt
-        # them for anything. We can just use the target they specified.
         if (choice := self.option(action)) is None:
             prompt = f"Which target would you like to copy {action}?"
             choices = [t for t in project.targets_by_name.keys()]
             choice = self.choice(prompt, choices)
 
-        # If the target they specified is unknown, we should error out.
         try:
             return project.get_target_by_name(choice)
         except ValueError:
             self.line_error(f"Unknown target: {choice}")
             raise UnknownTargetError
-
-    def resolve_type_filter(
-        self, schema_types: List[GraphObjectSchema], type_name: str
-    ) -> List[str]:
-        """Return the list of type names to copy for this kind (node/relationship).
-
-        --all (default): all types from schema.
-        explicit --node/--relationship flags: validate against schema and use as filter.
-        Neither flag set interactively: prompt user to select from schema types.
-        """
-        all_names = [str(t.name) for t in schema_types]
-
-        if self.option("all"):
-            return all_names
-
-        explicit = self.option(type_name)
-        if explicit:
-            unknown = [t for t in explicit if t not in all_names]
-            if unknown:
-                self.line_error(
-                    f"Unknown {type_name} type(s): {', '.join(unknown)}. "
-                    f"Valid options are: {', '.join(all_names)}"
-                )
-                raise UnknownTargetError
-            return list(explicit)
-
-        return self.choice(
-            f"Which {type_name} types would you like to copy? (You can select multiple by separating them with a comma)",
-            all_names,
-            multiple=True,
-        )

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -1,10 +1,11 @@
+from logging import getLogger
 from typing import Dict, List
 
 from cleo.helpers import option
 
 from ...metrics import Metrics
 from ...project import Project, Target
-from ...schema import GraphObjectSchema, Schema
+from ...schema import GraphObjectSchema
 from ..operations import (
     InitializeLogger,
     InitializeMetricsHandler,
@@ -14,6 +15,8 @@ from ..operations import (
 from ..operations.run_pipeline import create_progress_reporter
 from .nodestream_command import NodestreamCommand
 from .shared_options import JSON_OPTION, PROJECT_FILE_OPTION, PROMETHEUS_OPTIONS
+
+logger = getLogger(__name__)
 
 
 class UnknownTargetError(Exception):
@@ -124,42 +127,45 @@ class Copy(NodestreamCommand):
                 from_target = self.get_taget_from_user(project, "from")
                 to_target = self.get_taget_from_user(project, "to")
                 relationships_only = bool(self.option("relationships-only"))
-                use_all = self.option("all")
+
+                # Always build the schema so type filters can be validated
+                # against it and the retriever has full type metadata.
+                schema = project.make_schema_for_copy(include_additional_types=False)
+                node_types = self.resolve_type_filter(schema.nodes, "node")
+
+                # When node types are explicitly filtered (not --all and not
+                # interactive-all), narrow relationships to those whose
+                # adjacency involves at least one selected node type — unless
+                # the user also provided explicit --relationship filters.
                 explicit_nodes = self.option("node")
-                explicit_rels = self.option("relationship")
-
-                # Only load the schema when we actually need it: --all requires
-                # enumeration, and explicit types with no --all need validation.
-                # When both --node and --relationship are provided without --all
-                # we skip schema loading entirely (avoids instantiating pipeline
-                # steps like Athena extractors that need external credentials).
-                needs_schema = use_all or not (explicit_nodes or explicit_rels)
-                if needs_schema:
-                    # For copy operations we intentionally build a schema *without*
-                    # expanding additional types so that we only copy the concrete
-                    # node / relationship types declared in pipelines.
-                    schema = project.make_schema_for_copy(
-                        include_additional_types=False
-                    )
-                    all_node_types = schema.nodes
-                    all_rel_types = schema.relationships
+                if (
+                    explicit_nodes
+                    and not self.option("relationship")
+                    and not self.option("all")
+                ):
+                    node_set = set(node_types)
+                    rel_types = [
+                        adj.relationship_type
+                        for adj in schema.adjacencies
+                        if adj.from_node_type in node_set
+                        or adj.to_node_type in node_set
+                    ]
+                    # deduplicate while preserving order
+                    seen: set = set()
+                    rel_types = [r for r in rel_types if not (r in seen or seen.add(r))]
                 else:
-                    schema = Schema()
-                    all_node_types = []
-                    all_rel_types = []
+                    rel_types = self.resolve_type_filter(
+                        schema.relationships, "relationship"
+                    )
 
-                node_types = self.get_type_selection_from_user(all_node_types, "node")
-                rel_types = self.get_type_selection_from_user(
-                    all_rel_types, "relationship"
-                )
                 batch_size = int(self.option("batch-size"))
                 step_outbox_size = int(self.option("step-outbox-size"))
                 flush_concurrency = int(self.option("flush-concurrency"))
-                connector_overrides = self.parse_key_value_options("connector-option")
-                retriever_overrides = self.parse_key_value_options("retriever-option")
                 concurrency_limit = int(self.option("concurrency-limit"))
                 shard_size_raw = self.option("shard-size")
-                shard_size = int(shard_size_raw) if shard_size_raw is not None else None
+                connector_overrides = self.parse_key_value_options("connector-option")
+                retriever_overrides = self.parse_key_value_options("retriever-option")
+
                 # Merge CLI-level retriever knobs into retriever_overrides so that
                 # make_type_retriever receives a single flat dict. Plugins pop what
                 # they understand and ignore the rest — no plugin-specific kwargs
@@ -169,29 +175,23 @@ class Copy(NodestreamCommand):
                     "orchestrator_queue_size", step_outbox_size
                 )
                 retriever_overrides.setdefault("relationships_only", relationships_only)
-                if shard_size is not None:
-                    retriever_overrides.setdefault("shard_size", shard_size)
+                if shard_size_raw is not None:
+                    retriever_overrides.setdefault("shard_size", int(shard_size_raw))
             except UnknownTargetError:
                 return 1
 
-            self.line("Starting to Copy:")
-            self.line(f"<info>From: {from_target.name}</info>")
-            self.line(f"<info>To: {to_target.name}</info>")
-            if relationships_only:
-                self.line("<info>Mode: relationships only (nodes skipped)</info>")
-            else:
-                self.line(f"<info>Node Types: {', '.join(node_types)}</info>")
-            self.line(f"<info>Relationship Types: {', '.join(rel_types)}</info>")
-            if concurrency_limit > 1:
-                self.line(f"<info>Concurrency Limit: {concurrency_limit}</info>")
-            if flush_concurrency > 1:
-                self.line(f"<info>Flush Concurrency: {flush_concurrency}</info>")
-            if connector_overrides:
-                self.line(f"<info>Connector Overrides: {connector_overrides}</info>")
-            if retriever_overrides:
-                self.line(f"<info>Retriever Options: {retriever_overrides}</info>")
-            if shard_size is not None:
-                self.line(f"<info>Shard Size: {shard_size}</info>")
+            logger.info(
+                "Starting copy",
+                extra={
+                    "from": from_target.name,
+                    "to": to_target.name,
+                    "relationships_only": relationships_only,
+                    "node_types": node_types,
+                    "relationship_types": rel_types,
+                    "retriever_overrides": retriever_overrides,
+                    "connector_overrides": connector_overrides,
+                },
+            )
             reporter = create_progress_reporter(self, "copy")
             await self.run_operation(
                 RunCopy(
@@ -245,36 +245,33 @@ class Copy(NodestreamCommand):
             self.line_error(f"Unknown target: {choice}")
             raise UnknownTargetError
 
-    def get_type_selection_from_user(
-        self, types: List[GraphObjectSchema], type_name: str
+    def resolve_type_filter(
+        self, schema_types: List[GraphObjectSchema], type_name: str
     ) -> List[str]:
-        choices = [str(t.name) for t in types]
+        """Return the list of type names to copy for this kind (node/relationship).
 
-        # If the user has specified the --all flag, we don't need to prompt them for
-        # anything. We can just return all the types.
+        --all (default): all types from schema.
+        explicit --node/--relationship flags: validate against schema and use as filter.
+        Neither flag set interactively: prompt user to select from schema types.
+        """
+        all_names = [str(t.name) for t in schema_types]
+
         if self.option("all"):
-            return choices
+            return all_names
 
-        # If the user has specified type(s) in the options, we don't need to prompt
-        # them for anything. We can just return the type they specified. If they
-        # specified an unknown type, we should error out — but only when we have
-        # a schema to validate against (choices is non-empty).
-        selections_from_options = self.option(type_name)
-        if selections_from_options:
-            if choices:
-                for selection in selections_from_options:
-                    if selection not in choices:
-                        self.line_error(
-                            f"Unknown {type_name} type: {selection}. "
-                            f"Valid options are: {', '.join(choices)}"
-                        )
-                        raise UnknownTargetError
-            return selections_from_options
+        explicit = self.option(type_name)
+        if explicit:
+            unknown = [t for t in explicit if t not in all_names]
+            if unknown:
+                self.line_error(
+                    f"Unknown {type_name} type(s): {', '.join(unknown)}. "
+                    f"Valid options are: {', '.join(all_names)}"
+                )
+                raise UnknownTargetError
+            return list(explicit)
 
-        # If the user has not specified the type(s) in the options, we need to prompt
-        # them for the type(s). We can just return the type they specified.
         return self.choice(
             f"Which {type_name} types would you like to copy? (You can select multiple by separating them with a comma)",
-            choices,
+            all_names,
             multiple=True,
         )

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Dict, Optional, Set
+from typing import Dict
 
 from cleo.helpers import option
 
@@ -185,28 +185,22 @@ class Copy(NodestreamCommand):
         --relationship X Y: all adjacencies of type X or Y (and their endpoint nodes),
                             restricted to nodes in --node if also provided.
         """
-        node_filter: Optional[Set[str]] = None
-        rel_filter: Optional[Set[str]] = None
+        node_filter = []
+        rel_filter = []
 
-        explicit_nodes = self.option("node")
-        explicit_rels = self.option("relationship")
+        all_node_names = {n.name for n in schema.nodes}
+        for n in self.option("node") or []:
+            if n in all_node_names:
+                node_filter.append(n)
+            else:
+                logger.warning("Unknown node type %r — skipping", n)
 
-        if explicit_nodes:
-            all_node_names = {n.name for n in schema.nodes}
-            unknown = [n for n in explicit_nodes if n not in all_node_names]
-            for u in unknown:
-                logger.warning("Unknown node type %r — skipping", u)
-            node_filter = {n for n in explicit_nodes if n in all_node_names}
-
-        if explicit_rels:
-            all_rel_names = {r.name for r in schema.relationships}
-            unknown = [r for r in explicit_rels if r not in all_rel_names]
-            for u in unknown:
-                logger.warning("Unknown relationship type %r — skipping", u)
-            rel_filter = {r for r in explicit_rels if r in all_rel_names}
-
-        if node_filter is None and rel_filter is None:
-            return schema
+        all_rel_names = {r.name for r in schema.relationships}
+        for r in self.option("relationship") or []:
+            if r in all_rel_names:
+                rel_filter.append(r)
+            else:
+                logger.warning("Unknown relationship type %r — skipping", r)
 
         return schema.filtered(node_filter=node_filter, relationship_filter=rel_filter)
 

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -138,10 +138,6 @@ class Copy(NodestreamCommand):
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
 
-                retriever_overrides.setdefault("concurrency_limit", concurrency_limit)
-                retriever_overrides.setdefault(
-                    "orchestrator_queue_size", step_outbox_size
-                )
                 retriever_overrides.setdefault("node_only", node_only)
                 if shard_size_raw is not None:
                     retriever_overrides.setdefault("shard_size", int(shard_size_raw))
@@ -170,6 +166,7 @@ class Copy(NodestreamCommand):
                     batch_size=batch_size,
                     step_outbox_size=step_outbox_size,
                     flush_concurrency=flush_concurrency,
+                    concurrency_limit=concurrency_limit,
                     connector_overrides=connector_overrides,
                     retriever_overrides=retriever_overrides,
                 )

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -105,12 +105,10 @@ class Copy(NodestreamCommand):
             flag=False,
         ),
         option(
-            "relationships-only",
+            "node-only",
             description=(
-                "Skip node fetching entirely — copy only relationships. "
-                "Nodes must already exist in the target; missing endpoints "
-                "are silently dropped (MATCH_ONLY). Useful for e2e test "
-                "partition seeding where nodes are pre-populated."
+                "Copy only nodes — skip relationship fetching entirely. "
+                "Useful when you want to seed nodes without their adjacencies."
             ),
             flag=True,
         ),
@@ -126,7 +124,7 @@ class Copy(NodestreamCommand):
             try:
                 from_target = self.get_taget_from_user(project, "from")
                 to_target = self.get_taget_from_user(project, "to")
-                relationships_only = bool(self.option("relationships-only"))
+                node_only = bool(self.option("node-only"))
 
                 # Always build the schema so type filters can be validated
                 # against it and the retriever has full type metadata.
@@ -174,7 +172,7 @@ class Copy(NodestreamCommand):
                 retriever_overrides.setdefault(
                     "orchestrator_queue_size", step_outbox_size
                 )
-                retriever_overrides.setdefault("relationships_only", relationships_only)
+                retriever_overrides.setdefault("node_only", node_only)
                 if shard_size_raw is not None:
                     retriever_overrides.setdefault("shard_size", int(shard_size_raw))
             except UnknownTargetError:
@@ -185,7 +183,7 @@ class Copy(NodestreamCommand):
                 extra={
                     "from": from_target.name,
                     "to": to_target.name,
-                    "relationships_only": relationships_only,
+                    "node_only": node_only,
                     "node_types": node_types,
                     "relationship_types": rel_types,
                     "retriever_overrides": retriever_overrides,

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -90,6 +90,17 @@ class Copy(NodestreamCommand):
             flag=False,
             multiple=True,
         ),
+        option(
+            "shard-size",
+            description=(
+                "Split each type into fixed-size shards of this many records, "
+                "interleaved across types for sustained concurrency. "
+                "Requires the type retriever to support sharding. "
+                "Disabled when not set."
+            ),
+            default=None,
+            flag=False,
+        ),
         *PROMETHEUS_OPTIONS,
     ]
 
@@ -118,6 +129,8 @@ class Copy(NodestreamCommand):
                 flush_concurrency = int(self.option("flush-concurrency"))
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
+                shard_size_raw = self.option("shard-size")
+                shard_size = int(shard_size_raw) if shard_size_raw is not None else None
             except UnknownTargetError:
                 return 1
 
@@ -134,6 +147,8 @@ class Copy(NodestreamCommand):
                 self.line(f"<info>Connector Overrides: {connector_overrides}</info>")
             if retriever_overrides:
                 self.line(f"<info>Retriever Options: {retriever_overrides}</info>")
+            if shard_size is not None:
+                self.line(f"<info>Shard Size: {shard_size}</info>")
             reporter = create_progress_reporter(self, "copy")
             await self.run_operation(
                 RunCopy(
@@ -149,6 +164,7 @@ class Copy(NodestreamCommand):
                     flush_concurrency=flush_concurrency,
                     connector_overrides=connector_overrides,
                     retriever_overrides=retriever_overrides,
+                    shard_size=shard_size,
                 )
             )
         return 0

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -1,5 +1,4 @@
 from logging import getLogger
-from typing import Dict
 
 from cleo.helpers import option
 
@@ -123,7 +122,7 @@ class Copy(NodestreamCommand):
             try:
                 from_target = self.get_taget_from_user(project, "from")
                 to_target = self.get_taget_from_user(project, "to")
-                preloadNodes = bool(self.option("preload-nodes"))
+                preload_nodes = bool(self.option("preload-nodes"))
 
                 full_schema = project.make_schema_for_copy(
                     include_additional_types=False
@@ -134,13 +133,13 @@ class Copy(NodestreamCommand):
                 step_outbox_size = int(self.option("step-outbox-size"))
                 flush_concurrency = int(self.option("flush-concurrency"))
                 concurrency_limit = int(self.option("concurrency-limit"))
-                shardSizeRaw = self.option("shard-size")
+                shard_size_raw = self.option("shard-size")
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
 
-                retriever_overrides.setdefault("preload_nodes", preloadNodes)
-                if shardSizeRaw is not None:
-                    retriever_overrides.setdefault("shard_size", int(shardSizeRaw))
+                retriever_overrides.setdefault("preload_nodes", preload_nodes)
+                if shard_size_raw is not None:
+                    retriever_overrides.setdefault("shard_size", int(shard_size_raw))
             except UnknownTargetError:
                 return 1
 
@@ -149,11 +148,11 @@ class Copy(NodestreamCommand):
                 extra={
                     "from": from_target.name,
                     "to": to_target.name,
-                    "preload_nodes": preloadNodes,
-                    "node_types": [nodeType.name for nodeType in schema.nodes],
+                    "preload_nodes": preload_nodes,
+                    "node_types": [node_type.name for node_type in schema.nodes],
                     "relationship_types": [
-                        relationshipType.name
-                        for relationshipType in schema.relationships
+                        relationship_type.name
+                        for relationship_type in schema.relationships
                     ],
                     "retriever_overrides": retriever_overrides,
                     "connector_overrides": connector_overrides,
@@ -210,9 +209,9 @@ class Copy(NodestreamCommand):
             node_filter=node_filter, relationship_filter=relationship_filter
         )
 
-    def parse_key_value_options(self, option_name: str) -> Dict[str, object]:
+    def parse_key_value_options(self, option_name: str) -> dict[str, object]:
         raw = self.option(option_name) or []
-        overrides: Dict[str, object] = {}
+        overrides: dict[str, object] = {}
         for item in raw:
             key, _, value = item.partition("=")
             if value.lower() == "true":

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -194,24 +194,16 @@ class Copy(NodestreamCommand):
         if explicit_nodes:
             all_node_names = {n.name for n in schema.nodes}
             unknown = [n for n in explicit_nodes if n not in all_node_names]
-            if unknown:
-                self.line_error(
-                    f"Unknown node type(s): {', '.join(unknown)}. "
-                    f"Valid options are: {', '.join(sorted(all_node_names))}"
-                )
-                raise UnknownTargetError
-            node_filter = set(explicit_nodes)
+            for u in unknown:
+                logger.warning("Unknown node type %r — skipping", u)
+            node_filter = {n for n in explicit_nodes if n in all_node_names}
 
         if explicit_rels:
             all_rel_names = {r.name for r in schema.relationships}
             unknown = [r for r in explicit_rels if r not in all_rel_names]
-            if unknown:
-                self.line_error(
-                    f"Unknown relationship type(s): {', '.join(unknown)}. "
-                    f"Valid options are: {', '.join(sorted(all_rel_names))}"
-                )
-                raise UnknownTargetError
-            rel_filter = set(explicit_rels)
+            for u in unknown:
+                logger.warning("Unknown relationship type %r — skipping", u)
+            rel_filter = {r for r in explicit_rels if r in all_rel_names}
 
         if node_filter is None and rel_filter is None:
             return schema

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -186,27 +186,29 @@ class Copy(NodestreamCommand):
                             restricted to nodes in --node if also provided.
         """
         node_filter = []
-        rel_filter = []
+        relationship_filter = []
 
-        all_node_names = {nodeType.name for nodeType in schema.nodes}
-        for nodeTypeName in self.option("node") or []:
-            if nodeTypeName in all_node_names:
-                node_filter.append(nodeTypeName)
+        all_node_names = {node_type.name for node_type in schema.nodes}
+        for node_type_name in self.option("node") or []:
+            if node_type_name in all_node_names:
+                node_filter.append(node_type_name)
             else:
-                logger.warning("Unknown node type %r — skipping", nodeTypeName)
+                logger.warning("Unknown node type %r — skipping", node_type_name)
 
-        all_rel_names = {
-            relationshipType.name for relationshipType in schema.relationships
+        all_relationship_names = {
+            relationship_type.name for relationship_type in schema.relationships
         }
-        for relationshipTypeName in self.option("relationship") or []:
-            if relationshipTypeName in all_rel_names:
-                rel_filter.append(relationshipTypeName)
+        for relationship_type_name in self.option("relationship") or []:
+            if relationship_type_name in all_relationship_names:
+                relationship_filter.append(relationship_type_name)
             else:
                 logger.warning(
-                    "Unknown relationship type %r — skipping", relationshipTypeName
+                    "Unknown relationship type %r — skipping", relationship_type_name
                 )
 
-        return schema.filtered(node_filter=node_filter, relationship_filter=rel_filter)
+        return schema.filtered(
+            node_filter=node_filter, relationship_filter=relationship_filter
+        )
 
     def parse_key_value_options(self, option_name: str) -> Dict[str, object]:
         raw = self.option(option_name) or []

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -138,7 +138,9 @@ class Copy(NodestreamCommand):
                     # For copy operations we intentionally build a schema *without*
                     # expanding additional types so that we only copy the concrete
                     # node / relationship types declared in pipelines.
-                    schema = project.make_schema_for_copy(include_additional_types=False)
+                    schema = project.make_schema_for_copy(
+                        include_additional_types=False
+                    )
                     all_node_types = schema.nodes
                     all_rel_types = schema.relationships
                 else:
@@ -147,7 +149,9 @@ class Copy(NodestreamCommand):
                     all_rel_types = []
 
                 node_types = self.get_type_selection_from_user(all_node_types, "node")
-                rel_types = self.get_type_selection_from_user(all_rel_types, "relationship")
+                rel_types = self.get_type_selection_from_user(
+                    all_rel_types, "relationship"
+                )
                 batch_size = int(self.option("batch-size"))
                 step_outbox_size = int(self.option("step-outbox-size"))
                 flush_concurrency = int(self.option("flush-concurrency"))
@@ -161,7 +165,9 @@ class Copy(NodestreamCommand):
                 # they understand and ignore the rest — no plugin-specific kwargs
                 # leak from core into the retriever contract.
                 retriever_overrides.setdefault("concurrency_limit", concurrency_limit)
-                retriever_overrides.setdefault("orchestrator_queue_size", step_outbox_size)
+                retriever_overrides.setdefault(
+                    "orchestrator_queue_size", step_outbox_size
+                )
                 retriever_overrides.setdefault("relationships_only", relationships_only)
                 if shard_size is not None:
                     retriever_overrides.setdefault("shard_size", shard_size)

--- a/nodestream/cli/commands/copy.py
+++ b/nodestream/cli/commands/copy.py
@@ -4,7 +4,7 @@ from cleo.helpers import option
 
 from ...metrics import Metrics
 from ...project import Project, Target
-from ...schema import GraphObjectSchema
+from ...schema import GraphObjectSchema, Schema
 from ..operations import (
     InitializeLogger,
     InitializeMetricsHandler,
@@ -101,6 +101,16 @@ class Copy(NodestreamCommand):
             default=None,
             flag=False,
         ),
+        option(
+            "relationships-only",
+            description=(
+                "Skip node fetching entirely — copy only relationships. "
+                "Nodes must already exist in the target; missing endpoints "
+                "are silently dropped (MATCH_ONLY). Useful for e2e test "
+                "partition seeding where nodes are pre-populated."
+            ),
+            flag=True,
+        ),
         *PROMETHEUS_OPTIONS,
     ]
 
@@ -113,31 +123,58 @@ class Copy(NodestreamCommand):
             try:
                 from_target = self.get_taget_from_user(project, "from")
                 to_target = self.get_taget_from_user(project, "to")
-                # For copy operations we intentionally build a schema *without*
-                # expanding additional types so that we only copy the concrete
-                # node / relationship types declared in pipelines.
-                schema = project.make_schema(include_additional_types=False)
-                all_node_types = schema.nodes
-                all_rel_types = schema.relationships
+                relationships_only = bool(self.option("relationships-only"))
+                use_all = self.option("all")
+                explicit_nodes = self.option("node")
+                explicit_rels = self.option("relationship")
+
+                # Only load the schema when we actually need it: --all requires
+                # enumeration, and explicit types with no --all need validation.
+                # When both --node and --relationship are provided without --all
+                # we skip schema loading entirely (avoids instantiating pipeline
+                # steps like Athena extractors that need external credentials).
+                needs_schema = use_all or not (explicit_nodes or explicit_rels)
+                if needs_schema:
+                    # For copy operations we intentionally build a schema *without*
+                    # expanding additional types so that we only copy the concrete
+                    # node / relationship types declared in pipelines.
+                    schema = project.make_schema_for_copy(include_additional_types=False)
+                    all_node_types = schema.nodes
+                    all_rel_types = schema.relationships
+                else:
+                    schema = Schema()
+                    all_node_types = []
+                    all_rel_types = []
+
                 node_types = self.get_type_selection_from_user(all_node_types, "node")
-                rel_types = self.get_type_selection_from_user(
-                    all_rel_types, "relationship"
-                )
-                concurrency_limit = int(self.option("concurrency-limit"))
+                rel_types = self.get_type_selection_from_user(all_rel_types, "relationship")
                 batch_size = int(self.option("batch-size"))
                 step_outbox_size = int(self.option("step-outbox-size"))
                 flush_concurrency = int(self.option("flush-concurrency"))
                 connector_overrides = self.parse_key_value_options("connector-option")
                 retriever_overrides = self.parse_key_value_options("retriever-option")
+                concurrency_limit = int(self.option("concurrency-limit"))
                 shard_size_raw = self.option("shard-size")
                 shard_size = int(shard_size_raw) if shard_size_raw is not None else None
+                # Merge CLI-level retriever knobs into retriever_overrides so that
+                # make_type_retriever receives a single flat dict. Plugins pop what
+                # they understand and ignore the rest — no plugin-specific kwargs
+                # leak from core into the retriever contract.
+                retriever_overrides.setdefault("concurrency_limit", concurrency_limit)
+                retriever_overrides.setdefault("orchestrator_queue_size", step_outbox_size)
+                retriever_overrides.setdefault("relationships_only", relationships_only)
+                if shard_size is not None:
+                    retriever_overrides.setdefault("shard_size", shard_size)
             except UnknownTargetError:
                 return 1
 
             self.line("Starting to Copy:")
             self.line(f"<info>From: {from_target.name}</info>")
             self.line(f"<info>To: {to_target.name}</info>")
-            self.line(f"<info>Node Types: {', '.join(node_types)}</info>")
+            if relationships_only:
+                self.line("<info>Mode: relationships only (nodes skipped)</info>")
+            else:
+                self.line(f"<info>Node Types: {', '.join(node_types)}</info>")
             self.line(f"<info>Relationship Types: {', '.join(rel_types)}</info>")
             if concurrency_limit > 1:
                 self.line(f"<info>Concurrency Limit: {concurrency_limit}</info>")
@@ -157,14 +194,12 @@ class Copy(NodestreamCommand):
                     schema=schema,
                     node_types=node_types,
                     relationship_types=rel_types,
-                    concurrency_limit=concurrency_limit,
                     progress_reporter=reporter,
                     batch_size=batch_size,
                     step_outbox_size=step_outbox_size,
                     flush_concurrency=flush_concurrency,
                     connector_overrides=connector_overrides,
                     retriever_overrides=retriever_overrides,
-                    shard_size=shard_size,
                 )
             )
         return 0
@@ -216,16 +251,18 @@ class Copy(NodestreamCommand):
 
         # If the user has specified type(s) in the options, we don't need to prompt
         # them for anything. We can just return the type they specified. If they
-        # specified an unknown type, we should error out.
+        # specified an unknown type, we should error out — but only when we have
+        # a schema to validate against (choices is non-empty).
         selections_from_options = self.option(type_name)
         if selections_from_options:
-            for selection in selections_from_options:
-                if selection not in choices:
-                    self.line_error(
-                        f"Unknown {type_name} type: {selection}. "
-                        f"Valid options are: {', '.join(choices)}"
-                    )
-                    raise UnknownTargetError
+            if choices:
+                for selection in selections_from_options:
+                    if selection not in choices:
+                        self.line_error(
+                            f"Unknown {type_name} type: {selection}. "
+                            f"Valid options are: {', '.join(choices)}"
+                        )
+                        raise UnknownTargetError
             return selections_from_options
 
         # If the user has not specified the type(s) in the options, we need to prompt

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from ...databases import Copier, GraphDatabaseWriter
 from ...pipeline import Pipeline
@@ -16,8 +16,6 @@ class RunCopy(Operation):
         from_target: Target,
         to_target: Target,
         schema: Schema,
-        node_types: List[str],
-        relationship_types: List[str],
         progress_reporter: Optional[PipelineProgressReporter] = None,
         batch_size: int = 1000,
         step_outbox_size: int = 10000,
@@ -28,8 +26,6 @@ class RunCopy(Operation):
         self.from_target = from_target
         self.to_target = to_target
         self.schema = schema
-        self.node_types = node_types
-        self.relationship_types = relationship_types
         self.progress_reporter = progress_reporter or PipelineProgressReporter()
         self.batch_size = batch_size
         self.step_outbox_size = step_outbox_size
@@ -52,8 +48,6 @@ class RunCopy(Operation):
     def build_copier(self) -> Copier:
         retriever = self.from_target.make_type_retriever(
             schema=self.schema,
-            node_types=self.node_types,
-            relationship_types=self.relationship_types,
             **self.retriever_overrides,
         )
         return Copier(retriever)

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -25,6 +25,7 @@ class RunCopy(Operation):
         flush_concurrency: int = 1,
         connector_overrides: Optional[Dict[str, object]] = None,
         retriever_overrides: Optional[Dict[str, object]] = None,
+        shard_size: Optional[int] = None,
     ) -> None:
         self.from_target = from_target
         self.to_target = to_target
@@ -38,6 +39,7 @@ class RunCopy(Operation):
         self.flush_concurrency = flush_concurrency
         self.connector_overrides = connector_overrides or {}
         self.retriever_overrides = retriever_overrides or {}
+        self.shard_size = shard_size
 
     async def perform(self, command: NodestreamCommand):
         pipeline = self.build_pipeline()
@@ -60,6 +62,7 @@ class RunCopy(Operation):
             self.relationship_types,
             concurrency_limit=self.concurrency_limit,
             orchestrator_queue_size=self.step_outbox_size,
+            shard_size=self.shard_size,
         )
 
     def build_writer(self) -> GraphDatabaseWriter:

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -51,11 +51,12 @@ class RunCopy(Operation):
 
     def build_copier(self) -> Copier:
         retriever = self.from_target.make_type_retriever(
+            schema=self.schema,
             node_types=self.node_types,
             relationship_types=self.relationship_types,
             **self.retriever_overrides,
         )
-        return Copier(retriever, self.schema)
+        return Copier(retriever)
 
     def build_writer(self) -> GraphDatabaseWriter:
         return self.to_target.make_writer(

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -18,35 +18,31 @@ class RunCopy(Operation):
         schema: Schema,
         node_types: List[str],
         relationship_types: List[str],
-        concurrency_limit: int = 1,
         progress_reporter: Optional[PipelineProgressReporter] = None,
         batch_size: int = 1000,
         step_outbox_size: int = 10000,
         flush_concurrency: int = 1,
         connector_overrides: Optional[Dict[str, object]] = None,
         retriever_overrides: Optional[Dict[str, object]] = None,
-        shard_size: Optional[int] = None,
     ) -> None:
         self.from_target = from_target
         self.to_target = to_target
         self.schema = schema
         self.node_types = node_types
         self.relationship_types = relationship_types
-        self.concurrency_limit = concurrency_limit
         self.progress_reporter = progress_reporter or PipelineProgressReporter()
         self.batch_size = batch_size
         self.step_outbox_size = step_outbox_size
         self.flush_concurrency = flush_concurrency
         self.connector_overrides = connector_overrides or {}
         self.retriever_overrides = retriever_overrides or {}
-        self.shard_size = shard_size
 
     async def perform(self, command: NodestreamCommand):
-        pipeline = self.build_pipeline()
+        pipeline = await self.build_pipeline()
         await pipeline.run(reporter=self.progress_reporter)
 
-    def build_pipeline(self) -> Pipeline:
-        copier = self.build_copier()
+    async def build_pipeline(self) -> Pipeline:
+        copier = await self.build_copier()
         writer = self.build_writer()
         return Pipeline(
             (copier, writer),
@@ -54,16 +50,20 @@ class RunCopy(Operation):
             object_store=ObjectStore.null(),
         )
 
-    def build_copier(self) -> Copier:
-        return Copier.create(
-            self.from_target.make_type_retriever(**self.retriever_overrides),
-            self.schema,
-            self.node_types,
-            self.relationship_types,
-            concurrency_limit=self.concurrency_limit,
-            orchestrator_queue_size=self.step_outbox_size,
-            shard_size=self.shard_size,
+    async def build_copier(self) -> Copier:
+        retriever = self.from_target.make_type_retriever(
+            node_types=self.node_types,
+            relationship_types=self.relationship_types,
+            **self.retriever_overrides,
         )
+        schema = self.schema
+        # If the schema has no node types defined (skipped for performance), infer
+        # key fields and adjacency patterns from the live source database.
+        if not list(schema.nodes) and hasattr(retriever, "build_schema_from_db"):
+            schema = await retriever.build_schema_from_db(
+                self.node_types, self.relationship_types
+            )
+        return Copier(retriever, schema)
 
     def build_writer(self) -> GraphDatabaseWriter:
         return self.to_target.make_writer(

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -20,6 +20,7 @@ class RunCopy(Operation):
         batch_size: int = 1000,
         step_outbox_size: int = 10000,
         flush_concurrency: int = 1,
+        concurrency_limit: int = 1,
         connector_overrides: Optional[Dict[str, object]] = None,
         retriever_overrides: Optional[Dict[str, object]] = None,
     ) -> None:
@@ -30,6 +31,7 @@ class RunCopy(Operation):
         self.batch_size = batch_size
         self.step_outbox_size = step_outbox_size
         self.flush_concurrency = flush_concurrency
+        self.concurrency_limit = concurrency_limit
         self.connector_overrides = connector_overrides or {}
         self.retriever_overrides = retriever_overrides or {}
 
@@ -50,7 +52,11 @@ class RunCopy(Operation):
             schema=self.schema,
             **self.retriever_overrides,
         )
-        return Copier(retriever)
+        return Copier(
+            retriever,
+            concurrency_limit=self.concurrency_limit,
+            queue_size=self.step_outbox_size,
+        )
 
     def build_writer(self) -> GraphDatabaseWriter:
         return self.to_target.make_writer(

--- a/nodestream/cli/operations/run_copy.py
+++ b/nodestream/cli/operations/run_copy.py
@@ -38,11 +38,10 @@ class RunCopy(Operation):
         self.retriever_overrides = retriever_overrides or {}
 
     async def perform(self, command: NodestreamCommand):
-        pipeline = await self.build_pipeline()
-        await pipeline.run(reporter=self.progress_reporter)
+        await self.build_pipeline().run(reporter=self.progress_reporter)
 
-    async def build_pipeline(self) -> Pipeline:
-        copier = await self.build_copier()
+    def build_pipeline(self) -> Pipeline:
+        copier = self.build_copier()
         writer = self.build_writer()
         return Pipeline(
             (copier, writer),
@@ -50,20 +49,13 @@ class RunCopy(Operation):
             object_store=ObjectStore.null(),
         )
 
-    async def build_copier(self) -> Copier:
+    def build_copier(self) -> Copier:
         retriever = self.from_target.make_type_retriever(
             node_types=self.node_types,
             relationship_types=self.relationship_types,
             **self.retriever_overrides,
         )
-        schema = self.schema
-        # If the schema has no node types defined (skipped for performance), infer
-        # key fields and adjacency patterns from the live source database.
-        if not list(schema.nodes) and hasattr(retriever, "build_schema_from_db"):
-            schema = await retriever.build_schema_from_db(
-                self.node_types, self.relationship_types
-            )
-        return Copier(retriever, schema)
+        return Copier(retriever, self.schema)
 
     def build_writer(self) -> GraphDatabaseWriter:
         return self.to_target.make_writer(

--- a/nodestream/databases/__init__.py
+++ b/nodestream/databases/__init__.py
@@ -1,4 +1,4 @@
-from .copy import ConcurrentCopier, Copier, TypeRetriever
+from .copy import Copier, TypeRetriever
 from .database_connector import DatabaseConnector
 from .debounced_ingest_strategy import DebouncedIngestStrategy
 from .writer import ConcurrentGraphDatabaseWriter, GraphDatabaseWriter
@@ -10,5 +10,4 @@ __all__ = (
     "DatabaseConnector",
     "TypeRetriever",
     "Copier",
-    "ConcurrentCopier",
 )

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -141,12 +141,16 @@ class Copier(Extractor):
                     break
                 yield record
         finally:
+            # Cancel the producer first so it stops blocking on a full queue
+            # if the consumer exited early (exception or generator abandoned).
+            producer_task.cancel()
             try:
                 await producer_task
-            except Exception as exc:
-                # Store the error instead of raising here so the finally block
-                # completes before propagating — re-raised immediately after.
-                producer_error = exc
+            except (asyncio.CancelledError, Exception) as exc:
+                # Store non-cancellation errors to re-raise after the finally
+                # completes. CancelledError is expected when we cancelled above.
+                if not isinstance(exc, asyncio.CancelledError):
+                    producer_error = exc
         if producer_error is not None:
             raise producer_error
 

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -102,7 +102,7 @@ class TypeRetriever(ABC):
         return TypeHistogram.empty()
 
 
-class FetchOrchestrator(ABC):
+class ExtractionOrchestrator(ABC):
     """Controls how the Copier drives fetchNodes and fetchRelationships.
 
     Selected once at Copier construction time based on the retriever's
@@ -119,7 +119,7 @@ class FetchOrchestrator(ABC):
     ) -> AsyncGenerator[Any, None]: ...
 
 
-class SequentialFetchOrchestrator(FetchOrchestrator):
+class SequentialExtractionOrchestrator(ExtractionOrchestrator):
     def __init__(self, includeNodes: bool) -> None:
         self.includeNodes = includeNodes
 
@@ -137,7 +137,7 @@ class SequentialFetchOrchestrator(FetchOrchestrator):
             yield convertRelationship(relationship)
 
 
-class ConcurrentFetchOrchestrator(FetchOrchestrator):
+class ConcurrentExtractionOrchestrator(ExtractionOrchestrator):
     """Producer/consumer orchestrator with separate node and relationship queues.
 
     The node queue is fully produced and drained before the relationship queue
@@ -213,11 +213,11 @@ class ConcurrentFetchOrchestrator(FetchOrchestrator):
             raise relationshipError
 
 
-def buildFetchOrchestrator(retriever: TypeRetriever) -> FetchOrchestrator:
+def buildExtractionOrchestrator(retriever: TypeRetriever) -> ExtractionOrchestrator:
     includeNodes = not retriever.relationships_only
     if retriever.concurrency_limit > 1:
-        return ConcurrentFetchOrchestrator(includeNodes=includeNodes)
-    return SequentialFetchOrchestrator(includeNodes=includeNodes)
+        return ConcurrentExtractionOrchestrator(includeNodes=includeNodes)
+    return SequentialExtractionOrchestrator(includeNodes=includeNodes)
 
 
 class Copier(Extractor):
@@ -236,7 +236,7 @@ class Copier(Extractor):
         self.type_retriever = type_retriever
         self.schema = schema
         self.logger = getLogger(__name__)
-        self.orchestrator = buildFetchOrchestrator(type_retriever)
+        self.orchestrator = buildExtractionOrchestrator(type_retriever)
 
     async def start(self, context: StepContext):
         await super().start(context)

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
-from typing import AsyncGenerator, Dict, List
+from typing import AsyncGenerator
 
 from ..metrics import Metric, Metrics
 from ..pipeline import Extractor
@@ -21,10 +21,11 @@ ACTIVE_QUERIES = Metric(
 class TypeHistogram:
     """Count estimates for all node and relationship types to be copied."""
 
-    node_counts: Dict[str, int] = field(default_factory=dict)
-    relationship_counts: Dict[str, int] = field(default_factory=dict)
+    node_counts: dict[str, int] = field(default_factory=dict)
+    relationship_counts: dict[str, int] = field(default_factory=dict)
 
-    def sorted_types_by_count(self, counts: Dict[str, int]) -> List[str]:
+    @staticmethod
+    def sorted_types_by_count(counts: dict[str, int]) -> list[str]:
         return sorted(counts, key=counts.__getitem__, reverse=True)
 
     def log(self, logger: Logger) -> None:

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -44,8 +44,10 @@ class TypeHistogram:
         for nodeType in self.sorted_node_types():
             logger.info("  %s: %d", nodeType, self.node_counts[nodeType])
         logger.info("Relationship type histogram (descending):")
-        for relType in self.sorted_relationship_types():
-            logger.info("  %s: %d", relType, self.relationship_counts[relType])
+        for relationshipType in self.sorted_relationship_types():
+            logger.info(
+                "  %s: %d", relationshipType, self.relationship_counts[relationshipType]
+            )
         logger.info(
             "Total nodes: %d, Total relationships: %d",
             sum(self.node_counts.values()),
@@ -110,54 +112,51 @@ class Copier(Extractor):
         histogram.log(self.logger)
 
     async def extract_records(self):
-        queue_size = self.queue_size
         semaphore = asyncio.Semaphore(self.concurrency_limit)
-        record_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
+        recordQueue: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size)
 
-        async def run_extractor(extractor: Extractor) -> None:
+        async def runExtractor(extractor: Extractor) -> None:
             async with semaphore:
                 Metrics.get().increment(ACTIVE_QUERIES)
                 try:
                     async for record in extractor.extract_records():
-                        await record_queue.put(record)
+                        await recordQueue.put(record)
                 finally:
                     Metrics.get().decrement(ACTIVE_QUERIES)
 
-        async def produce_all() -> None:
+        async def produceAll() -> None:
             tasks = []
             try:
                 async for extractor in self.type_retriever.fetch_extractors():
-                    tasks.append(asyncio.create_task(run_extractor(extractor)))
+                    tasks.append(asyncio.create_task(runExtractor(extractor)))
                 await asyncio.gather(*tasks)
             finally:
-                await record_queue.put(DoneObject)
+                await recordQueue.put(DoneObject)
 
-        producer_task = asyncio.create_task(produce_all())
-        producer_error = None
+        producerTask = asyncio.create_task(produceAll())
+        producerError = None
         try:
             while True:
-                record = await record_queue.get()
+                record = await recordQueue.get()
                 if record is DoneObject:
                     break
                 yield record
         finally:
             try:
-                await producer_task
+                await producerTask
             except Exception as exc:
-                producer_error = exc
-        if producer_error is not None:
-            raise producer_error
+                producerError = exc
+        if producerError is not None:
+            raise producerError
 
     def reorganize_node_key_properties(self, node):
         """Move key fields from properties into key_values for ingestion."""
-        node_type_definition = self.type_retriever.schema.get_node_type_by_name(
-            node.type
-        )
-        if node_type_definition is None:
+        nodeTypeDefinition = self.type_retriever.schema.get_node_type_by_name(node.type)
+        if nodeTypeDefinition is None:
             return
-        for key_name in node_type_definition.keys:
-            if key_name in node.properties:
-                node.key_values[key_name] = node.properties.pop(key_name)
+        for keyName in nodeTypeDefinition.keys:
+            if keyName in node.properties:
+                node.key_values[keyName] = node.properties.pop(keyName)
 
     def convert_node_to_ingest(self, node):
         self.reorganize_node_key_properties(node)

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -24,22 +24,15 @@ class TypeHistogram:
     node_counts: Dict[str, int] = field(default_factory=dict)
     relationship_counts: Dict[str, int] = field(default_factory=dict)
 
-    def sorted_node_types(self) -> List[str]:
-        return sorted(self.node_counts, key=self.node_counts.__getitem__, reverse=True)
-
-    def sorted_relationship_types(self) -> List[str]:
-        return sorted(
-            self.relationship_counts,
-            key=self.relationship_counts.__getitem__,
-            reverse=True,
-        )
+    def sorted_types_by_count(self, counts: Dict[str, int]) -> List[str]:
+        return sorted(counts, key=counts.__getitem__, reverse=True)
 
     def log(self, logger: Logger) -> None:
         logger.info("Node type histogram (descending):")
-        for node_type in self.sorted_node_types():
+        for node_type in self.sorted_types_by_count(self.node_counts):
             logger.info("  %s: %d", node_type, self.node_counts[node_type])
         logger.info("Relationship type histogram (descending):")
-        for relationship_type in self.sorted_relationship_types():
+        for relationship_type in self.sorted_types_by_count(self.relationship_counts):
             logger.info(
                 "  %s: %d",
                 relationship_type,
@@ -58,6 +51,10 @@ class TypeRetriever(ABC):
     Owns the schema and is responsible for building a TypeHistogram and yielding
     Extractor objects for each type in the copy run. The Copier drives those
     extractors concurrently; concurrency parameters belong to the Copier, not here.
+
+    Required call order: ``build_histogram()`` must be awaited before
+    ``fetch_extractors()`` is iterated. Implementations should assert this
+    invariant; the Copier guarantees it via ``start()``.
     """
 
     def __init__(self, schema: Schema) -> None:
@@ -65,7 +62,10 @@ class TypeRetriever(ABC):
 
     @abstractmethod
     async def fetch_extractors(self) -> AsyncGenerator[Extractor, None]:
-        """Yield all Extractor objects for this copy run in implementation-defined order."""
+        """Yield all Extractor objects for this copy run in implementation-defined order.
+
+        ``build_histogram()`` must be called before iterating this generator.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -80,6 +80,12 @@ class Copier(Extractor):
     Pulls Extractor objects from fetch_extractors() and runs them concurrently
     up to concurrency_limit via a producer/consumer queue. No branching on
     types or shards — all of that lives in the TypeRetriever.
+
+    Args:
+        type_retriever: Supplies the extractors and histogram for this run.
+        concurrency_limit: Maximum number of extractor tasks running at once.
+        queue_size: Maximum records buffered between producer and consumer.
+            0 means unbounded.
     """
 
     def __init__(
@@ -137,6 +143,8 @@ class Copier(Extractor):
             try:
                 await producer_task
             except Exception as exc:
+                # Store the error instead of raising here so the finally block
+                # completes before propagating — re-raised immediately after.
                 producer_error = exc
         if producer_error is not None:
             raise producer_error

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -1,7 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from logging import getLogger
-from typing import AsyncGenerator, Coroutine, Dict, List, Optional
+from typing import AsyncGenerator, Coroutine, Dict, List, Optional, Set
 
 from ..metrics import Metric, Metrics
 from ..model import Node, RelationshipWithNodes
@@ -67,6 +67,7 @@ class Copier(Extractor):
         relationship_types: List[str],
         concurrency_limit: int = 1,
         orchestrator_queue_size: Optional[int] = None,
+        shard_size: Optional[int] = None,
     ) -> "Copier":
         if concurrency_limit > 1:
             return ConcurrentCopier(
@@ -76,6 +77,7 @@ class Copier(Extractor):
                 relationship_types,
                 concurrency_limit=concurrency_limit,
                 orchestrator_queue_size=orchestrator_queue_size,
+                shard_size=shard_size,
             )
         return cls(type_retriever, schema, node_types, relationship_types)
 
@@ -171,9 +173,36 @@ class Copier(Extractor):
         self.reorganize_node_key_properties(relationship.to_node)
         return relationship.into_ingest()
 
+    def _get_node_key_field(self, node_type: str) -> Optional[str]:
+        """Return the first key field for a node type, or None if unavailable."""
+        type_def = self.schema.get_node_type_by_name(node_type)
+        if type_def is None:
+            return None
+        keys: Set[str] = type_def.keys
+        return next(iter(sorted(keys)), None) if keys else None
+
+    def _get_relationship_key_field(self, relationship_type: str) -> Optional[str]:
+        """Return the first key field for a relationship type, or None if unavailable."""
+        type_def = self.schema.get_relationship_type_by_name(relationship_type)
+        if type_def is None:
+            return None
+        keys: Set[str] = type_def.keys
+        return next(iter(sorted(keys)), None) if keys else None
+
 
 class ConcurrentCopier(Copier):
     """Copier that runs concurrent fetch loops per type.
+
+    When *shard_size* is provided and the TypeRetriever supports sharding
+    (i.e. exposes ``get_nodes_of_type_shard`` /
+    ``get_relationships_of_type_between_shard``), each type is split into
+    pre-computed shard windows derived from the histogram counts collected at
+    startup.  Shards across all types are interleaved in a single dynamic work
+    queue so that concurrency slots are never left idle while a single large
+    type is still draining — the next type's shards fill in immediately.
+
+    When *shard_size* is None, or the retriever does not support sharding, the
+    behaviour falls back to the original one-coroutine-per-type model.
 
     All node types are fetched concurrently first, then all relationship types.
     The two groups are never mixed so slow relationship scans cannot starve
@@ -188,15 +217,141 @@ class ConcurrentCopier(Copier):
         relationship_types_to_copy: List[str],
         concurrency_limit: int = 10,
         orchestrator_queue_size: Optional[int] = None,
+        shard_size: Optional[int] = None,
     ) -> None:
         super().__init__(
             type_retriever, schema, node_types_to_copy, relationship_types_to_copy
         )
         self.concurrency_limit = max(1, concurrency_limit)
         self.orchestrator_queue_size = orchestrator_queue_size or 0
+        self.shard_size = shard_size
+
+    def _retriever_supports_sharding(self) -> bool:
+        return (
+            self.shard_size is not None
+            and hasattr(self.type_retriever, "get_nodes_of_type_shard")
+            and hasattr(self.type_retriever, "get_relationships_of_type_between_shard")
+            and hasattr(self.type_retriever, "compute_shards")
+        )
+
+    def _build_node_shard_coroutines(self, queue: asyncio.Queue) -> List[Coroutine]:
+        """Return one coroutine per (type, shard) pair, interleaved across types.
+
+        Shards are interleaved round-robin by type so that when large types are
+        still running their later shards, smaller types already have slots to
+        fill.  Types with no key field fall back to a single full-type coroutine.
+        """
+        # Build per-type shard lists: [(node_type, shard_offset, shard_limit), ...]
+        per_type_shards: List[List[tuple]] = []
+        for node_type in self.node_types:
+            count = self._node_counts.get(node_type, 0)
+            key_field = self._get_node_key_field(node_type)
+            if key_field is None:
+                # No key — single coroutine covering the whole type.
+                per_type_shards.append([(node_type, None, None, None)])
+            else:
+                shards = self.type_retriever.compute_shards(count, self.shard_size)
+                per_type_shards.append(
+                    [(node_type, key_field, off, lim) for off, lim in shards]
+                )
+
+        async def produce_node_shard(
+            node_type: str,
+            key_field: Optional[str],
+            shard_offset: Optional[int],
+            shard_limit: Optional[int],
+        ) -> None:
+            if key_field is None:
+                gen = self.type_retriever.get_nodes_of_type(node_type)
+            else:
+                gen = self.type_retriever.get_nodes_of_type_shard(
+                    node_type, key_field, shard_offset, shard_limit
+                )
+            async for node in gen:
+                Metrics.get().increment(ORCHESTRATOR_QUEUE)
+                await queue.put(self.convert_node_to_ingest(node))
+
+        # Interleave: round-robin across types so shards from different types
+        # are adjacent in the coroutine list.  This lets the semaphore pick up
+        # the next type's shard as soon as a slot frees.
+        coroutines: List[Coroutine] = []
+        max_shards = max((len(s) for s in per_type_shards), default=0)
+        for shard_idx in range(max_shards):
+            for type_shards in per_type_shards:
+                if shard_idx < len(type_shards):
+                    node_type, key_field, off, lim = type_shards[shard_idx]
+                    coroutines.append(
+                        produce_node_shard(node_type, key_field, off, lim)
+                    )
+        return coroutines
+
+    def _build_relationship_shard_coroutines(
+        self, queue: asyncio.Queue, all_adjacencies: List[Adjacency]
+    ) -> List[Coroutine]:
+        """Return one coroutine per (adjacency, shard) pair, interleaved."""
+        per_adjacency_shards: List[List[tuple]] = []
+        for adjacency in all_adjacencies:
+            count = self._relationship_counts.get(adjacency.relationship_type, 0)
+            key_field = self._get_relationship_key_field(adjacency.relationship_type)
+            if key_field is None:
+                per_adjacency_shards.append([(adjacency, None, None, None)])
+            else:
+                shards = self.type_retriever.compute_shards(count, self.shard_size)
+                per_adjacency_shards.append(
+                    [(adjacency, key_field, off, lim) for off, lim in shards]
+                )
+
+        async def produce_relationship_shard(
+            adjacency: Adjacency,
+            key_field: Optional[str],
+            shard_offset: Optional[int],
+            shard_limit: Optional[int],
+        ) -> None:
+            if key_field is None:
+                gen = self.type_retriever.get_relationships_of_type_between(
+                    adjacency.from_node_type,
+                    adjacency.to_node_type,
+                    adjacency.relationship_type,
+                )
+            else:
+                gen = self.type_retriever.get_relationships_of_type_between_shard(
+                    adjacency.from_node_type,
+                    adjacency.to_node_type,
+                    adjacency.relationship_type,
+                    key_field,
+                    shard_offset,
+                    shard_limit,
+                )
+            async for relationship in gen:
+                Metrics.get().increment(ORCHESTRATOR_QUEUE)
+                await queue.put(self.convert_relationship_to_ingest(relationship))
+
+        coroutines: List[Coroutine] = []
+        max_shards = max((len(s) for s in per_adjacency_shards), default=0)
+        for shard_idx in range(max_shards):
+            for adj_shards in per_adjacency_shards:
+                if shard_idx < len(adj_shards):
+                    adjacency, key_field, off, lim = adj_shards[shard_idx]
+                    coroutines.append(
+                        produce_relationship_shard(adjacency, key_field, off, lim)
+                    )
+        return coroutines
 
     async def extract_records(self):
         queue: asyncio.Queue = asyncio.Queue(maxsize=self.orchestrator_queue_size)
+        use_sharding = self._retriever_supports_sharding()
+
+        if use_sharding:
+            self.logger.info(
+                "Sharded copy mode: shard_size=%d, concurrency_limit=%d",
+                self.shard_size,
+                self.concurrency_limit,
+            )
+        else:
+            self.logger.info(
+                "Standard concurrent copy mode: concurrency_limit=%d",
+                self.concurrency_limit,
+            )
 
         async def produce_nodes(node_type: str) -> None:
             expected_count = self._node_counts.get(node_type, "?")
@@ -244,21 +399,51 @@ class ConcurrentCopier(Copier):
 
         async def orchestrate() -> None:
             try:
-                # All nodes first, then all relationships.
-                await run_bounded(
-                    [produce_nodes(node_type) for node_type in self.node_types]
-                )
-
-                all_adjacencies: List[Adjacency] = []
-                for relationship_type in self.relationship_types:
-                    all_adjacencies.extend(
-                        self.schema.get_adjacencies_by_relationship_type(
-                            relationship_type
-                        )
+                if use_sharding:
+                    # Build interleaved shard coroutines from histogram counts.
+                    node_coroutines = self._build_node_shard_coroutines(queue)
+                    self.logger.info(
+                        "Sharded node fetch: %d total shard coroutines across %d types",
+                        len(node_coroutines),
+                        len(self.node_types),
                     )
-                await run_bounded(
-                    [produce_relationships(adjacency) for adjacency in all_adjacencies]
-                )
+                    await run_bounded(node_coroutines)
+
+                    all_adjacencies: List[Adjacency] = []
+                    for relationship_type in self.relationship_types:
+                        all_adjacencies.extend(
+                            self.schema.get_adjacencies_by_relationship_type(
+                                relationship_type
+                            )
+                        )
+                    rel_coroutines = self._build_relationship_shard_coroutines(
+                        queue, all_adjacencies
+                    )
+                    self.logger.info(
+                        "Sharded relationship fetch: %d total shard coroutines across %d adjacencies",
+                        len(rel_coroutines),
+                        len(all_adjacencies),
+                    )
+                    await run_bounded(rel_coroutines)
+                else:
+                    # Original behaviour: one coroutine per type.
+                    await run_bounded(
+                        [produce_nodes(node_type) for node_type in self.node_types]
+                    )
+
+                    all_adjacencies = []
+                    for relationship_type in self.relationship_types:
+                        all_adjacencies.extend(
+                            self.schema.get_adjacencies_by_relationship_type(
+                                relationship_type
+                            )
+                        )
+                    await run_bounded(
+                        [
+                            produce_relationships(adjacency)
+                            for adjacency in all_adjacencies
+                        ]
+                    )
             finally:
                 # Always signal the consumer so it never hangs, even on error.
                 await queue.put(DoneObject)

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -1,17 +1,21 @@
 import asyncio
 from abc import ABC, abstractmethod
-from logging import getLogger
-from typing import AsyncGenerator, Coroutine, Dict, List, Optional, Set
+from dataclasses import dataclass, field
+from logging import Logger, getLogger
+from typing import AsyncGenerator, Dict, List, Optional
 
 from ..metrics import Metric, Metrics
 from ..model import Node, RelationshipWithNodes
 from ..pipeline import Extractor
 from ..pipeline.channel import DoneObject
 from ..pipeline.step import StepContext
-from ..schema import Adjacency, Schema
+from ..schema import Schema
 
-ORCHESTRATOR_QUEUE = Metric(
-    "orchestrator_queue", "Number of items in the orchestrator queue", accumulate=False
+ORCHESTRATOR_NODE_QUEUE = Metric(
+    "orchestrator_node_queue", "Number of nodes in the orchestrator node queue", accumulate=False
+)
+ORCHESTRATOR_REL_QUEUE = Metric(
+    "orchestrator_rel_queue", "Number of relationships in the orchestrator relationship queue", accumulate=False
 )
 ACTIVE_QUERIES = Metric(
     "active_queries",
@@ -20,134 +24,195 @@ ACTIVE_QUERIES = Metric(
 )
 
 
+@dataclass
+class TypeHistogram:
+    """Count estimates for all node and relationship types to be copied."""
+
+    node_counts: Dict[str, int] = field(default_factory=dict)
+    relationship_counts: Dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def empty(cls) -> "TypeHistogram":
+        return cls()
+
+    def sorted_node_types(self) -> List[str]:
+        return sorted(self.node_counts, key=self.node_counts.__getitem__, reverse=True)
+
+    def sorted_relationship_types(self) -> List[str]:
+        return sorted(
+            self.relationship_counts,
+            key=self.relationship_counts.__getitem__,
+            reverse=True,
+        )
+
+    def log(self, logger: Logger) -> None:
+        logger.info("Node type histogram (descending):")
+        for t in self.sorted_node_types():
+            logger.info("  %s: %d", t, self.node_counts[t])
+        logger.info("Relationship type histogram (descending):")
+        for t in self.sorted_relationship_types():
+            logger.info("  %s: %d", t, self.relationship_counts[t])
+        logger.info(
+            "Total nodes: %d, Total relationships: %d",
+            sum(self.node_counts.values()),
+            sum(self.relationship_counts.values()),
+        )
+
+
 class TypeRetriever(ABC):
+    """Abstract base for retrieving graph objects from a source database.
+
+    Implementors own type decomposition, shard splitting, histogram computation,
+    and concurrency strategy. The copier's only interface to the retriever is
+    fetch_nodes() and fetch_relationships() — both async generators. If the
+    retriever wants internal parallelism (shards, per-type coroutines) it runs
+    its own concurrency machinery and yields results as they arrive. The copier
+    never sees the difference.
+
+    Concurrency knobs (concurrency_limit, orchestrator_queue_size) live here so
+    that a single Copier pipeline can be wired with any retriever implementation,
+    including one that is fully sequential (the default).
+    """
+
+    # Subclasses set these to opt into the concurrent consumer loop in Copier.
+    concurrency_limit: int = 1
+    orchestrator_queue_size: int = 0
+
+    relationships_only: bool = False
+
     @abstractmethod
-    async def preview_relationship_count(self, relationship_type: str) -> int:
+    async def fetch_nodes(self, schema: Schema) -> AsyncGenerator[Node, None]:
+        """Yield all nodes that should be copied, across all types."""
         raise NotImplementedError
 
     @abstractmethod
-    async def preview_node_count(self, node_type: str) -> int:
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_nodes_of_type(self, node_type: str) -> AsyncGenerator[Node, None]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_relationships_of_type_between(
-        self, from_node_type: str, to_node_type: str, relationship_type: str
+    async def fetch_relationships(
+        self, schema: Schema
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
+        """Yield all relationships that should be copied, across all types."""
         raise NotImplementedError
+
+    async def build_histogram(self, schema: Schema) -> TypeHistogram:
+        """Return count estimates for all types to be copied.
+
+        Default returns an empty histogram. Subclasses that support counting
+        should override this to issue real COUNT queries.
+        """
+        return TypeHistogram.empty()
 
 
 class Copier(Extractor):
-    """Copies nodes and relationships sequentially, one type at a time."""
+    """Copies nodes and relationships from a source via a TypeRetriever.
+
+    Concurrency is controlled entirely by the retriever: if
+    retriever.concurrency_limit > 1 the copier spins up a producer/consumer
+    queue so the retriever's async generators can push records concurrently
+    while the copier drains them. If concurrency_limit == 1 the copier iterates
+    sequentially — no queue, no tasks.
+
+    This means a single Copier(retriever, schema) works for any retriever
+    regardless of its internal strategy (sequential, sharded, sampled, etc.).
+    """
 
     def __init__(
         self,
         type_retriever: TypeRetriever,
         schema: Schema,
-        node_types_to_copy: List[str],
-        relationship_types_to_copy: List[str],
     ) -> None:
         self.type_retriever = type_retriever
-        self.relationship_types = relationship_types_to_copy
-        self.node_types = node_types_to_copy
         self.schema = schema
         self.logger = getLogger(__name__)
-        self._node_counts: Dict[str, int] = {}
-        self._relationship_counts: Dict[str, int] = {}
-
-    @classmethod
-    def create(
-        cls,
-        type_retriever: TypeRetriever,
-        schema: Schema,
-        node_types: List[str],
-        relationship_types: List[str],
-        concurrency_limit: int = 1,
-        orchestrator_queue_size: Optional[int] = None,
-        shard_size: Optional[int] = None,
-    ) -> "Copier":
-        if concurrency_limit > 1:
-            return ConcurrentCopier(
-                type_retriever,
-                schema,
-                node_types,
-                relationship_types,
-                concurrency_limit=concurrency_limit,
-                orchestrator_queue_size=orchestrator_queue_size,
-                shard_size=shard_size,
-            )
-        return cls(type_retriever, schema, node_types, relationship_types)
 
     async def start(self, context: StepContext):
         await super().start(context)
-
-        # Preview counts and sort descending so largest types are copied first.
-        for node_type in self.node_types:
-            self._node_counts[node_type] = await self.type_retriever.preview_node_count(
-                node_type
-            )
-        for relationship_type in self.relationship_types:
-            self._relationship_counts[relationship_type] = (
-                await self.type_retriever.preview_relationship_count(relationship_type)
-            )
-
-        self.node_types.sort(key=lambda t: self._node_counts[t], reverse=True)
-        self.relationship_types.sort(
-            key=lambda t: self._relationship_counts[t], reverse=True
-        )
-
-        self._log_histogram()
-
-    def _log_histogram(self):
-        self.logger.info("Node type histogram (descending):")
-        for node_type in self.node_types:
-            self.logger.info("  %s: %d", node_type, self._node_counts[node_type])
-        self.logger.info("Relationship type histogram (descending):")
-        for relationship_type in self.relationship_types:
-            self.logger.info(
-                "  %s: %d",
-                relationship_type,
-                self._relationship_counts[relationship_type],
-            )
-        self.logger.info(
-            "Total nodes: %d, Total relationships: %d",
-            sum(self._node_counts.values()),
-            sum(self._relationship_counts.values()),
-        )
+        histogram = await self.type_retriever.build_histogram(self.schema)
+        histogram.log(self.logger)
 
     async def extract_records(self):
-        for node_type in self.node_types:
-            expected_count = self._node_counts.get(node_type, "?")
-            self.logger.info(
-                "Copying nodes of type %s (expected ~%s)", node_type, expected_count
-            )
-            async for node in self.type_retriever.get_nodes_of_type(node_type):
-                yield self.convert_node_to_ingest(node)
+        if self.type_retriever.concurrency_limit > 1:
+            async for record in self._extract_concurrent():
+                yield record
+        else:
+            async for record in self._extract_sequential():
+                yield record
 
-        for relationship_type in self.relationship_types:
-            expected_count = self._relationship_counts.get(relationship_type, "?")
-            adjacencies = list(
-                self.schema.get_adjacencies_by_relationship_type(relationship_type)
+    async def _extract_sequential(self):
+        if not self.type_retriever.relationships_only:
+            async for node in self.type_retriever.fetch_nodes(self.schema):
+                yield self.convert_node_to_ingest(node)
+        async for relationship in self.type_retriever.fetch_relationships(self.schema):
+            yield self.convert_relationship_to_ingest(relationship)
+
+    async def _extract_concurrent(self):
+        """Producer/consumer loop with separate node and relationship queues.
+
+        Two typed queues keep nodes and relationships distinct throughout the
+        pipeline. The node queue is fully produced and drained before the
+        relationship queue starts, preserving write-side ordering. Metrics are
+        tracked independently so queue depth is visible per type.
+        """
+        concurrency_limit = self.type_retriever.concurrency_limit
+        queue_size = self.type_retriever.orchestrator_queue_size
+
+        node_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
+        rel_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
+
+        async def _fill_queue(generator, queue, queue_metric) -> None:
+            try:
+                async for record in generator:
+                    Metrics.get().increment(queue_metric)
+                    await queue.put(record)
+            finally:
+                await queue.put(DoneObject)
+
+        async def _drain_queue(queue, queue_metric):
+            while True:
+                message = await queue.get()
+                if message is DoneObject:
+                    break
+                Metrics.get().decrement(queue_metric)
+                yield message
+
+        # --- nodes first (skipped when relationships_only=True) ---
+        if not self.type_retriever.relationships_only:
+            self.logger.info("Node fetch started, concurrency_limit=%d", concurrency_limit)
+            nodes_gen = (self.convert_node_to_ingest(n)
+                         async for n in self.type_retriever.fetch_nodes(self.schema))
+            node_task = asyncio.create_task(
+                _fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
             )
-            for adjacency in adjacencies:
-                self.logger.info(
-                    "Copying %s (%s -> %s, expected ~%s)",
-                    adjacency.relationship_type,
-                    adjacency.from_node_type,
-                    adjacency.to_node_type,
-                    expected_count,
-                )
-                async for (
-                    relationship
-                ) in self.type_retriever.get_relationships_of_type_between(
-                    adjacency.from_node_type,
-                    adjacency.to_node_type,
-                    adjacency.relationship_type,
-                ):
-                    yield self.convert_relationship_to_ingest(relationship)
+            node_error = None
+            try:
+                async for record in _drain_queue(node_queue, ORCHESTRATOR_NODE_QUEUE):
+                    yield record
+            finally:
+                try:
+                    await node_task
+                except Exception as exc:
+                    node_error = exc
+            if node_error is not None:
+                raise node_error
+
+        # --- relationships (only reached after nodes fully drained, or immediately if relationships_only) ---
+        self.logger.info(
+            "Relationship fetch started, concurrency_limit=%d", concurrency_limit
+        )
+        rels_gen = (self.convert_relationship_to_ingest(r)
+                    async for r in self.type_retriever.fetch_relationships(self.schema))
+        rel_task = asyncio.create_task(
+            _fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
+        )
+        rel_error = None
+        try:
+            async for record in _drain_queue(rel_queue, ORCHESTRATOR_REL_QUEUE):
+                yield record
+        finally:
+            try:
+                await rel_task
+            except Exception as exc:
+                rel_error = exc
+        if rel_error is not None:
+            raise rel_error
 
     def reorganize_node_key_properties(self, node: Node):
         """Move key fields from properties into key_values for ingestion.
@@ -161,8 +226,8 @@ class Copier(Extractor):
         if node_type_definition is None:
             return
         for key_name in node_type_definition.keys:
-            node.key_values[key_name] = node.properties[key_name]
-            del node.properties[key_name]
+            if key_name in node.properties:
+                node.key_values[key_name] = node.properties.pop(key_name)
 
     def convert_node_to_ingest(self, node: Node):
         self.reorganize_node_key_properties(node)
@@ -173,282 +238,7 @@ class Copier(Extractor):
         self.reorganize_node_key_properties(relationship.to_node)
         return relationship.into_ingest()
 
-    def _get_node_key_field(self, node_type: str) -> Optional[str]:
-        """Return the first key field for a node type, or None if unavailable."""
-        type_def = self.schema.get_node_type_by_name(node_type)
-        if type_def is None:
-            return None
-        keys: Set[str] = type_def.keys
-        return next(iter(sorted(keys)), None) if keys else None
 
-    def _get_relationship_key_field(self, relationship_type: str) -> Optional[str]:
-        """Return the first key field for a relationship type, or None if unavailable."""
-        type_def = self.schema.get_relationship_type_by_name(relationship_type)
-        if type_def is None:
-            return None
-        keys: Set[str] = type_def.keys
-        return next(iter(sorted(keys)), None) if keys else None
-
-
-class ConcurrentCopier(Copier):
-    """Copier that runs concurrent fetch loops per type.
-
-    When *shard_size* is provided and the TypeRetriever supports sharding
-    (i.e. exposes ``get_nodes_of_type_shard`` /
-    ``get_relationships_of_type_between_shard``), each type is split into
-    pre-computed shard windows derived from the histogram counts collected at
-    startup.  Shards across all types are interleaved in a single dynamic work
-    queue so that concurrency slots are never left idle while a single large
-    type is still draining — the next type's shards fill in immediately.
-
-    When *shard_size* is None, or the retriever does not support sharding, the
-    behaviour falls back to the original one-coroutine-per-type model.
-
-    All node types are fetched concurrently first, then all relationship types.
-    The two groups are never mixed so slow relationship scans cannot starve
-    fast node scans.  A semaphore bounds the number of concurrent producers.
-    """
-
-    def __init__(
-        self,
-        type_retriever: TypeRetriever,
-        schema: Schema,
-        node_types_to_copy: List[str],
-        relationship_types_to_copy: List[str],
-        concurrency_limit: int = 10,
-        orchestrator_queue_size: Optional[int] = None,
-        shard_size: Optional[int] = None,
-    ) -> None:
-        super().__init__(
-            type_retriever, schema, node_types_to_copy, relationship_types_to_copy
-        )
-        self.concurrency_limit = max(1, concurrency_limit)
-        self.orchestrator_queue_size = orchestrator_queue_size or 0
-        self.shard_size = shard_size
-
-    def _retriever_supports_sharding(self) -> bool:
-        return (
-            self.shard_size is not None
-            and hasattr(self.type_retriever, "get_nodes_of_type_shard")
-            and hasattr(self.type_retriever, "get_relationships_of_type_between_shard")
-            and hasattr(self.type_retriever, "compute_shards")
-        )
-
-    def _build_node_shard_coroutines(self, queue: asyncio.Queue) -> List[Coroutine]:
-        """Return one coroutine per (type, shard) pair, interleaved across types.
-
-        Shards are interleaved round-robin by type so that when large types are
-        still running their later shards, smaller types already have slots to
-        fill.  Types with no key field fall back to a single full-type coroutine.
-        """
-        # Build per-type shard lists: [(node_type, key_field, shard_offset, shard_limit), ...]
-        # key_field may be None — the retriever falls back to elementId ordering in that case.
-        per_type_shards: List[List[tuple]] = []
-        for node_type in self.node_types:
-            count = self._node_counts.get(node_type, 0)
-            key_field = self._get_node_key_field(node_type)
-            shards = self.type_retriever.compute_shards(count, self.shard_size)
-            per_type_shards.append(
-                [(node_type, key_field, off, lim) for off, lim in shards]
-            )
-
-        async def produce_node_shard(
-            node_type: str,
-            key_field: Optional[str],
-            shard_offset: int,
-            shard_limit: int,
-        ) -> None:
-            async for node in self.type_retriever.get_nodes_of_type_shard(
-                node_type, key_field, shard_offset, shard_limit
-            ):
-                Metrics.get().increment(ORCHESTRATOR_QUEUE)
-                await queue.put(self.convert_node_to_ingest(node))
-
-        # Interleave: round-robin across types so shards from different types
-        # are adjacent in the coroutine list.  This lets the semaphore pick up
-        # the next type's shard as soon as a slot frees.
-        coroutines: List[Coroutine] = []
-        max_shards = max((len(s) for s in per_type_shards), default=0)
-        for shard_idx in range(max_shards):
-            for type_shards in per_type_shards:
-                if shard_idx < len(type_shards):
-                    node_type, key_field, off, lim = type_shards[shard_idx]
-                    coroutines.append(
-                        produce_node_shard(node_type, key_field, off, lim)
-                    )
-        return coroutines
-
-    def _build_relationship_shard_coroutines(
-        self, queue: asyncio.Queue, all_adjacencies: List[Adjacency]
-    ) -> List[Coroutine]:
-        """Return one coroutine per (adjacency, shard) pair, interleaved."""
-        # key_field may be None — the retriever falls back to elementId ordering in that case.
-        per_adjacency_shards: List[List[tuple]] = []
-        for adjacency in all_adjacencies:
-            count = self._relationship_counts.get(adjacency.relationship_type, 0)
-            key_field = self._get_relationship_key_field(adjacency.relationship_type)
-            shards = self.type_retriever.compute_shards(count, self.shard_size)
-            per_adjacency_shards.append(
-                [(adjacency, key_field, off, lim) for off, lim in shards]
-            )
-
-        async def produce_relationship_shard(
-            adjacency: Adjacency,
-            key_field: Optional[str],
-            shard_offset: int,
-            shard_limit: int,
-        ) -> None:
-            async for (
-                relationship
-            ) in self.type_retriever.get_relationships_of_type_between_shard(
-                adjacency.from_node_type,
-                adjacency.to_node_type,
-                adjacency.relationship_type,
-                key_field,
-                shard_offset,
-                shard_limit,
-            ):
-                Metrics.get().increment(ORCHESTRATOR_QUEUE)
-                await queue.put(self.convert_relationship_to_ingest(relationship))
-
-        coroutines: List[Coroutine] = []
-        max_shards = max((len(s) for s in per_adjacency_shards), default=0)
-        for shard_idx in range(max_shards):
-            for adj_shards in per_adjacency_shards:
-                if shard_idx < len(adj_shards):
-                    adjacency, key_field, off, lim = adj_shards[shard_idx]
-                    coroutines.append(
-                        produce_relationship_shard(adjacency, key_field, off, lim)
-                    )
-        return coroutines
-
-    async def extract_records(self):
-        queue: asyncio.Queue = asyncio.Queue(maxsize=self.orchestrator_queue_size)
-        use_sharding = self._retriever_supports_sharding()
-
-        if use_sharding:
-            self.logger.info(
-                "Sharded copy mode: shard_size=%d, concurrency_limit=%d",
-                self.shard_size,
-                self.concurrency_limit,
-            )
-        else:
-            self.logger.info(
-                "Standard concurrent copy mode: concurrency_limit=%d",
-                self.concurrency_limit,
-            )
-
-        async def produce_nodes(node_type: str) -> None:
-            expected_count = self._node_counts.get(node_type, "?")
-            self.logger.info(
-                "Copying nodes of type %s (expected ~%s)", node_type, expected_count
-            )
-            async for node in self.type_retriever.get_nodes_of_type(node_type):
-                Metrics.get().increment(ORCHESTRATOR_QUEUE)
-                await queue.put(self.convert_node_to_ingest(node))
-
-        async def produce_relationships(adjacency: Adjacency) -> None:
-            expected_count = self._relationship_counts.get(
-                adjacency.relationship_type, "?"
-            )
-            self.logger.info(
-                "Copying %s (%s -> %s, expected ~%s)",
-                adjacency.relationship_type,
-                adjacency.from_node_type,
-                adjacency.to_node_type,
-                expected_count,
-            )
-            async for (
-                relationship
-            ) in self.type_retriever.get_relationships_of_type_between(
-                adjacency.from_node_type,
-                adjacency.to_node_type,
-                adjacency.relationship_type,
-            ):
-                Metrics.get().increment(ORCHESTRATOR_QUEUE)
-                await queue.put(self.convert_relationship_to_ingest(relationship))
-
-        async def run_bounded(coroutines: List[Coroutine]) -> None:
-            semaphore = asyncio.Semaphore(self.concurrency_limit)
-
-            async def run_with_limit(coroutine: Coroutine) -> None:
-                async with semaphore:
-                    Metrics.get().increment(ACTIVE_QUERIES)
-                    try:
-                        await coroutine
-                    finally:
-                        Metrics.get().decrement(ACTIVE_QUERIES)
-
-            if coroutines:
-                await asyncio.gather(*(run_with_limit(c) for c in coroutines))
-
-        async def orchestrate() -> None:
-            try:
-                if use_sharding:
-                    # Build interleaved shard coroutines from histogram counts.
-                    node_coroutines = self._build_node_shard_coroutines(queue)
-                    self.logger.info(
-                        "Sharded node fetch: %d total shard coroutines across %d types",
-                        len(node_coroutines),
-                        len(self.node_types),
-                    )
-                    await run_bounded(node_coroutines)
-
-                    all_adjacencies: List[Adjacency] = []
-                    for relationship_type in self.relationship_types:
-                        all_adjacencies.extend(
-                            self.schema.get_adjacencies_by_relationship_type(
-                                relationship_type
-                            )
-                        )
-                    rel_coroutines = self._build_relationship_shard_coroutines(
-                        queue, all_adjacencies
-                    )
-                    self.logger.info(
-                        "Sharded relationship fetch: %d total shard coroutines across %d adjacencies",
-                        len(rel_coroutines),
-                        len(all_adjacencies),
-                    )
-                    await run_bounded(rel_coroutines)
-                else:
-                    # Original behaviour: one coroutine per type.
-                    await run_bounded(
-                        [produce_nodes(node_type) for node_type in self.node_types]
-                    )
-
-                    all_adjacencies = []
-                    for relationship_type in self.relationship_types:
-                        all_adjacencies.extend(
-                            self.schema.get_adjacencies_by_relationship_type(
-                                relationship_type
-                            )
-                        )
-                    await run_bounded(
-                        [
-                            produce_relationships(adjacency)
-                            for adjacency in all_adjacencies
-                        ]
-                    )
-            finally:
-                # Always signal the consumer so it never hangs, even on error.
-                await queue.put(DoneObject)
-
-        orchestrator_task = asyncio.create_task(orchestrate())
-        orchestrator_error = None
-        try:
-            while True:
-                message = await queue.get()
-                if message is DoneObject:
-                    break
-                Metrics.get().decrement(ORCHESTRATOR_QUEUE)
-                yield message
-        finally:
-            # Wait for the orchestrator to finish and capture any error.
-            try:
-                await orchestrator_task
-            except Exception as exc:
-                orchestrator_error = exc
-
-        # Re-raise the orchestrator error after the generator has cleaned up.
-        if orchestrator_error is not None:
-            raise orchestrator_error
+# Backwards-compatible alias — callers that imported ConcurrentCopier directly
+# still work; Copier now handles both modes based on retriever.concurrency_limit.
+ConcurrentCopier = Copier

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -41,12 +41,12 @@ class TypeHistogram:
 
     def log(self, logger: Logger) -> None:
         logger.info("Node type histogram (descending):")
-        for nodeType in self.sorted_node_types():
-            logger.info("  %s: %d", nodeType, self.node_counts[nodeType])
+        for node_type in self.sorted_node_types():
+            logger.info("  %s: %d", node_type, self.node_counts[node_type])
         logger.info("Relationship type histogram (descending):")
-        for relationshipType in self.sorted_relationship_types():
+        for relationship_type in self.sorted_relationship_types():
             logger.info(
-                "  %s: %d", relationshipType, self.relationship_counts[relationshipType]
+                "  %s: %d", relationship_type, self.relationship_counts[relationship_type]
             )
         logger.info(
             "Total nodes: %d, Total relationships: %d",
@@ -78,13 +78,10 @@ class TypeRetriever(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
     async def build_histogram(self) -> TypeHistogram:
-        """Return count estimates for all types to be copied.
-
-        Default returns an empty histogram. Subclasses that support counting
-        should override this to issue real COUNT queries.
-        """
-        return TypeHistogram()
+        """Return count estimates for all types to be copied."""
+        raise NotImplementedError
 
 
 class Copier(Extractor):
@@ -113,59 +110,41 @@ class Copier(Extractor):
 
     async def extract_records(self):
         semaphore = asyncio.Semaphore(self.concurrency_limit)
-        recordQueue: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size)
+        record_queue: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size)
 
-        async def runExtractor(extractor: Extractor) -> None:
+        async def run_extractor(extractor: Extractor) -> None:
             async with semaphore:
                 Metrics.get().increment(ACTIVE_QUERIES)
                 try:
                     async for record in extractor.extract_records():
-                        await recordQueue.put(record)
+                        await record_queue.put(record)
                 finally:
                     Metrics.get().decrement(ACTIVE_QUERIES)
 
-        async def produceAll() -> None:
+        async def produce_all() -> None:
             tasks = []
             try:
                 async for extractor in self.type_retriever.fetch_extractors():
-                    tasks.append(asyncio.create_task(runExtractor(extractor)))
+                    tasks.append(asyncio.create_task(run_extractor(extractor)))
                 await asyncio.gather(*tasks)
             finally:
-                await recordQueue.put(DoneObject)
+                await record_queue.put(DoneObject)
 
-        producerTask = asyncio.create_task(produceAll())
-        producerError = None
+        producer_task = asyncio.create_task(produce_all())
+        producer_error = None
         try:
             while True:
-                record = await recordQueue.get()
+                record = await record_queue.get()
                 if record is DoneObject:
                     break
                 yield record
         finally:
             try:
-                await producerTask
+                await producer_task
             except Exception as exc:
-                producerError = exc
-        if producerError is not None:
-            raise producerError
-
-    def reorganize_node_key_properties(self, node):
-        """Move key fields from properties into key_values for ingestion."""
-        nodeTypeDefinition = self.type_retriever.schema.get_node_type_by_name(node.type)
-        if nodeTypeDefinition is None:
-            return
-        for keyName in nodeTypeDefinition.keys:
-            if keyName in node.properties:
-                node.key_values[keyName] = node.properties.pop(keyName)
-
-    def convert_node_to_ingest(self, node):
-        self.reorganize_node_key_properties(node)
-        return node.into_ingest()
-
-    def convert_relationship_to_ingest(self, relationship):
-        self.reorganize_node_key_properties(relationship.from_node)
-        self.reorganize_node_key_properties(relationship.to_node)
-        return relationship.into_ingest()
+                producer_error = exc
+        if producer_error is not None:
+            raise producer_error
 
 
 ConcurrentCopier = Copier

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -78,11 +78,15 @@ class TypeRetriever(ABC):
     including one that is fully sequential (the default).
     """
 
-    # Subclasses set these to opt into the concurrent consumer loop in Copier.
-    concurrency_limit: int = 1
-    orchestrator_queue_size: int = 0
-
-    relationships_only: bool = False
+    def __init__(
+        self,
+        concurrency_limit: int = 1,
+        orchestrator_queue_size: int = 0,
+        relationships_only: bool = False,
+    ) -> None:
+        self.concurrency_limit = concurrency_limit
+        self.orchestrator_queue_size = orchestrator_queue_size
+        self.relationships_only = relationships_only
 
     @abstractmethod
     async def fetch_nodes(self, schema: Schema) -> AsyncGenerator[Node, None]:
@@ -161,7 +165,7 @@ class Copier(Extractor):
         node_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
         rel_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
 
-        async def _fill_queue(generator, queue, queue_metric) -> None:
+        async def fill_queue(generator, queue, queue_metric) -> None:
             try:
                 async for record in generator:
                     Metrics.get().increment(queue_metric)
@@ -169,7 +173,7 @@ class Copier(Extractor):
             finally:
                 await queue.put(DoneObject)
 
-        async def _drain_queue(queue, queue_metric):
+        async def drain_queue(queue, queue_metric):
             while True:
                 message = await queue.get()
                 if message is DoneObject:
@@ -187,11 +191,11 @@ class Copier(Extractor):
                 async for n in self.type_retriever.fetch_nodes(self.schema)
             )
             node_task = asyncio.create_task(
-                _fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
+                fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
             )
             node_error = None
             try:
-                async for record in _drain_queue(node_queue, ORCHESTRATOR_NODE_QUEUE):
+                async for record in drain_queue(node_queue, ORCHESTRATOR_NODE_QUEUE):
                     yield record
             finally:
                 try:
@@ -210,11 +214,11 @@ class Copier(Extractor):
             async for r in self.type_retriever.fetch_relationships(self.schema)
         )
         rel_task = asyncio.create_task(
-            _fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
+            fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
         )
         rel_error = None
         try:
-            async for record in _drain_queue(rel_queue, ORCHESTRATOR_REL_QUEUE):
+            async for record in drain_queue(rel_queue, ORCHESTRATOR_REL_QUEUE):
                 yield record
         finally:
             try:

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -153,5 +153,3 @@ class Copier(Extractor):
                     producer_error = exc
         if producer_error is not None:
             raise producer_error
-
-

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -10,11 +10,6 @@ from ..pipeline.channel import DoneObject
 from ..pipeline.step import StepContext
 from ..schema import Schema
 
-ORCHESTRATOR_QUEUE = Metric(
-    "orchestrator_queue",
-    "Number of extractor jobs pending in the copier queue",
-    accumulate=False,
-)
 ACTIVE_QUERIES = Metric(
     "active_queries",
     "Number of active database queries in the copier",
@@ -60,11 +55,9 @@ class TypeHistogram:
 class TypeRetriever(ABC):
     """Abstract base for retrieving graph objects from a source database.
 
-    The retriever owns schema, type decomposition, shard splitting, histogram
-    computation, and node_only policy. It exposes two async generators of
-    Extractor objects — one for node shards, one for relationship shards.
-    The Copier drives those extractors concurrently; concurrency parameters
-    belong to the Copier, not here.
+    Owns the schema and is responsible for building a TypeHistogram and yielding
+    Extractor objects for each type in the copy run. The Copier drives those
+    extractors concurrently; concurrency parameters belong to the Copier, not here.
     """
 
     def __init__(self, schema: Schema) -> None:
@@ -72,12 +65,7 @@ class TypeRetriever(ABC):
 
     @abstractmethod
     async def fetch_extractors(self) -> AsyncGenerator[Extractor, None]:
-        """Yield all Extractor objects for this copy run.
-
-        preload_nodes=True  → yield node extractors first, then relationship extractors.
-        preload_nodes=False → yield relationship extractors only (RelationshipWithNodes
-                              carries both endpoints, so a separate node pass is not needed).
-        """
+        """Yield all Extractor objects for this copy run in implementation-defined order."""
         raise NotImplementedError
 
     @abstractmethod
@@ -124,6 +112,11 @@ class Copier(Extractor):
                     Metrics.get().decrement(ACTIVE_QUERIES)
 
         async def produce_all() -> None:
+            # All extractor tasks are created upfront before any are awaited.
+            # The semaphore enforces concurrency_limit, so tasks queue behind
+            # it rather than running freely. Creating them all at once lets
+            # asyncio schedule them as soon as a semaphore slot opens without
+            # requiring the producer loop to still be running.
             tasks = []
             try:
                 async for extractor in self.type_retriever.fetch_extractors():

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -59,30 +59,20 @@ class TypeRetriever(ABC):
     The retriever owns schema, type decomposition, shard splitting, histogram
     computation, and node_only policy. It exposes two async generators of
     Extractor objects — one for node shards, one for relationship shards.
-    The Copier drives those extractors concurrently without knowing about
-    types, shards, or node_only.
+    The Copier drives those extractors concurrently; concurrency parameters
+    belong to the Copier, not here.
     """
 
-    def __init__(
-        self,
-        schema: Schema,
-        concurrency_limit: int = 1,
-        orchestrator_queue_size: int = 0,
-    ) -> None:
+    def __init__(self, schema: Schema) -> None:
         self.schema = schema
-        self.concurrency_limit = concurrency_limit
-        self.orchestrator_queue_size = orchestrator_queue_size
 
     @abstractmethod
-    async def fetchNodeExtractors(self) -> AsyncGenerator[Extractor, None]:
-        """Yield one Extractor per node shard/type to be copied."""
-        raise NotImplementedError
+    async def fetchExtractors(self) -> AsyncGenerator[Extractor, None]:
+        """Yield all Extractor objects for this copy run.
 
-    @abstractmethod
-    async def fetchRelationshipExtractors(self) -> AsyncGenerator[Extractor, None]:
-        """Yield one Extractor per relationship shard/type to be copied.
-
-        Yield nothing when node_only=True.
+        node_only=True  → yield node extractors only.
+        node_only=False → yield relationship extractors only (RelationshipWithNodes
+                          carries both endpoints, so a separate node pass is not needed).
         """
         raise NotImplementedError
 
@@ -104,8 +94,15 @@ class Copier(Extractor):
     types, shards, or node_only — all of that lives in the TypeRetriever.
     """
 
-    def __init__(self, type_retriever: TypeRetriever) -> None:
+    def __init__(
+        self,
+        type_retriever: TypeRetriever,
+        concurrency_limit: int = 1,
+        queue_size: int = 0,
+    ) -> None:
         self.type_retriever = type_retriever
+        self.concurrency_limit = concurrency_limit
+        self.queue_size = queue_size
         self.logger = getLogger(__name__)
 
     async def start(self, context: StepContext):
@@ -114,8 +111,8 @@ class Copier(Extractor):
         histogram.log(self.logger)
 
     async def extract_records(self):
-        queueSize = self.type_retriever.orchestrator_queue_size
-        semaphore = asyncio.Semaphore(self.type_retriever.concurrency_limit)
+        queueSize = self.queue_size
+        semaphore = asyncio.Semaphore(self.concurrency_limit)
         recordQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
 
         async def runExtractor(extractor: Extractor) -> None:
@@ -130,9 +127,7 @@ class Copier(Extractor):
         async def produceAll() -> None:
             tasks = []
             try:
-                async for extractor in self.type_retriever.fetchNodeExtractors():
-                    tasks.append(asyncio.create_task(runExtractor(extractor)))
-                async for extractor in self.type_retriever.fetchRelationshipExtractors():
+                async for extractor in self.type_retriever.fetchExtractors():
                     tasks.append(asyncio.create_task(runExtractor(extractor)))
                 await asyncio.gather(*tasks)
             finally:

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
-from typing import AsyncGenerator, Dict, List
+from typing import Any, AsyncGenerator, Callable, Dict, List
 
 from ..metrics import Metric, Metrics
 from ..model import Node, RelationshipWithNodes
@@ -68,14 +68,7 @@ class TypeRetriever(ABC):
 
     Implementors own type decomposition, shard splitting, histogram computation,
     and concurrency strategy. The copier's only interface to the retriever is
-    fetch_nodes() and fetch_relationships() — both async generators. If the
-    retriever wants internal parallelism (shards, per-type coroutines) it runs
-    its own concurrency machinery and yields results as they arrive. The copier
-    never sees the difference.
-
-    Concurrency knobs (concurrency_limit, orchestrator_queue_size) live here so
-    that a single Copier pipeline can be wired with any retriever implementation,
-    including one that is fully sequential (the default).
+    fetch_nodes() and fetch_relationships() — both async generators.
     """
 
     def __init__(
@@ -109,61 +102,59 @@ class TypeRetriever(ABC):
         return TypeHistogram.empty()
 
 
-class Copier(Extractor):
-    """Copies nodes and relationships from a source via a TypeRetriever.
+class FetchOrchestrator(ABC):
+    """Controls how the Copier drives fetch_nodes and fetch_relationships.
 
-    Concurrency is controlled entirely by the retriever: if
-    retriever.concurrency_limit > 1 the copier spins up a producer/consumer
-    queue so the retriever's async generators can push records concurrently
-    while the copier drains them. If concurrency_limit == 1 the copier iterates
-    sequentially — no queue, no tasks.
-
-    This means a single Copier(retriever, schema) works for any retriever
-    regardless of its internal strategy (sequential, sharded, sampled, etc.).
+    Selected once at Copier construction time based on the retriever's
+    configuration — no runtime branching in extract_records.
     """
 
-    def __init__(
+    @abstractmethod
+    async def extract(
         self,
-        type_retriever: TypeRetriever,
+        retriever: TypeRetriever,
         schema: Schema,
-    ) -> None:
-        self.type_retriever = type_retriever
-        self.schema = schema
-        self.logger = getLogger(__name__)
+        convert_node: Callable[[Node], Any],
+        convert_relationship: Callable[[RelationshipWithNodes], Any],
+    ) -> AsyncGenerator[Any, None]: ...
 
-    async def start(self, context: StepContext):
-        await super().start(context)
-        histogram = await self.type_retriever.build_histogram(self.schema)
-        histogram.log(self.logger)
 
-    async def extract_records(self):
-        if self.type_retriever.concurrency_limit > 1:
-            async for record in self._extract_concurrent():
-                yield record
-        else:
-            async for record in self._extract_sequential():
-                yield record
+class SequentialFetchOrchestrator(FetchOrchestrator):
+    def __init__(self, include_nodes: bool) -> None:
+        self.include_nodes = include_nodes
 
-    async def _extract_sequential(self):
-        if not self.type_retriever.relationships_only:
-            async for node in self.type_retriever.fetch_nodes(self.schema):
-                yield self.convert_node_to_ingest(node)
-        async for relationship in self.type_retriever.fetch_relationships(self.schema):
-            yield self.convert_relationship_to_ingest(relationship)
+    async def extract(
+        self,
+        retriever: TypeRetriever,
+        schema: Schema,
+        convert_node: Callable[[Node], Any],
+        convert_relationship: Callable[[RelationshipWithNodes], Any],
+    ) -> AsyncGenerator[Any, None]:
+        if self.include_nodes:
+            async for node in retriever.fetch_nodes(schema):
+                yield convert_node(node)
+        async for relationship in retriever.fetch_relationships(schema):
+            yield convert_relationship(relationship)
 
-    async def _extract_concurrent(self):
-        """Producer/consumer loop with separate node and relationship queues.
 
-        Two typed queues keep nodes and relationships distinct throughout the
-        pipeline. The node queue is fully produced and drained before the
-        relationship queue starts, preserving write-side ordering. Metrics are
-        tracked independently so queue depth is visible per type.
-        """
-        concurrency_limit = self.type_retriever.concurrency_limit
-        queue_size = self.type_retriever.orchestrator_queue_size
+class ConcurrentFetchOrchestrator(FetchOrchestrator):
+    """Producer/consumer orchestrator with separate node and relationship queues.
 
-        node_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
-        rel_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
+    The node queue is fully produced and drained before the relationship queue
+    starts, preserving write-side ordering. Metrics track queue depth per type.
+    """
+
+    def __init__(self, include_nodes: bool) -> None:
+        self.include_nodes = include_nodes
+
+    async def extract(
+        self,
+        retriever: TypeRetriever,
+        schema: Schema,
+        convert_node: Callable[[Node], Any],
+        convert_relationship: Callable[[RelationshipWithNodes], Any],
+    ) -> AsyncGenerator[Any, None]:
+        queue_size = retriever.orchestrator_queue_size
 
         async def fill_queue(generator, queue, queue_metric) -> None:
             try:
@@ -181,15 +172,9 @@ class Copier(Extractor):
                 Metrics.get().decrement(queue_metric)
                 yield message
 
-        # --- nodes first (skipped when relationships_only=True) ---
-        if not self.type_retriever.relationships_only:
-            self.logger.info(
-                "Node fetch started, concurrency_limit=%d", concurrency_limit
-            )
-            nodes_gen = (
-                self.convert_node_to_ingest(n)
-                async for n in self.type_retriever.fetch_nodes(self.schema)
-            )
+        if self.include_nodes:
+            node_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
+            nodes_gen = (convert_node(n) async for n in retriever.fetch_nodes(schema))
             node_task = asyncio.create_task(
                 fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
             )
@@ -205,13 +190,9 @@ class Copier(Extractor):
             if node_error is not None:
                 raise node_error
 
-        # --- relationships (only reached after nodes fully drained, or immediately if relationships_only) ---
-        self.logger.info(
-            "Relationship fetch started, concurrency_limit=%d", concurrency_limit
-        )
+        rel_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
         rels_gen = (
-            self.convert_relationship_to_ingest(r)
-            async for r in self.type_retriever.fetch_relationships(self.schema)
+            convert_relationship(r) async for r in retriever.fetch_relationships(schema)
         )
         rel_task = asyncio.create_task(
             fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
@@ -228,14 +209,48 @@ class Copier(Extractor):
         if rel_error is not None:
             raise rel_error
 
-    def reorganize_node_key_properties(self, node: Node):
-        """Move key fields from properties into key_values for ingestion.
 
-        The type retriever returns all properties in a flat dict. The ingest
-        pipeline expects key fields to be separated from regular properties so
-        that the database connector can build the correct MERGE clause. We
-        relocate them here rather than pushing that concern into every connector.
-        """
+def make_fetch_orchestrator(retriever: TypeRetriever) -> FetchOrchestrator:
+    include_nodes = not retriever.relationships_only
+    if retriever.concurrency_limit > 1:
+        return ConcurrentFetchOrchestrator(include_nodes=include_nodes)
+    return SequentialFetchOrchestrator(include_nodes=include_nodes)
+
+
+class Copier(Extractor):
+    """Copies nodes and relationships from a source via a TypeRetriever.
+
+    The fetch orchestration strategy (sequential vs concurrent, nodes vs
+    relationships-only) is resolved once at construction time and stored as
+    self.orchestrator — extract_records contains no branching.
+    """
+
+    def __init__(
+        self,
+        type_retriever: TypeRetriever,
+        schema: Schema,
+    ) -> None:
+        self.type_retriever = type_retriever
+        self.schema = schema
+        self.logger = getLogger(__name__)
+        self.orchestrator = make_fetch_orchestrator(type_retriever)
+
+    async def start(self, context: StepContext):
+        await super().start(context)
+        histogram = await self.type_retriever.build_histogram(self.schema)
+        histogram.log(self.logger)
+
+    async def extract_records(self):
+        async for record in self.orchestrator.extract(
+            self.type_retriever,
+            self.schema,
+            self.convert_node_to_ingest,
+            self.convert_relationship_to_ingest,
+        ):
+            yield record
+
+    def reorganize_node_key_properties(self, node: Node):
+        """Move key fields from properties into key_values for ingestion."""
         node_type_definition = self.schema.get_node_type_by_name(node.type)
         if node_type_definition is None:
             return
@@ -253,6 +268,5 @@ class Copier(Extractor):
         return relationship.into_ingest()
 
 
-# Backwards-compatible alias — callers that imported ConcurrentCopier directly
-# still work; Copier now handles both modes based on retriever.concurrency_limit.
+# Backwards-compatible alias
 ConcurrentCopier = Copier

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -5,15 +5,14 @@ from logging import Logger, getLogger
 from typing import AsyncGenerator, Dict, List
 
 from ..metrics import Metric, Metrics
-from ..model import Node, RelationshipWithNodes
 from ..pipeline import Extractor
 from ..pipeline.channel import DoneObject
 from ..pipeline.step import StepContext
 from ..schema import Schema
 
-ORCHESTRATOR_REL_QUEUE = Metric(
-    "orchestrator_rel_queue",
-    "Number of relationships in the orchestrator relationship queue",
+ORCHESTRATOR_QUEUE = Metric(
+    "orchestrator_queue",
+    "Number of extractor jobs pending in the copier queue",
     accumulate=False,
 )
 ACTIVE_QUERIES = Metric(
@@ -57,12 +56,11 @@ class TypeHistogram:
 class TypeRetriever(ABC):
     """Abstract base for retrieving graph objects from a source database.
 
-    The retriever owns schema, type decomposition, shard splitting, and
-    histogram computation. Schema is a constructor argument — the retriever
-    uses it internally; callers never pass it at fetch time.
-
-    node_only=True: fetch only nodes (fetchRelationships is never called).
-    node_only=False (default): adjacency extraction — nodes then relationships.
+    The retriever owns schema, type decomposition, shard splitting, histogram
+    computation, and node_only policy. It exposes two async generators of
+    Extractor objects — one for node shards, one for relationship shards.
+    The Copier drives those extractors concurrently without knowing about
+    types, shards, or node_only.
     """
 
     def __init__(
@@ -70,23 +68,22 @@ class TypeRetriever(ABC):
         schema: Schema,
         concurrency_limit: int = 1,
         orchestrator_queue_size: int = 0,
-        node_only: bool = False,
     ) -> None:
         self.schema = schema
         self.concurrency_limit = concurrency_limit
         self.orchestrator_queue_size = orchestrator_queue_size
-        self.node_only = node_only
 
     @abstractmethod
-    async def fetchNodes(self) -> AsyncGenerator[Node, None]:
-        """Yield all nodes that should be copied, across all types."""
+    async def fetchNodeExtractors(self) -> AsyncGenerator[Extractor, None]:
+        """Yield one Extractor per node shard/type to be copied."""
         raise NotImplementedError
 
     @abstractmethod
-    async def fetchRelationships(
-        self,
-    ) -> AsyncGenerator[RelationshipWithNodes, None]:
-        """Yield all relationships that should be copied, across all types."""
+    async def fetchRelationshipExtractors(self) -> AsyncGenerator[Extractor, None]:
+        """Yield one Extractor per relationship shard/type to be copied.
+
+        Yield nothing when node_only=True.
+        """
         raise NotImplementedError
 
     async def build_histogram(self) -> TypeHistogram:
@@ -99,14 +96,12 @@ class TypeRetriever(ABC):
 
 
 class Copier(Extractor):
-    """Copies nodes and/or relationships from a source via a TypeRetriever.
+    """Copies nodes and relationships from a source via a TypeRetriever.
 
-    node_only=True  → yields nodes only (fetchRelationships never called).
-    node_only=False → yields adjacencies via a producer/consumer queue;
-                      RelationshipWithNodes carries both endpoints so no
-                      separate node fetch is needed. The queue is unbounded
-                      when orchestrator_queue_size=0, making it effectively
-                      sequential for concurrency_limit=1.
+    Pulls Extractor objects from fetchNodeExtractors() then
+    fetchRelationshipExtractors() and runs them concurrently up to
+    concurrency_limit via a producer/consumer queue. No branching on
+    types, shards, or node_only — all of that lives in the TypeRetriever.
     """
 
     def __init__(self, type_retriever: TypeRetriever) -> None:
@@ -119,41 +114,49 @@ class Copier(Extractor):
         histogram.log(self.logger)
 
     async def extract_records(self):
-        if self.type_retriever.node_only:
-            async for node in self.type_retriever.fetchNodes():
-                yield self.convert_node_to_ingest(node)
-            return
-
         queueSize = self.type_retriever.orchestrator_queue_size
+        semaphore = asyncio.Semaphore(self.type_retriever.concurrency_limit)
+        recordQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
 
-        async def fillQueue(queue) -> None:
+        async def runExtractor(extractor: Extractor) -> None:
+            async with semaphore:
+                Metrics.get().increment(ACTIVE_QUERIES)
+                try:
+                    async for record in extractor.extract_records():
+                        await recordQueue.put(record)
+                finally:
+                    Metrics.get().decrement(ACTIVE_QUERIES)
+
+        async def produceAll() -> None:
+            tasks = []
             try:
-                async for relationship in self.type_retriever.fetchRelationships():
-                    Metrics.get().increment(ORCHESTRATOR_REL_QUEUE)
-                    await queue.put(self.convert_relationship_to_ingest(relationship))
+                async for extractor in self.type_retriever.fetchNodeExtractors():
+                    tasks.append(asyncio.create_task(runExtractor(extractor)))
+                async for extractor in self.type_retriever.fetchRelationshipExtractors():
+                    tasks.append(asyncio.create_task(runExtractor(extractor)))
+                await asyncio.gather(*tasks)
             finally:
-                await queue.put(DoneObject)
+                await recordQueue.put(DoneObject)
 
-        queue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
-        task = asyncio.create_task(fillQueue(queue))
-        taskError = None
+        producerTask = asyncio.create_task(produceAll())
+        producerError = None
         try:
             while True:
-                record = await queue.get()
+                record = await recordQueue.get()
                 if record is DoneObject:
                     break
-                Metrics.get().decrement(ORCHESTRATOR_REL_QUEUE)
                 yield record
         finally:
             try:
-                await task
+                await producerTask
             except Exception as exc:
-                taskError = exc
-        if taskError is not None:
-            raise taskError
+                producerError = exc
+        if producerError is not None:
+            raise producerError
 
-    def reorganize_node_key_properties(self, node: Node):
+    def reorganize_node_key_properties(self, node):
         """Move key fields from properties into key_values for ingestion."""
+        from ..model import Node
         nodeTypeDefinition = self.type_retriever.schema.get_node_type_by_name(node.type)
         if nodeTypeDefinition is None:
             return
@@ -161,15 +164,14 @@ class Copier(Extractor):
             if keyName in node.properties:
                 node.key_values[keyName] = node.properties.pop(keyName)
 
-    def convert_node_to_ingest(self, node: Node):
+    def convert_node_to_ingest(self, node):
         self.reorganize_node_key_properties(node)
         return node.into_ingest()
 
-    def convert_relationship_to_ingest(self, relationship: RelationshipWithNodes):
+    def convert_relationship_to_ingest(self, relationship):
         self.reorganize_node_key_properties(relationship.from_node)
         self.reorganize_node_key_properties(relationship.to_node)
         return relationship.into_ingest()
 
 
-# Backwards-compatible alias
 ConcurrentCopier = Copier

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -72,9 +72,9 @@ class TypeRetriever(ABC):
     async def fetch_extractors(self) -> AsyncGenerator[Extractor, None]:
         """Yield all Extractor objects for this copy run.
 
-        node_only=True  → yield node extractors only.
-        node_only=False → yield relationship extractors only (RelationshipWithNodes
-                          carries both endpoints, so a separate node pass is not needed).
+        preload_nodes=True  → yield node extractors first, then relationship extractors.
+        preload_nodes=False → yield relationship extractors only (RelationshipWithNodes
+                              carries both endpoints, so a separate node pass is not needed).
         """
         raise NotImplementedError
 
@@ -92,7 +92,7 @@ class Copier(Extractor):
 
     Pulls Extractor objects from fetch_extractors() and runs them concurrently
     up to concurrency_limit via a producer/consumer queue. No branching on
-    types, shards, or node_only — all of that lives in the TypeRetriever.
+    types or shards — all of that lives in the TypeRetriever.
     """
 
     def __init__(

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -66,34 +66,39 @@ class TypeHistogram:
 class TypeRetriever(ABC):
     """Abstract base for retrieving graph objects from a source database.
 
-    Implementors own type decomposition, shard splitting, histogram computation,
-    and concurrency strategy. The copier's only interface to the retriever is
-    fetchNodes() and fetchRelationships() — both async generators.
+    The retriever owns schema, type decomposition, shard splitting, and
+    histogram computation. Schema is a constructor argument — the retriever
+    uses it internally; callers never pass it at fetch time.
+
+    node_only=True: fetch only nodes (fetchRelationships is never called).
+    node_only=False (default): adjacency extraction — nodes then relationships.
     """
 
     def __init__(
         self,
+        schema: Schema,
         concurrency_limit: int = 1,
         orchestrator_queue_size: int = 0,
-        relationships_only: bool = False,
+        node_only: bool = False,
     ) -> None:
+        self.schema = schema
         self.concurrency_limit = concurrency_limit
         self.orchestrator_queue_size = orchestrator_queue_size
-        self.relationships_only = relationships_only
+        self.node_only = node_only
 
     @abstractmethod
-    async def fetchNodes(self, schema: Schema) -> AsyncGenerator[Node, None]:
+    async def fetchNodes(self) -> AsyncGenerator[Node, None]:
         """Yield all nodes that should be copied, across all types."""
         raise NotImplementedError
 
     @abstractmethod
     async def fetchRelationships(
-        self, schema: Schema
+        self,
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
         """Yield all relationships that should be copied, across all types."""
         raise NotImplementedError
 
-    async def build_histogram(self, schema: Schema) -> TypeHistogram:
+    async def build_histogram(self) -> TypeHistogram:
         """Return count estimates for all types to be copied.
 
         Default returns an empty histogram. Subclasses that support counting
@@ -103,54 +108,61 @@ class TypeRetriever(ABC):
 
 
 class ExtractionOrchestrator(ABC):
-    """Controls how the Copier drives fetchNodes and fetchRelationships.
+    """Drives fetchNodes and/or fetchRelationships for a single copy run.
 
-    Selected once at Copier construction time based on the retriever's
-    configuration — no runtime branching in extract_records.
+    Two concrete modes, selected once at Copier construction time:
+      NodeOnlyOrchestrator   — fetches nodes, never calls fetchRelationships.
+      AdjacencyOrchestrator  — fetches nodes then relationships (default).
+    Sequential vs concurrent is a sub-variant of AdjacencyOrchestrator.
     """
 
     @abstractmethod
     async def extract(
         self,
         retriever: TypeRetriever,
-        schema: Schema,
         convertNode: Callable[[Node], Any],
         convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]: ...
 
 
-class SequentialExtractionOrchestrator(ExtractionOrchestrator):
-    def __init__(self, includeNodes: bool) -> None:
-        self.includeNodes = includeNodes
+class NodeOnlyOrchestrator(ExtractionOrchestrator):
+    """Yields only nodes — fetchRelationships is never called."""
 
     async def extract(
         self,
         retriever: TypeRetriever,
-        schema: Schema,
         convertNode: Callable[[Node], Any],
         convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]:
-        if self.includeNodes:
-            async for node in retriever.fetchNodes(schema):
-                yield convertNode(node)
-        async for relationship in retriever.fetchRelationships(schema):
+        async for node in retriever.fetchNodes():
+            yield convertNode(node)
+
+
+class SequentialAdjacencyOrchestrator(ExtractionOrchestrator):
+    """Yields nodes then relationships, sequentially."""
+
+    async def extract(
+        self,
+        retriever: TypeRetriever,
+        convertNode: Callable[[Node], Any],
+        convertRelationship: Callable[[RelationshipWithNodes], Any],
+    ) -> AsyncGenerator[Any, None]:
+        async for node in retriever.fetchNodes():
+            yield convertNode(node)
+        async for relationship in retriever.fetchRelationships():
             yield convertRelationship(relationship)
 
 
-class ConcurrentExtractionOrchestrator(ExtractionOrchestrator):
-    """Producer/consumer orchestrator with separate node and relationship queues.
+class ConcurrentAdjacencyOrchestrator(ExtractionOrchestrator):
+    """Producer/consumer adjacency orchestrator with separate node and relationship queues.
 
     The node queue is fully produced and drained before the relationship queue
     starts, preserving write-side ordering. Metrics track queue depth per type.
     """
 
-    def __init__(self, includeNodes: bool) -> None:
-        self.includeNodes = includeNodes
-
     async def extract(
         self,
         retriever: TypeRetriever,
-        schema: Schema,
         convertNode: Callable[[Node], Any],
         convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]:
@@ -172,30 +184,27 @@ class ConcurrentExtractionOrchestrator(ExtractionOrchestrator):
                 Metrics.get().decrement(queueMetric)
                 yield message
 
-        if self.includeNodes:
-            nodeQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
-            nodesGenerator = (
-                convertNode(node) async for node in retriever.fetchNodes(schema)
-            )
-            nodeTask = asyncio.create_task(
-                fillQueue(nodesGenerator, nodeQueue, ORCHESTRATOR_NODE_QUEUE)
-            )
-            nodeError = None
+        nodeQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
+        nodesGenerator = (convertNode(node) async for node in retriever.fetchNodes())
+        nodeTask = asyncio.create_task(
+            fillQueue(nodesGenerator, nodeQueue, ORCHESTRATOR_NODE_QUEUE)
+        )
+        nodeError = None
+        try:
+            async for record in drainQueue(nodeQueue, ORCHESTRATOR_NODE_QUEUE):
+                yield record
+        finally:
             try:
-                async for record in drainQueue(nodeQueue, ORCHESTRATOR_NODE_QUEUE):
-                    yield record
-            finally:
-                try:
-                    await nodeTask
-                except Exception as exception:
-                    nodeError = exception
-            if nodeError is not None:
-                raise nodeError
+                await nodeTask
+            except Exception as exception:
+                nodeError = exception
+        if nodeError is not None:
+            raise nodeError
 
         relationshipQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
         relationshipsGenerator = (
             convertRelationship(relationship)
-            async for relationship in retriever.fetchRelationships(schema)
+            async for relationship in retriever.fetchRelationships()
         )
         relationshipTask = asyncio.create_task(
             fillQueue(relationshipsGenerator, relationshipQueue, ORCHESTRATOR_REL_QUEUE)
@@ -214,10 +223,11 @@ class ConcurrentExtractionOrchestrator(ExtractionOrchestrator):
 
 
 def buildExtractionOrchestrator(retriever: TypeRetriever) -> ExtractionOrchestrator:
-    includeNodes = not retriever.relationships_only
+    if retriever.node_only:
+        return NodeOnlyOrchestrator()
     if retriever.concurrency_limit > 1:
-        return ConcurrentExtractionOrchestrator(includeNodes=includeNodes)
-    return SequentialExtractionOrchestrator(includeNodes=includeNodes)
+        return ConcurrentAdjacencyOrchestrator()
+    return SequentialAdjacencyOrchestrator()
 
 
 class Copier(Extractor):
@@ -228,25 +238,19 @@ class Copier(Extractor):
     self.orchestrator — extract_records contains no branching.
     """
 
-    def __init__(
-        self,
-        type_retriever: TypeRetriever,
-        schema: Schema,
-    ) -> None:
+    def __init__(self, type_retriever: TypeRetriever) -> None:
         self.type_retriever = type_retriever
-        self.schema = schema
         self.logger = getLogger(__name__)
         self.orchestrator = buildExtractionOrchestrator(type_retriever)
 
     async def start(self, context: StepContext):
         await super().start(context)
-        histogram = await self.type_retriever.build_histogram(self.schema)
+        histogram = await self.type_retriever.build_histogram()
         histogram.log(self.logger)
 
     async def extract_records(self):
         async for record in self.orchestrator.extract(
             self.type_retriever,
-            self.schema,
             self.convert_node_to_ingest,
             self.convert_relationship_to_ingest,
         ):
@@ -254,7 +258,7 @@ class Copier(Extractor):
 
     def reorganize_node_key_properties(self, node: Node):
         """Move key fields from properties into key_values for ingestion."""
-        nodeTypeDefinition = self.schema.get_node_type_by_name(node.type)
+        nodeTypeDefinition = self.type_retriever.schema.get_node_type_by_name(node.type)
         if nodeTypeDefinition is None:
             return
         for keyName in nodeTypeDefinition.keys:

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
-from typing import Any, AsyncGenerator, Callable, Dict, List
+from typing import AsyncGenerator, Dict, List
 
 from ..metrics import Metric, Metrics
 from ..model import Node, RelationshipWithNodes
@@ -11,11 +11,6 @@ from ..pipeline.channel import DoneObject
 from ..pipeline.step import StepContext
 from ..schema import Schema
 
-ORCHESTRATOR_NODE_QUEUE = Metric(
-    "orchestrator_node_queue",
-    "Number of nodes in the orchestrator node queue",
-    accumulate=False,
-)
 ORCHESTRATOR_REL_QUEUE = Metric(
     "orchestrator_rel_queue",
     "Number of relationships in the orchestrator relationship queue",
@@ -34,10 +29,6 @@ class TypeHistogram:
 
     node_counts: Dict[str, int] = field(default_factory=dict)
     relationship_counts: Dict[str, int] = field(default_factory=dict)
-
-    @classmethod
-    def empty(cls) -> "TypeHistogram":
-        return cls()
 
     def sorted_node_types(self) -> List[str]:
         return sorted(self.node_counts, key=self.node_counts.__getitem__, reverse=True)
@@ -104,144 +95,23 @@ class TypeRetriever(ABC):
         Default returns an empty histogram. Subclasses that support counting
         should override this to issue real COUNT queries.
         """
-        return TypeHistogram.empty()
-
-
-class ExtractionOrchestrator(ABC):
-    """Drives fetchNodes and/or fetchRelationships for a single copy run.
-
-    Two concrete modes, selected once at Copier construction time:
-      NodeOnlyOrchestrator   — fetches nodes, never calls fetchRelationships.
-      AdjacencyOrchestrator  — fetches nodes then relationships (default).
-    Sequential vs concurrent is a sub-variant of AdjacencyOrchestrator.
-    """
-
-    @abstractmethod
-    async def extract(
-        self,
-        retriever: TypeRetriever,
-        convertNode: Callable[[Node], Any],
-        convertRelationship: Callable[[RelationshipWithNodes], Any],
-    ) -> AsyncGenerator[Any, None]: ...
-
-
-class NodeOnlyOrchestrator(ExtractionOrchestrator):
-    """Yields only nodes — fetchRelationships is never called."""
-
-    async def extract(
-        self,
-        retriever: TypeRetriever,
-        convertNode: Callable[[Node], Any],
-        convertRelationship: Callable[[RelationshipWithNodes], Any],
-    ) -> AsyncGenerator[Any, None]:
-        async for node in retriever.fetchNodes():
-            yield convertNode(node)
-
-
-class SequentialAdjacencyOrchestrator(ExtractionOrchestrator):
-    """Yields nodes then relationships, sequentially."""
-
-    async def extract(
-        self,
-        retriever: TypeRetriever,
-        convertNode: Callable[[Node], Any],
-        convertRelationship: Callable[[RelationshipWithNodes], Any],
-    ) -> AsyncGenerator[Any, None]:
-        async for node in retriever.fetchNodes():
-            yield convertNode(node)
-        async for relationship in retriever.fetchRelationships():
-            yield convertRelationship(relationship)
-
-
-class ConcurrentAdjacencyOrchestrator(ExtractionOrchestrator):
-    """Producer/consumer adjacency orchestrator with separate node and relationship queues.
-
-    The node queue is fully produced and drained before the relationship queue
-    starts, preserving write-side ordering. Metrics track queue depth per type.
-    """
-
-    async def extract(
-        self,
-        retriever: TypeRetriever,
-        convertNode: Callable[[Node], Any],
-        convertRelationship: Callable[[RelationshipWithNodes], Any],
-    ) -> AsyncGenerator[Any, None]:
-        queueSize = retriever.orchestrator_queue_size
-
-        async def fillQueue(generator, queue, queueMetric) -> None:
-            try:
-                async for record in generator:
-                    Metrics.get().increment(queueMetric)
-                    await queue.put(record)
-            finally:
-                await queue.put(DoneObject)
-
-        async def drainQueue(queue, queueMetric):
-            while True:
-                message = await queue.get()
-                if message is DoneObject:
-                    break
-                Metrics.get().decrement(queueMetric)
-                yield message
-
-        nodeQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
-        nodesGenerator = (convertNode(node) async for node in retriever.fetchNodes())
-        nodeTask = asyncio.create_task(
-            fillQueue(nodesGenerator, nodeQueue, ORCHESTRATOR_NODE_QUEUE)
-        )
-        nodeError = None
-        try:
-            async for record in drainQueue(nodeQueue, ORCHESTRATOR_NODE_QUEUE):
-                yield record
-        finally:
-            try:
-                await nodeTask
-            except Exception as exception:
-                nodeError = exception
-        if nodeError is not None:
-            raise nodeError
-
-        relationshipQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
-        relationshipsGenerator = (
-            convertRelationship(relationship)
-            async for relationship in retriever.fetchRelationships()
-        )
-        relationshipTask = asyncio.create_task(
-            fillQueue(relationshipsGenerator, relationshipQueue, ORCHESTRATOR_REL_QUEUE)
-        )
-        relationshipError = None
-        try:
-            async for record in drainQueue(relationshipQueue, ORCHESTRATOR_REL_QUEUE):
-                yield record
-        finally:
-            try:
-                await relationshipTask
-            except Exception as exception:
-                relationshipError = exception
-        if relationshipError is not None:
-            raise relationshipError
-
-
-def buildExtractionOrchestrator(retriever: TypeRetriever) -> ExtractionOrchestrator:
-    if retriever.node_only:
-        return NodeOnlyOrchestrator()
-    if retriever.concurrency_limit > 1:
-        return ConcurrentAdjacencyOrchestrator()
-    return SequentialAdjacencyOrchestrator()
+        return TypeHistogram()
 
 
 class Copier(Extractor):
-    """Copies nodes and relationships from a source via a TypeRetriever.
+    """Copies nodes and/or relationships from a source via a TypeRetriever.
 
-    The fetch orchestration strategy (sequential vs concurrent, nodes vs
-    relationships-only) is resolved once at construction time and stored as
-    self.orchestrator — extract_records contains no branching.
+    node_only=True  → yields nodes only (fetchRelationships never called).
+    node_only=False → yields adjacencies via a producer/consumer queue;
+                      RelationshipWithNodes carries both endpoints so no
+                      separate node fetch is needed. The queue is unbounded
+                      when orchestrator_queue_size=0, making it effectively
+                      sequential for concurrency_limit=1.
     """
 
     def __init__(self, type_retriever: TypeRetriever) -> None:
         self.type_retriever = type_retriever
         self.logger = getLogger(__name__)
-        self.orchestrator = buildExtractionOrchestrator(type_retriever)
 
     async def start(self, context: StepContext):
         await super().start(context)
@@ -249,12 +119,38 @@ class Copier(Extractor):
         histogram.log(self.logger)
 
     async def extract_records(self):
-        async for record in self.orchestrator.extract(
-            self.type_retriever,
-            self.convert_node_to_ingest,
-            self.convert_relationship_to_ingest,
-        ):
-            yield record
+        if self.type_retriever.node_only:
+            async for node in self.type_retriever.fetchNodes():
+                yield self.convert_node_to_ingest(node)
+            return
+
+        queueSize = self.type_retriever.orchestrator_queue_size
+
+        async def fillQueue(queue) -> None:
+            try:
+                async for relationship in self.type_retriever.fetchRelationships():
+                    Metrics.get().increment(ORCHESTRATOR_REL_QUEUE)
+                    await queue.put(self.convert_relationship_to_ingest(relationship))
+            finally:
+                await queue.put(DoneObject)
+
+        queue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
+        task = asyncio.create_task(fillQueue(queue))
+        taskError = None
+        try:
+            while True:
+                record = await queue.get()
+                if record is DoneObject:
+                    break
+                Metrics.get().decrement(ORCHESTRATOR_REL_QUEUE)
+                yield record
+        finally:
+            try:
+                await task
+            except Exception as exc:
+                taskError = exc
+        if taskError is not None:
+            raise taskError
 
     def reorganize_node_key_properties(self, node: Node):
         """Move key fields from properties into key_values for ingestion."""

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from logging import Logger, getLogger
-from typing import AsyncGenerator, Dict, List, Optional
+from typing import AsyncGenerator, Dict, List
 
 from ..metrics import Metric, Metrics
 from ..model import Node, RelationshipWithNodes
@@ -12,10 +12,14 @@ from ..pipeline.step import StepContext
 from ..schema import Schema
 
 ORCHESTRATOR_NODE_QUEUE = Metric(
-    "orchestrator_node_queue", "Number of nodes in the orchestrator node queue", accumulate=False
+    "orchestrator_node_queue",
+    "Number of nodes in the orchestrator node queue",
+    accumulate=False,
 )
 ORCHESTRATOR_REL_QUEUE = Metric(
-    "orchestrator_rel_queue", "Number of relationships in the orchestrator relationship queue", accumulate=False
+    "orchestrator_rel_queue",
+    "Number of relationships in the orchestrator relationship queue",
+    accumulate=False,
 )
 ACTIVE_QUERIES = Metric(
     "active_queries",
@@ -175,9 +179,13 @@ class Copier(Extractor):
 
         # --- nodes first (skipped when relationships_only=True) ---
         if not self.type_retriever.relationships_only:
-            self.logger.info("Node fetch started, concurrency_limit=%d", concurrency_limit)
-            nodes_gen = (self.convert_node_to_ingest(n)
-                         async for n in self.type_retriever.fetch_nodes(self.schema))
+            self.logger.info(
+                "Node fetch started, concurrency_limit=%d", concurrency_limit
+            )
+            nodes_gen = (
+                self.convert_node_to_ingest(n)
+                async for n in self.type_retriever.fetch_nodes(self.schema)
+            )
             node_task = asyncio.create_task(
                 _fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
             )
@@ -197,8 +205,10 @@ class Copier(Extractor):
         self.logger.info(
             "Relationship fetch started, concurrency_limit=%d", concurrency_limit
         )
-        rels_gen = (self.convert_relationship_to_ingest(r)
-                    async for r in self.type_retriever.fetch_relationships(self.schema))
+        rels_gen = (
+            self.convert_relationship_to_ingest(r)
+            async for r in self.type_retriever.fetch_relationships(self.schema)
+        )
         rel_task = asyncio.create_task(
             _fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
         )

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -241,33 +241,26 @@ class ConcurrentCopier(Copier):
         still running their later shards, smaller types already have slots to
         fill.  Types with no key field fall back to a single full-type coroutine.
         """
-        # Build per-type shard lists: [(node_type, shard_offset, shard_limit), ...]
+        # Build per-type shard lists: [(node_type, key_field, shard_offset, shard_limit), ...]
+        # key_field may be None — the retriever falls back to elementId ordering in that case.
         per_type_shards: List[List[tuple]] = []
         for node_type in self.node_types:
             count = self._node_counts.get(node_type, 0)
             key_field = self._get_node_key_field(node_type)
-            if key_field is None:
-                # No key — single coroutine covering the whole type.
-                per_type_shards.append([(node_type, None, None, None)])
-            else:
-                shards = self.type_retriever.compute_shards(count, self.shard_size)
-                per_type_shards.append(
-                    [(node_type, key_field, off, lim) for off, lim in shards]
-                )
+            shards = self.type_retriever.compute_shards(count, self.shard_size)
+            per_type_shards.append(
+                [(node_type, key_field, off, lim) for off, lim in shards]
+            )
 
         async def produce_node_shard(
             node_type: str,
             key_field: Optional[str],
-            shard_offset: Optional[int],
-            shard_limit: Optional[int],
+            shard_offset: int,
+            shard_limit: int,
         ) -> None:
-            if key_field is None:
-                gen = self.type_retriever.get_nodes_of_type(node_type)
-            else:
-                gen = self.type_retriever.get_nodes_of_type_shard(
-                    node_type, key_field, shard_offset, shard_limit
-                )
-            async for node in gen:
+            async for node in self.type_retriever.get_nodes_of_type_shard(
+                node_type, key_field, shard_offset, shard_limit
+            ):
                 Metrics.get().increment(ORCHESTRATOR_QUEUE)
                 await queue.put(self.convert_node_to_ingest(node))
 
@@ -289,40 +282,32 @@ class ConcurrentCopier(Copier):
         self, queue: asyncio.Queue, all_adjacencies: List[Adjacency]
     ) -> List[Coroutine]:
         """Return one coroutine per (adjacency, shard) pair, interleaved."""
+        # key_field may be None — the retriever falls back to elementId ordering in that case.
         per_adjacency_shards: List[List[tuple]] = []
         for adjacency in all_adjacencies:
             count = self._relationship_counts.get(adjacency.relationship_type, 0)
             key_field = self._get_relationship_key_field(adjacency.relationship_type)
-            if key_field is None:
-                per_adjacency_shards.append([(adjacency, None, None, None)])
-            else:
-                shards = self.type_retriever.compute_shards(count, self.shard_size)
-                per_adjacency_shards.append(
-                    [(adjacency, key_field, off, lim) for off, lim in shards]
-                )
+            shards = self.type_retriever.compute_shards(count, self.shard_size)
+            per_adjacency_shards.append(
+                [(adjacency, key_field, off, lim) for off, lim in shards]
+            )
 
         async def produce_relationship_shard(
             adjacency: Adjacency,
             key_field: Optional[str],
-            shard_offset: Optional[int],
-            shard_limit: Optional[int],
+            shard_offset: int,
+            shard_limit: int,
         ) -> None:
-            if key_field is None:
-                gen = self.type_retriever.get_relationships_of_type_between(
-                    adjacency.from_node_type,
-                    adjacency.to_node_type,
-                    adjacency.relationship_type,
-                )
-            else:
-                gen = self.type_retriever.get_relationships_of_type_between_shard(
-                    adjacency.from_node_type,
-                    adjacency.to_node_type,
-                    adjacency.relationship_type,
-                    key_field,
-                    shard_offset,
-                    shard_limit,
-                )
-            async for relationship in gen:
+            async for (
+                relationship
+            ) in self.type_retriever.get_relationships_of_type_between_shard(
+                adjacency.from_node_type,
+                adjacency.to_node_type,
+                adjacency.relationship_type,
+                key_field,
+                shard_offset,
+                shard_limit,
+            ):
                 Metrics.get().increment(ORCHESTRATOR_QUEUE)
                 await queue.put(self.convert_relationship_to_ingest(relationship))
 

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -46,7 +46,9 @@ class TypeHistogram:
         logger.info("Relationship type histogram (descending):")
         for relationship_type in self.sorted_relationship_types():
             logger.info(
-                "  %s: %d", relationship_type, self.relationship_counts[relationship_type]
+                "  %s: %d",
+                relationship_type,
+                self.relationship_counts[relationship_type],
             )
         logger.info(
             "Total nodes: %d, Total relationships: %d",

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -151,7 +151,6 @@ class Copier(Extractor):
 
     def reorganize_node_key_properties(self, node):
         """Move key fields from properties into key_values for ingestion."""
-        from ..model import Node
         nodeTypeDefinition = self.type_retriever.schema.get_node_type_by_name(node.type)
         if nodeTypeDefinition is None:
             return

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -51,11 +51,11 @@ class TypeHistogram:
 
     def log(self, logger: Logger) -> None:
         logger.info("Node type histogram (descending):")
-        for t in self.sorted_node_types():
-            logger.info("  %s: %d", t, self.node_counts[t])
+        for nodeType in self.sorted_node_types():
+            logger.info("  %s: %d", nodeType, self.node_counts[nodeType])
         logger.info("Relationship type histogram (descending):")
-        for t in self.sorted_relationship_types():
-            logger.info("  %s: %d", t, self.relationship_counts[t])
+        for relType in self.sorted_relationship_types():
+            logger.info("  %s: %d", relType, self.relationship_counts[relType])
         logger.info(
             "Total nodes: %d, Total relationships: %d",
             sum(self.node_counts.values()),
@@ -68,7 +68,7 @@ class TypeRetriever(ABC):
 
     Implementors own type decomposition, shard splitting, histogram computation,
     and concurrency strategy. The copier's only interface to the retriever is
-    fetch_nodes() and fetch_relationships() — both async generators.
+    fetchNodes() and fetchRelationships() — both async generators.
     """
 
     def __init__(
@@ -82,12 +82,12 @@ class TypeRetriever(ABC):
         self.relationships_only = relationships_only
 
     @abstractmethod
-    async def fetch_nodes(self, schema: Schema) -> AsyncGenerator[Node, None]:
+    async def fetchNodes(self, schema: Schema) -> AsyncGenerator[Node, None]:
         """Yield all nodes that should be copied, across all types."""
         raise NotImplementedError
 
     @abstractmethod
-    async def fetch_relationships(
+    async def fetchRelationships(
         self, schema: Schema
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
         """Yield all relationships that should be copied, across all types."""
@@ -103,7 +103,7 @@ class TypeRetriever(ABC):
 
 
 class FetchOrchestrator(ABC):
-    """Controls how the Copier drives fetch_nodes and fetch_relationships.
+    """Controls how the Copier drives fetchNodes and fetchRelationships.
 
     Selected once at Copier construction time based on the retriever's
     configuration — no runtime branching in extract_records.
@@ -114,27 +114,27 @@ class FetchOrchestrator(ABC):
         self,
         retriever: TypeRetriever,
         schema: Schema,
-        convert_node: Callable[[Node], Any],
-        convert_relationship: Callable[[RelationshipWithNodes], Any],
+        convertNode: Callable[[Node], Any],
+        convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]: ...
 
 
 class SequentialFetchOrchestrator(FetchOrchestrator):
-    def __init__(self, include_nodes: bool) -> None:
-        self.include_nodes = include_nodes
+    def __init__(self, includeNodes: bool) -> None:
+        self.includeNodes = includeNodes
 
     async def extract(
         self,
         retriever: TypeRetriever,
         schema: Schema,
-        convert_node: Callable[[Node], Any],
-        convert_relationship: Callable[[RelationshipWithNodes], Any],
+        convertNode: Callable[[Node], Any],
+        convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]:
-        if self.include_nodes:
-            async for node in retriever.fetch_nodes(schema):
-                yield convert_node(node)
-        async for relationship in retriever.fetch_relationships(schema):
-            yield convert_relationship(relationship)
+        if self.includeNodes:
+            async for node in retriever.fetchNodes(schema):
+                yield convertNode(node)
+        async for relationship in retriever.fetchRelationships(schema):
+            yield convertRelationship(relationship)
 
 
 class ConcurrentFetchOrchestrator(FetchOrchestrator):
@@ -144,77 +144,80 @@ class ConcurrentFetchOrchestrator(FetchOrchestrator):
     starts, preserving write-side ordering. Metrics track queue depth per type.
     """
 
-    def __init__(self, include_nodes: bool) -> None:
-        self.include_nodes = include_nodes
+    def __init__(self, includeNodes: bool) -> None:
+        self.includeNodes = includeNodes
 
     async def extract(
         self,
         retriever: TypeRetriever,
         schema: Schema,
-        convert_node: Callable[[Node], Any],
-        convert_relationship: Callable[[RelationshipWithNodes], Any],
+        convertNode: Callable[[Node], Any],
+        convertRelationship: Callable[[RelationshipWithNodes], Any],
     ) -> AsyncGenerator[Any, None]:
-        queue_size = retriever.orchestrator_queue_size
+        queueSize = retriever.orchestrator_queue_size
 
-        async def fill_queue(generator, queue, queue_metric) -> None:
+        async def fillQueue(generator, queue, queueMetric) -> None:
             try:
                 async for record in generator:
-                    Metrics.get().increment(queue_metric)
+                    Metrics.get().increment(queueMetric)
                     await queue.put(record)
             finally:
                 await queue.put(DoneObject)
 
-        async def drain_queue(queue, queue_metric):
+        async def drainQueue(queue, queueMetric):
             while True:
                 message = await queue.get()
                 if message is DoneObject:
                     break
-                Metrics.get().decrement(queue_metric)
+                Metrics.get().decrement(queueMetric)
                 yield message
 
-        if self.include_nodes:
-            node_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
-            nodes_gen = (convert_node(n) async for n in retriever.fetch_nodes(schema))
-            node_task = asyncio.create_task(
-                fill_queue(nodes_gen, node_queue, ORCHESTRATOR_NODE_QUEUE)
+        if self.includeNodes:
+            nodeQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
+            nodesGenerator = (
+                convertNode(node) async for node in retriever.fetchNodes(schema)
             )
-            node_error = None
+            nodeTask = asyncio.create_task(
+                fillQueue(nodesGenerator, nodeQueue, ORCHESTRATOR_NODE_QUEUE)
+            )
+            nodeError = None
             try:
-                async for record in drain_queue(node_queue, ORCHESTRATOR_NODE_QUEUE):
+                async for record in drainQueue(nodeQueue, ORCHESTRATOR_NODE_QUEUE):
                     yield record
             finally:
                 try:
-                    await node_task
-                except Exception as exc:
-                    node_error = exc
-            if node_error is not None:
-                raise node_error
+                    await nodeTask
+                except Exception as exception:
+                    nodeError = exception
+            if nodeError is not None:
+                raise nodeError
 
-        rel_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_size)
-        rels_gen = (
-            convert_relationship(r) async for r in retriever.fetch_relationships(schema)
+        relationshipQueue: asyncio.Queue = asyncio.Queue(maxsize=queueSize)
+        relationshipsGenerator = (
+            convertRelationship(relationship)
+            async for relationship in retriever.fetchRelationships(schema)
         )
-        rel_task = asyncio.create_task(
-            fill_queue(rels_gen, rel_queue, ORCHESTRATOR_REL_QUEUE)
+        relationshipTask = asyncio.create_task(
+            fillQueue(relationshipsGenerator, relationshipQueue, ORCHESTRATOR_REL_QUEUE)
         )
-        rel_error = None
+        relationshipError = None
         try:
-            async for record in drain_queue(rel_queue, ORCHESTRATOR_REL_QUEUE):
+            async for record in drainQueue(relationshipQueue, ORCHESTRATOR_REL_QUEUE):
                 yield record
         finally:
             try:
-                await rel_task
-            except Exception as exc:
-                rel_error = exc
-        if rel_error is not None:
-            raise rel_error
+                await relationshipTask
+            except Exception as exception:
+                relationshipError = exception
+        if relationshipError is not None:
+            raise relationshipError
 
 
-def make_fetch_orchestrator(retriever: TypeRetriever) -> FetchOrchestrator:
-    include_nodes = not retriever.relationships_only
+def buildFetchOrchestrator(retriever: TypeRetriever) -> FetchOrchestrator:
+    includeNodes = not retriever.relationships_only
     if retriever.concurrency_limit > 1:
-        return ConcurrentFetchOrchestrator(include_nodes=include_nodes)
-    return SequentialFetchOrchestrator(include_nodes=include_nodes)
+        return ConcurrentFetchOrchestrator(includeNodes=includeNodes)
+    return SequentialFetchOrchestrator(includeNodes=includeNodes)
 
 
 class Copier(Extractor):
@@ -233,7 +236,7 @@ class Copier(Extractor):
         self.type_retriever = type_retriever
         self.schema = schema
         self.logger = getLogger(__name__)
-        self.orchestrator = make_fetch_orchestrator(type_retriever)
+        self.orchestrator = buildFetchOrchestrator(type_retriever)
 
     async def start(self, context: StepContext):
         await super().start(context)
@@ -251,12 +254,12 @@ class Copier(Extractor):
 
     def reorganize_node_key_properties(self, node: Node):
         """Move key fields from properties into key_values for ingestion."""
-        node_type_definition = self.schema.get_node_type_by_name(node.type)
-        if node_type_definition is None:
+        nodeTypeDefinition = self.schema.get_node_type_by_name(node.type)
+        if nodeTypeDefinition is None:
             return
-        for key_name in node_type_definition.keys:
-            if key_name in node.properties:
-                node.key_values[key_name] = node.properties.pop(key_name)
+        for keyName in nodeTypeDefinition.keys:
+            if keyName in node.properties:
+                node.key_values[keyName] = node.properties.pop(keyName)
 
     def convert_node_to_ingest(self, node: Node):
         self.reorganize_node_key_properties(node)

--- a/nodestream/databases/copy.py
+++ b/nodestream/databases/copy.py
@@ -155,4 +155,3 @@ class Copier(Extractor):
             raise producer_error
 
 
-ConcurrentCopier = Copier

--- a/nodestream/databases/debounced_ingest_strategy.py
+++ b/nodestream/databases/debounced_ingest_strategy.py
@@ -55,15 +55,18 @@ class DebouncedIngestStrategy(IngestionStrategy, alias="debounced"):
         )
         return asyncio.gather(*update_coroutines)
 
-    async def flush_relationship_updates(self):
-        # Because databases tend to require exclusive locks on both nodes,
-        # and these updates are very likely to be related to at least one of the nodes
-        # in the relationship, we need to update relationships one operation type
-        # at a time to avoid deadlocks.
-        for rel_shape, rel_group in self.debouncer.drain_relationship_groups():
-            await self.executor.upsert_relationships_in_bulk_of_same_operation(
+    def flush_relationship_updates(self):
+        # Run all relationship-shape flushes concurrently. Neo4j may deadlock on
+        # shapes that share endpoint node types, but those are detected and returned
+        # as retryable errors — the executor's retry loop handles them. The speedup
+        # from parallelism far outweighs the occasional retry cost.
+        update_coroutines = (
+            self.executor.upsert_relationships_in_bulk_of_same_operation(
                 rel_shape, rel_group
             )
+            for rel_shape, rel_group in self.debouncer.drain_relationship_groups()
+        )
+        return asyncio.gather(*update_coroutines)
 
     async def flush(self):
         await self.flush_nodes_updates()

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -47,11 +47,11 @@ class NullQueryExecutor(QueryExecutor):
 
 
 class NullRetriever(TypeRetriever):
-    def __init__(self, **_):
+    def __init__(self, schema=None, **_):
         # Local import avoids a circular dependency: schema.state → databases → copy
         from ..schema.state import Schema
 
-        super().__init__(schema=Schema())
+        super().__init__(schema=schema or Schema())
 
     async def build_histogram(self) -> TypeHistogram:
         return TypeHistogram()
@@ -72,4 +72,4 @@ class NullConnector(DatabaseConnector, alias="null"):
         return NullQueryExecutor()
 
     def make_type_retriever(self, **kwargs) -> TypeRetriever:
-        return NullRetriever()
+        return NullRetriever(**kwargs)

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -51,13 +51,13 @@ class NullRetriever(TypeRetriever):
         from ..schema.state import Schema
         super().__init__(schema=Schema())
 
-    async def fetchNodes(self) -> AsyncGenerator[Node, None]:
+    async def fetchNodeExtractors(self):
         return
-        yield  # pragma: no cover — makes this an async generator
+        yield  # pragma: no cover
 
-    async def fetchRelationships(self) -> AsyncGenerator[RelationshipWithNodes, None]:
+    async def fetchRelationshipExtractors(self):
         return
-        yield  # pragma: no cover — makes this an async generator
+        yield  # pragma: no cover
 
 
 # Backwards-compatible alias for any external code still referencing the old name.

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator, Iterable
+from typing import Iterable
 
 from ..model import IngestionHook, Node, RelationshipWithNodes, TimeToLiveConfiguration
 from ..schema.migrations import Migrator
@@ -49,6 +49,7 @@ class NullQueryExecutor(QueryExecutor):
 class NullRetriever(TypeRetriever):
     def __init__(self, **_):
         from ..schema.state import Schema
+
         super().__init__(schema=Schema())
 
     async def fetchExtractors(self):

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -51,7 +51,9 @@ class NullRetriever(TypeRetriever):
         return
         yield  # pragma: no cover — makes this an async generator
 
-    async def fetch_relationships(self, schema) -> AsyncGenerator[RelationshipWithNodes, None]:
+    async def fetch_relationships(
+        self, schema
+    ) -> AsyncGenerator[RelationshipWithNodes, None]:
         return
         yield  # pragma: no cover — makes this an async generator
 

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -48,6 +48,7 @@ class NullQueryExecutor(QueryExecutor):
 
 class NullRetriever(TypeRetriever):
     def __init__(self, **_):
+        # Local import avoids a circular dependency: schema.state → databases → copy
         from ..schema.state import Schema
 
         super().__init__(schema=Schema())

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -47,13 +47,15 @@ class NullQueryExecutor(QueryExecutor):
 
 
 class NullRetriever(TypeRetriever):
-    async def fetch_nodes(self, schema) -> AsyncGenerator[Node, None]:
+    def __init__(self, **_):
+        from ..schema.state import Schema
+        super().__init__(schema=Schema())
+
+    async def fetchNodes(self) -> AsyncGenerator[Node, None]:
         return
         yield  # pragma: no cover — makes this an async generator
 
-    async def fetch_relationships(
-        self, schema
-    ) -> AsyncGenerator[RelationshipWithNodes, None]:
+    async def fetchRelationships(self) -> AsyncGenerator[RelationshipWithNodes, None]:
         return
         yield  # pragma: no cover — makes this an async generator
 

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -57,10 +57,6 @@ class NullRetriever(TypeRetriever):
         yield  # pragma: no cover
 
 
-# Backwards-compatible alias for any external code still referencing the old name.
-NullRetriver = NullRetriever
-
-
 class NullConnector(DatabaseConnector, alias="null"):
     def __init__(self, **_) -> None:
         pass

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -46,25 +46,18 @@ class NullQueryExecutor(QueryExecutor):
         pass
 
 
-class NullRetriver(TypeRetriever):
-    async def preview_node_count(self, _: str) -> int:
-        return 0
+class NullRetriever(TypeRetriever):
+    async def fetch_nodes(self, schema) -> AsyncGenerator[Node, None]:
+        return
+        yield  # pragma: no cover — makes this an async generator
 
-    async def preview_relationship_count(self, _: str) -> int:
-        return 0
+    async def fetch_relationships(self, schema) -> AsyncGenerator[RelationshipWithNodes, None]:
+        return
+        yield  # pragma: no cover — makes this an async generator
 
-    def get_nodes_of_type(self, _: str) -> AsyncGenerator[Node, None]:
-        return empty_async_generator()
 
-    def get_relationships_of_type_between(
-        self, __: str, ___: str, ____: str
-    ) -> AsyncGenerator[RelationshipWithNodes, None]:
-        return empty_async_generator()
-
-    def get_relationships_of_type(
-        self, _: str
-    ) -> AsyncGenerator[RelationshipWithNodes, None]:
-        return empty_async_generator()
+# Backwards-compatible alias for any external code still referencing the old name.
+NullRetriver = NullRetriever
 
 
 class NullConnector(DatabaseConnector, alias="null"):
@@ -78,4 +71,4 @@ class NullConnector(DatabaseConnector, alias="null"):
         return NullQueryExecutor()
 
     def make_type_retriever(self, **kwargs) -> TypeRetriever:
-        return NullRetriver()
+        return NullRetriever()

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -51,11 +51,7 @@ class NullRetriever(TypeRetriever):
         from ..schema.state import Schema
         super().__init__(schema=Schema())
 
-    async def fetchNodeExtractors(self):
-        return
-        yield  # pragma: no cover
-
-    async def fetchRelationshipExtractors(self):
+    async def fetchExtractors(self):
         return
         yield  # pragma: no cover
 

--- a/nodestream/databases/null.py
+++ b/nodestream/databases/null.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from ..model import IngestionHook, Node, RelationshipWithNodes, TimeToLiveConfiguration
 from ..schema.migrations import Migrator
 from ..schema.migrations.operations import Operation
-from .copy import TypeRetriever
+from .copy import TypeHistogram, TypeRetriever
 from .database_connector import DatabaseConnector
 from .query_executor import (
     OperationOnNodeIdentity,
@@ -51,6 +51,9 @@ class NullRetriever(TypeRetriever):
         from ..schema.state import Schema
 
         super().__init__(schema=Schema())
+
+    async def build_histogram(self) -> TypeHistogram:
+        return TypeHistogram()
 
     async def fetch_extractors(self):
         return

--- a/nodestream/databases/writer.py
+++ b/nodestream/databases/writer.py
@@ -148,6 +148,7 @@ class ConcurrentGraphDatabaseWriter(GraphDatabaseWriter):
 
         # Back-pressure: wait until a flush lane is available.
         await self.flush_lane_semaphore.acquire()
+        self._report_active_lanes()  # report immediately on acquire, not after release
         self._raise_if_flush_errors()
 
         # Rotate: save the full strategy, give the pipeline a fresh one.

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -193,7 +193,14 @@ class LazyLoadedTagSafeLoader(SafeLoader):
 
 
 def wrap_unloaded_tag(self, node):
-    value = self.construct_scalar(node)
+    from yaml import MappingNode, SequenceNode
+
+    if isinstance(node, MappingNode):
+        value = self.construct_mapping(node, deep=True)
+    elif isinstance(node, SequenceNode):
+        value = self.construct_sequence(node, deep=True)
+    else:
+        value = self.construct_scalar(node)
     return LazyLoadedArgument(node.tag[1:], value)
 
 

--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -218,13 +218,16 @@ class RelationshipWithNodes(DeduplicatableObject):
     def into_ingest(self) -> "DesiredIngestion":
         from .desired_ingestion import DesiredIngestion
 
-        ingest = DesiredIngestion(source=self.from_node)
+        ingest = DesiredIngestion(
+            source=self.from_node,
+            source_node_creation_rule=self.from_side_node_creation_rule,
+        )
         ingest.add_relationship(
             self.to_node,
             self.relationship,
             outbound=True,
-            node_creation_rule=NodeCreationRule.MATCH_ONLY,
-            relationship_creation_rule=RelationshipCreationRule.EAGER,
+            node_creation_rule=self.to_side_node_creation_rule,
+            relationship_creation_rule=self.relationship_creation_rule,
         )
         return ingest
 

--- a/nodestream/model/graph_objects.py
+++ b/nodestream/model/graph_objects.py
@@ -190,8 +190,8 @@ class RelationshipWithNodes(DeduplicatableObject):
     relationship: Relationship
     outbound: bool = True  # lets us maintain knowledge of which node is the source node
 
-    to_side_node_creation_rule: NodeCreationRule = NodeCreationRule.EAGER
-    from_side_node_creation_rule: NodeCreationRule = NodeCreationRule.EAGER
+    to_side_node_creation_rule: NodeCreationRule = NodeCreationRule.MATCH_ONLY
+    from_side_node_creation_rule: NodeCreationRule = NodeCreationRule.MATCH_ONLY
     relationship_creation_rule: RelationshipCreationRule = (
         RelationshipCreationRule.EAGER
     )

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -15,7 +15,6 @@ from .argument_resolvers import set_config
 from .class_loader import ClassLoader, find_class
 from .normalizers import Normalizer
 from .object_storage import NamespacedObjectStore, NullObjectStore, ObjectStore
-from ..schema import ExpandsSchema
 from .pipeline import Pipeline
 from .scope_config import ScopeConfig
 from .step import Step

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -130,8 +130,11 @@ class StepDefinition(LoadsFromYaml):
         Resolves the class by import path without instantiating it, so this
         is safe to call in a credential-free schema-collection context.
         """
-        resolved_class = find_class(self.implementation_path)
-        return issubclass(resolved_class, ExpandsSchema)
+        try:
+            resolved_class = find_class(self.implementation_path)
+            return issubclass(resolved_class, ExpandsSchema)
+        except Exception:
+            return False
 
     def load_step(self) -> Step:
         arguments = LazyLoadedArgument.resolve_if_needed(self.arguments)

--- a/nodestream/pipeline/pipeline_file_loader.py
+++ b/nodestream/pipeline/pipeline_file_loader.py
@@ -14,6 +14,7 @@ from .argument_resolvers import set_config
 from .class_loader import ClassLoader
 from .normalizers import Normalizer
 from .object_storage import NamespacedObjectStore, NullObjectStore, ObjectStore
+from ..schema import ExpandsSchema
 from .pipeline import Pipeline
 from .scope_config import ScopeConfig
 from .step import Step
@@ -54,10 +55,20 @@ class PipelineInitializationArguments:
     extra_steps: Optional[List[Step]] = None
     effective_config_values: Optional[ScopeConfig] = None
     object_store: ObjectStore = field(default_factory=ObjectStore.null)
+    schema_only: bool = False
 
     @classmethod
     def for_introspection(cls):
-        return cls(annotations=["introspection"])
+        return cls(annotations=["introspection"], schema_only=True)
+
+    @classmethod
+    def for_schema_collection(cls):
+        """Load all pipelines (no annotation filter) but only instantiate ExpandsSchema steps.
+
+        Used by make_schema during copy operations where we need the full type/adjacency
+        graph regardless of which environment annotation (live, test, etc.) a pipeline has.
+        """
+        return cls(schema_only=True)
 
     @classmethod
     def for_testing(cls):
@@ -113,6 +124,15 @@ class StepDefinition(LoadsFromYaml):
 
         return bool(self.annotations.intersection(user_annotations))
 
+    def expands_schema(self) -> bool:
+        """Return True if the step class implements ExpandsSchema, without instantiating it."""
+        from .class_loader import find_class
+        try:
+            cls = find_class(self.implementation_path)
+            return issubclass(cls, ExpandsSchema)
+        except Exception:
+            return False
+
     def load_step(self) -> Step:
         arguments = LazyLoadedArgument.resolve_if_needed(self.arguments)
         return ClassLoader.instance(Step).load_class(
@@ -146,11 +166,17 @@ class PipelineFileContents(LoadsFromYamlFile):
 
     def initialize_with_arguments(self, init_args: PipelineInitializationArguments):
         with set_config(init_args.effective_config_values):
-            steps_defined_in_file = [
-                step_definition.load_step()
-                for step_definition in self.step_definitions
-                if step_definition.should_be_loaded(init_args.annotations)
-            ]
+            steps_defined_in_file = []
+            for step_definition in self.step_definitions:
+                if not step_definition.should_be_loaded(init_args.annotations):
+                    continue
+                if init_args.schema_only and not step_definition.expands_schema():
+                    continue
+                try:
+                    steps_defined_in_file.append(step_definition.load_step())
+                except Exception:
+                    if not init_args.schema_only:
+                        raise
             steps = steps_defined_in_file + (init_args.extra_steps or [])
         return Pipeline(
             steps,
@@ -191,6 +217,11 @@ class PipelineFile:
 
     def load_pipeline_for_introspection(self) -> Pipeline:
         initialization_arguments = PipelineInitializationArguments.for_introspection()
+        contents = self.get_contents()
+        return contents.initialize_with_arguments(initialization_arguments)
+
+    def load_pipeline_for_schema_collection(self) -> Pipeline:
+        initialization_arguments = PipelineInitializationArguments.for_schema_collection()
         contents = self.get_contents()
         return contents.initialize_with_arguments(initialization_arguments)
 

--- a/nodestream/project/pipeline_definition.py
+++ b/nodestream/project/pipeline_definition.py
@@ -164,6 +164,16 @@ class PipelineDefinition(ExpandsSchema, SavesToYaml, LoadsFromYaml):
     def initialize_for_introspection(self) -> Pipeline:
         return PipelineFile(self.file_path).load_pipeline_for_introspection()
 
+    def initialize_for_schema_collection(self) -> Pipeline:
+        return PipelineFile(self.file_path).load_pipeline_for_schema_collection()
+
     def expand_schema(self, coordinator: SchemaExpansionCoordinator):
         with coordinator.pipeline_context(self.name):
             self.initialize_for_introspection().expand_schema(coordinator)
+
+    def expand_schema_for_copy(self, coordinator: SchemaExpansionCoordinator):
+        try:
+            with coordinator.pipeline_context(self.name):
+                self.initialize_for_schema_collection().expand_schema(coordinator)
+        except Exception:
+            pass

--- a/nodestream/project/pipeline_definition.py
+++ b/nodestream/project/pipeline_definition.py
@@ -187,4 +187,8 @@ class PipelineDefinition(ExpandsSchema, SavesToYaml, LoadsFromYaml):
             with coordinator.pipeline_context(self.name):
                 self.initialize_for_schema_collection().expand_schema(coordinator)
         except Exception:
-            pass
+            logger.warning(
+                "Schema collection failed for pipeline '%s'; skipping.",
+                self.name,
+                exc_info=True,
+            )

--- a/nodestream/project/project.py
+++ b/nodestream/project/project.py
@@ -462,6 +462,21 @@ class Project(ExpandsSchemaFromChildren, LoadsFromYamlFile, SavesToYamlFile):
     def get_child_expanders(self) -> Iterable[ExpandsSchema]:
         return self.scopes_by_name.values()
 
+    def make_schema_for_copy(self, include_additional_types: bool = False) -> Schema:
+        """Build schema across all pipelines regardless of annotation, for copy operations.
+
+        Unlike make_schema (which filters by the 'introspection' annotation), this loads
+        every pipeline but still only instantiates ExpandsSchema steps — so no credentials
+        are needed. This gives the full adjacency graph needed for typed relationship queries.
+        """
+        coordinator = SchemaExpansionCoordinator(
+            schema := Schema(), include_additional_types=include_additional_types
+        )
+        for scope in self.scopes_by_name.values():
+            for pipeline in scope.pipelines_by_name.values():
+                pipeline.expand_schema_for_copy(coordinator)
+        return schema
+
     def dig_for_step_of_type(
         self, step_type: Type[T]
     ) -> Iterable[Tuple[PipelineDefinition, int, T]]:

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -678,6 +678,69 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
             relationship_type_name,
         ) in self.type_schemas
 
+    def filtered(
+        self,
+        node_filter: Optional[Set[str]] = None,
+        relationship_filter: Optional[Set[str]] = None,
+    ) -> "Schema":
+        """Return a new Schema restricted to the specified types.
+
+        Rules:
+        - If node_filter is None, all node types are included.
+        - If relationship_filter is None, all relationship types are included.
+        - An adjacency is included only when its relationship_type passes the
+          relationship_filter AND at least one of its endpoints passes the
+          node_filter.
+        - Nodes that participate in a surviving adjacency are always included,
+          even if they were not in node_filter — this ensures adjacency
+          endpoints are never dangling.
+        """
+        result = Schema()
+
+        # Determine which nodes to seed from the explicit filter.
+        included_nodes: Set[str] = (
+            set(node_filter) if node_filter is not None else {n.name for n in self.nodes}
+        )
+
+        # Determine which relationship types are allowed.
+        included_rels: Set[str] = (
+            set(relationship_filter)
+            if relationship_filter is not None
+            else {r.name for r in self.relationships}
+        )
+
+        # Build the set of surviving adjacencies (and collect endpoint nodes).
+        surviving_nodes: Set[str] = set(included_nodes)
+        surviving_adjacencies = []
+        for adjacency, cardinality in self.cardinalities.items():
+            if adjacency.relationship_type not in included_rels:
+                continue
+            touches_included = (
+                adjacency.from_node_type in included_nodes
+                or adjacency.to_node_type in included_nodes
+            )
+            if not touches_included:
+                continue
+            surviving_adjacencies.append((adjacency, cardinality))
+            surviving_nodes.add(adjacency.from_node_type)
+            surviving_nodes.add(adjacency.to_node_type)
+
+        # Populate result schema with surviving nodes.
+        for node in self.nodes:
+            if node.name in surviving_nodes:
+                result.put_node_type(node)
+
+        # Populate result schema with surviving relationship types.
+        surviving_rel_types = {adj.relationship_type for adj, _ in surviving_adjacencies}
+        for rel in self.relationships:
+            if rel.name in surviving_rel_types:
+                result.put_relationship_type(rel)
+
+        for adjacency, cardinality in surviving_adjacencies:
+            result.add_adjacency(adjacency, cardinality)
+
+        return result
+
     def diff_node_types(self, other: "Schema") -> Tuple[Set[str], Set[str]]:
         """Diff node types with another schema.
 

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -731,7 +731,9 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
                 result.put_node_type(node)
 
         # Populate result schema with surviving relationship types.
-        surviving_rel_types = {adj.relationship_type for adj, _ in surviving_adjacencies}
+        surviving_rel_types = {
+            adj.relationship_type for adj, _ in surviving_adjacencies
+        }
         for rel in self.relationships:
             if rel.name in surviving_rel_types:
                 result.put_relationship_type(rel)

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -699,14 +699,14 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
 
         # Determine which nodes to seed from the explicit filter.
         included_nodes: Set[str] = (
-            set(node_filter) if node_filter else {n.name for n in self.nodes}
+            set(node_filter) if node_filter else {node.name for node in self.nodes}
         )
 
         # Determine which relationship types are allowed.
         included_rels: Set[str] = (
             set(relationship_filter)
             if relationship_filter
-            else {r.name for r in self.relationships}
+            else {relationship.name for relationship in self.relationships}
         )
 
         # Build the set of surviving adjacencies (and collect endpoint nodes).

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, Iterable, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 from nodestream.utils import LayeredDict, LayeredList
 
@@ -680,14 +680,14 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
 
     def filtered(
         self,
-        node_filter: Optional[Set[str]] = None,
-        relationship_filter: Optional[Set[str]] = None,
+        node_filter: Optional[List[str]] = None,
+        relationship_filter: Optional[List[str]] = None,
     ) -> "Schema":
         """Return a new Schema restricted to the specified types.
 
         Rules:
-        - If node_filter is None, all node types are included.
-        - If relationship_filter is None, all relationship types are included.
+        - If node_filter is None or [], all node types are included.
+        - If relationship_filter is None or [], all relationship types are included.
         - An adjacency is included only when its relationship_type passes the
           relationship_filter AND at least one of its endpoints passes the
           node_filter.
@@ -699,13 +699,13 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
 
         # Determine which nodes to seed from the explicit filter.
         included_nodes: Set[str] = (
-            set(node_filter) if node_filter is not None else {n.name for n in self.nodes}
+            set(node_filter) if node_filter else {n.name for n in self.nodes}
         )
 
         # Determine which relationship types are allowed.
         included_rels: Set[str] = (
             set(relationship_filter)
-            if relationship_filter is not None
+            if relationship_filter
             else {r.name for r in self.relationships}
         )
 

--- a/nodestream/schema/state.py
+++ b/nodestream/schema/state.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, Optional, Set, Tuple
 
 from nodestream.utils import LayeredDict, LayeredList
 
@@ -680,8 +680,8 @@ class Schema(WritesToYamlToStdout, LoadsFromYamlFile):
 
     def filtered(
         self,
-        node_filter: Optional[List[str]] = None,
-        relationship_filter: Optional[List[str]] = None,
+        node_filter: list[str] | None = None,
+        relationship_filter: list[str] | None = None,
     ) -> "Schema":
         """Return a new Schema restricted to the specified types.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.15.3"
+version = "0.16.0"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/scripts/rev-official-plugins.sh
+++ b/scripts/rev-official-plugins.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+ORIGINAL_DIR="$(pwd)"
+trap 'cd "$ORIGINAL_DIR"' EXIT
+
 CURRENT_VERSION=$(poetry version -s)
 
 # Discover all plugin repos matching the nodestream-plugin-* prefix
@@ -27,18 +30,23 @@ for plugin_path in "${PLUGINS[@]}"; do
     git stash || true
     git checkout "$DEFAULT_BRANCH"
 
-    # Keep pulls simple: only fast-forward. If we can't, skip this plugin and move on.
-    if ! git pull --ff-only origin "$DEFAULT_BRANCH"; then
+    # Fetch all remote refs so that remote tracking branches (including release
+    # branches) are available locally for checkout.
+    git fetch origin
+
+    # Fast-forward the default branch. If we can't, skip this plugin.
+    if ! git merge --ff-only "origin/$DEFAULT_BRANCH"; then
         echo "Cannot fast-forward $DEFAULT_BRANCH for $plugin; skipping this plugin."
         cd - >/dev/null
         continue
     fi
 
     # Checkout the release branch or create it if it doesn't exist.
+    REMOTE_HAS_RELEASE=$(git ls-remote --heads origin "refs/heads/release-${CURRENT_VERSION}" | head -1)
     if git show-ref --verify --quiet "refs/heads/release-$CURRENT_VERSION"; then
         echo "Checking out existing local release-$CURRENT_VERSION"
         git checkout "release-$CURRENT_VERSION"
-    elif git ls-remote --heads origin | grep -q "refs/heads/release-$CURRENT_VERSION"; then
+    elif [ -n "$REMOTE_HAS_RELEASE" ]; then
         echo "Creating local tracking branch release-$CURRENT_VERSION from origin"
         git checkout -b "release-$CURRENT_VERSION" "origin/release-$CURRENT_VERSION"
     else

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -156,7 +156,7 @@ _DEFAULT_OPTIONS = {
     "connector-option": [],
     "retriever-option": [],
     "shard-size": None,
-    "node-only": False,
+    "preload-nodes": False,
     "reporting-frequency": "1000",
     "metrics-interval-in-seconds": None,
 }
@@ -232,12 +232,14 @@ async def test_handle_async_with_shard_size(
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_node_only(copy_command, mocker, basic_schema, project):
-    opts = {**_DEFAULT_OPTIONS, "node-only": True}
+async def test_handle_async_with_preload_nodes(
+    copy_command, mocker, basic_schema, project
+):
+    opts = {**_DEFAULT_OPTIONS, "preload-nodes": True}
     _make_handle_async_setup(copy_command, mocker, project, basic_schema, opts)
     await copy_command.handle_async()
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
-    assert run_copy_op.retriever_overrides.get("node_only") is True
+    assert run_copy_op.retriever_overrides.get("preload_nodes") is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -106,6 +106,21 @@ def test_apply_schema_filter_unknown_relationship_skipped(
     assert "NONEXISTENT" not in rel_names
 
 
+def test_apply_schema_filter_known_relationship_included(
+    copy_command, mocker, basic_schema
+):
+    def opt(name):
+        if name == "relationship":
+            return ["BEST_FRIEND_OF"]
+        return []
+
+    copy_command.option = mocker.Mock(side_effect=opt)
+    result = copy_command.apply_schema_filter(basic_schema)
+    rel_names = {r.name for r in result.relationships}
+    assert "BEST_FRIEND_OF" in rel_names
+    assert "HAS_EMPLOYEE" not in rel_names
+
+
 # ---------------------------------------------------------------------------
 # handle_async integration tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -111,7 +111,7 @@ async def test_handle_async_unknown_target_error(copy_command, mocker):
 
 @pytest.mark.asyncio
 async def test_handle_async(copy_command, mocker, basic_schema, project):
-    project.make_schema = mocker.Mock(return_value=basic_schema)
+    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
     copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
@@ -124,6 +124,9 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
     )
 
     option_values = {
+        "all": False,
+        "node": [],
+        "relationship": [],
         "concurrency-limit": "1",
         "batch-size": "1000",
         "step-outbox-size": "10000",
@@ -131,6 +134,7 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
         "connector-option": [],
         "retriever-option": [],
         "shard-size": None,
+        "relationships-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -155,10 +159,9 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
     assert run_copy_op.node_types == ["Person", "Organization"]
     assert run_copy_op.relationship_types == ["BEST_FRIEND_OF", "HAS_EMPLOYEE"]
     assert run_copy_op.batch_size == 1000
-    assert run_copy_op.concurrency_limit == 1
     assert run_copy_op.flush_concurrency == 1
     assert run_copy_op.connector_overrides == {}
-    assert run_copy_op.retriever_overrides == {}
+    assert run_copy_op.retriever_overrides.get("concurrency_limit") == 1
 
 
 @pytest.mark.asyncio
@@ -166,7 +169,7 @@ async def test_handle_async_with_non_default_options(
     copy_command, mocker, basic_schema, project
 ):
     """Conditional output lines should fire when concurrency/overrides are non-default."""
-    project.make_schema = mocker.Mock(return_value=basic_schema)
+    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
     copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
@@ -179,6 +182,9 @@ async def test_handle_async_with_non_default_options(
     )
 
     option_values = {
+        "all": False,
+        "node": [],
+        "relationship": [],
         "concurrency-limit": "4",
         "batch-size": "1000",
         "step-outbox-size": "10000",
@@ -186,6 +192,7 @@ async def test_handle_async_with_non_default_options(
         "connector-option": ["uri=bolt://remote:7687"],
         "retriever-option": ["limit=500", "sample_ratio=50"],
         "shard-size": None,
+        "relationships-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -201,10 +208,11 @@ async def test_handle_async_with_non_default_options(
 
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
     assert isinstance(run_copy_op, RunCopy)
-    assert run_copy_op.concurrency_limit == 4
     assert run_copy_op.flush_concurrency == 3
     assert run_copy_op.connector_overrides == {"uri": "bolt://remote:7687"}
-    assert run_copy_op.retriever_overrides == {"limit": 500, "sample_ratio": 50}
+    assert run_copy_op.retriever_overrides.get("concurrency_limit") == 4
+    assert run_copy_op.retriever_overrides.get("limit") == 500
+    assert run_copy_op.retriever_overrides.get("sample_ratio") == 50
 
     # Verify the conditional output lines were printed.
     printed = [str(c) for c in copy_command.line.call_args_list]

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -131,7 +131,7 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
         "connector-option": [],
         "retriever-option": [],
         "shard-size": None,
-        "relationships-only": False,
+        "node-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -188,7 +188,7 @@ async def test_handle_async_with_non_default_options(
         "connector-option": ["uri=bolt://remote:7687"],
         "retriever-option": ["limit=500", "sample_ratio=50"],
         "shard-size": None,
-        "relationships-only": False,
+        "node-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -250,7 +250,7 @@ async def test_handle_async_with_shard_size(
         "connector-option": [],
         "retriever-option": [],
         "shard-size": "5000",
-        "relationships-only": False,
+        "node-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -261,10 +261,10 @@ async def test_handle_async_with_shard_size(
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_relationships_only(
+async def test_handle_async_with_node_only(
     copy_command, mocker, basic_schema, project
 ):
-    """relationships_only=True is forwarded into retriever_overrides."""
+    """node_only=True is forwarded into retriever_overrides."""
     option_values = {
         "all": False,
         "node": [],
@@ -276,14 +276,14 @@ async def test_handle_async_with_relationships_only(
         "connector-option": [],
         "retriever-option": [],
         "shard-size": None,
-        "relationships-only": True,
+        "node-only": True,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
     _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
     await copy_command.handle_async()
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
-    assert run_copy_op.retriever_overrides.get("relationships_only") is True
+    assert run_copy_op.retriever_overrides.get("node_only") is True
 
 
 @pytest.mark.asyncio
@@ -302,7 +302,7 @@ async def test_handle_async_always_loads_schema(
         "connector-option": [],
         "retriever-option": [],
         "shard-size": None,
-        "relationships-only": False,
+        "node-only": False,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -50,55 +50,108 @@ def test_get_target_from_user_from_option_unknown_target(copy_command, project, 
     copy_command.line_error.assert_called_once_with("Unknown target: unknown")
 
 
-def test_resolve_type_filter_from_option(copy_command, mocker, basic_schema):
-    copy_command.option = mocker.Mock(side_effect=[False, ["Person"]])
-    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
-    assert_that(types, equal_to(["Person"]))
-    copy_command.option.assert_called_with("node")
+# ---------------------------------------------------------------------------
+# apply_schema_filter tests
+# ---------------------------------------------------------------------------
 
 
-def test_resolve_type_filter_from_prompt(copy_command, mocker, basic_schema):
-    copy_command.option = mocker.Mock(side_effect=[False, None])
-    copy_command.choice = mocker.Mock(return_value=["Person"])
-    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
-    assert_that(types, equal_to(["Person"]))
-    copy_command.option.assert_called_with("node")
-    copy_command.choice.assert_called_with(
-        "Which node types would you like to copy? (You can select multiple by separating them with a comma)",
-        ["Person", "Organization"],
-        multiple=True,
-    )
+def test_apply_schema_filter_no_filters_returns_full_schema(
+    copy_command, mocker, basic_schema
+):
+    copy_command.option = mocker.Mock(side_effect=lambda name: [] if name in ("node", "relationship") else None)
+    result = copy_command.apply_schema_filter(basic_schema)
+    assert result is basic_schema
 
 
-def test_resolve_type_filter_from_all_flag(copy_command, mocker, basic_schema):
-    copy_command.option = mocker.Mock(return_value=True)
-    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
-    assert_that(types, equal_to(["Person", "Organization"]))
-    copy_command.option.assert_called_once_with("all")
+def test_apply_schema_filter_node_filter(copy_command, mocker, basic_schema):
+    def opt(name):
+        if name == "node":
+            return ["Person"]
+        return []
+
+    copy_command.option = mocker.Mock(side_effect=opt)
+    result = copy_command.apply_schema_filter(basic_schema)
+    node_names = {n.name for n in result.nodes}
+    assert "Person" in node_names
 
 
-def test_resolve_type_filter_unknown_type(copy_command, mocker, basic_schema):
+def test_apply_schema_filter_unknown_node_raises(copy_command, mocker, basic_schema):
     copy_command.line_error = mocker.Mock()
+
+    def opt(name):
+        if name == "node":
+            return ["UnknownType"]
+        return []
+
+    copy_command.option = mocker.Mock(side_effect=opt)
     with pytest.raises(UnknownTargetError):
-        copy_command.option = mocker.Mock(side_effect=[False, ["Unknown"]])
-        copy_command.resolve_type_filter(basic_schema.nodes, "node")
-    copy_command.line_error.assert_called_once_with(
-        "Unknown node type(s): Unknown. Valid options are: Person, Organization"
+        copy_command.apply_schema_filter(basic_schema)
+    copy_command.line_error.assert_called_once()
+
+
+def test_apply_schema_filter_unknown_relationship_raises(
+    copy_command, mocker, basic_schema
+):
+    copy_command.line_error = mocker.Mock()
+
+    def opt(name):
+        if name == "relationship":
+            return ["NONEXISTENT"]
+        return []
+
+    copy_command.option = mocker.Mock(side_effect=opt)
+    with pytest.raises(UnknownTargetError):
+        copy_command.apply_schema_filter(basic_schema)
+    copy_command.line_error.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_async integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values):
+    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
+    copy_command.run_operation = mocker.AsyncMock(
+        side_effect=[None, None, project, None]
     )
+    copy_command.get_taget_from_user = mocker.Mock(
+        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
+    )
+    copy_command.apply_schema_filter = mocker.Mock(return_value=basic_schema)
+    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
+    mocker.patch.object(
+        type(copy_command),
+        "has_json_logging_set",
+        new_callable=mocker.PropertyMock,
+        return_value=False,
+    )
+
+
+_DEFAULT_OPTIONS = {
+    "node": [],
+    "relationship": [],
+    "concurrency-limit": "1",
+    "batch-size": "1000",
+    "step-outbox-size": "10000",
+    "flush-concurrency": "1",
+    "connector-option": [],
+    "retriever-option": [],
+    "shard-size": None,
+    "node-only": False,
+    "reporting-frequency": "1000",
+    "metrics-interval-in-seconds": None,
+}
 
 
 @pytest.mark.asyncio
 async def test_handle_async_unknown_target_error(copy_command, mocker):
-    # assume we load the project and the user selects a target that doesn't exist
     copy_command.line_error = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock()
     copy_command.get_taget_from_user = mocker.Mock(side_effect=UnknownTargetError)
-    # InitializeLogger, InitializeMetricsHandler, InitializeProject = 3 operations
-    # then get_taget_from_user raises, so RunCopy is never called.
     result = await copy_command.handle_async()
     assert_that(result, equal_to(1))
     assert copy_command.run_operation.await_count == 3
-    # Verify no RunCopy operation was created.
     run_copy_calls = [
         c
         for c in copy_command.run_operation.call_args_list
@@ -109,52 +162,17 @@ async def test_handle_async_unknown_target_error(copy_command, mocker):
 
 @pytest.mark.asyncio
 async def test_handle_async(copy_command, mocker, basic_schema, project):
-    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.run_operation = mocker.AsyncMock(
-        side_effect=[None, None, project, None]
+    _make_handle_async_setup(
+        copy_command, mocker, project, basic_schema, _DEFAULT_OPTIONS
     )
-    copy_command.get_taget_from_user = mocker.Mock(
-        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
-    )
-    copy_command.resolve_type_filter = mocker.Mock(
-        side_effect=[["Person", "Organization"], ["BEST_FRIEND_OF", "HAS_EMPLOYEE"]]
-    )
-
-    option_values = {
-        "all": False,
-        "node": [],
-        "relationship": [],
-        "concurrency-limit": "1",
-        "batch-size": "1000",
-        "step-outbox-size": "10000",
-        "flush-concurrency": "1",
-        "connector-option": [],
-        "retriever-option": [],
-        "shard-size": None,
-        "node-only": False,
-        "reporting-frequency": "1000",
-        "metrics-interval-in-seconds": None,
-    }
-    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
-    mocker.patch.object(
-        type(copy_command),
-        "has_json_logging_set",
-        new_callable=mocker.PropertyMock,
-        return_value=False,
-    )
-
     await copy_command.handle_async()
-    # InitializeLogger, InitializeMetricsHandler, InitializeProject, RunCopy = 4
     assert copy_command.run_operation.await_count == 4
 
-    # The last operation should be a RunCopy with the expected arguments.
-    run_copy_call = copy_command.run_operation.call_args_list[-1]
-    run_copy_op = run_copy_call.args[0]
+    run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
     assert isinstance(run_copy_op, RunCopy)
     assert run_copy_op.from_target == project.targets_by_name["test"]
     assert run_copy_op.to_target == project.targets_by_name["test2"]
-    assert run_copy_op.node_types == ["Person", "Organization"]
-    assert run_copy_op.relationship_types == ["BEST_FRIEND_OF", "HAS_EMPLOYEE"]
+    assert run_copy_op.schema is basic_schema
     assert run_copy_op.batch_size == 1000
     assert run_copy_op.flush_concurrency == 1
     assert run_copy_op.connector_overrides == {}
@@ -165,41 +183,14 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
 async def test_handle_async_with_non_default_options(
     copy_command, mocker, basic_schema, project
 ):
-    """Non-default concurrency/overrides are forwarded into the RunCopy operation."""
-    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.run_operation = mocker.AsyncMock(
-        side_effect=[None, None, project, None]
-    )
-    copy_command.get_taget_from_user = mocker.Mock(
-        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
-    )
-    copy_command.resolve_type_filter = mocker.Mock(
-        side_effect=[["Person", "Organization"], ["BEST_FRIEND_OF"]]
-    )
-
-    option_values = {
-        "all": False,
-        "node": [],
-        "relationship": [],
+    opts = {
+        **_DEFAULT_OPTIONS,
         "concurrency-limit": "4",
-        "batch-size": "1000",
-        "step-outbox-size": "10000",
         "flush-concurrency": "3",
         "connector-option": ["uri=bolt://remote:7687"],
         "retriever-option": ["limit=500", "sample_ratio=50"],
-        "shard-size": None,
-        "node-only": False,
-        "reporting-frequency": "1000",
-        "metrics-interval-in-seconds": None,
     }
-    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
-    mocker.patch.object(
-        type(copy_command),
-        "has_json_logging_set",
-        new_callable=mocker.PropertyMock,
-        return_value=False,
-    )
-
+    _make_handle_async_setup(copy_command, mocker, project, basic_schema, opts)
     await copy_command.handle_async()
 
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
@@ -211,76 +202,19 @@ async def test_handle_async_with_non_default_options(
     assert run_copy_op.retriever_overrides.get("sample_ratio") == 50
 
 
-def _make_handle_async_setup(
-    copy_command, mocker, project, basic_schema, option_values
-):
-    """Shared wiring for handle_async tests."""
-    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.run_operation = mocker.AsyncMock(
-        side_effect=[None, None, project, None]
-    )
-    copy_command.get_taget_from_user = mocker.Mock(
-        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
-    )
-    copy_command.resolve_type_filter = mocker.Mock(
-        side_effect=[["Person"], ["BEST_FRIEND_OF"]]
-    )
-    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
-    mocker.patch.object(
-        type(copy_command),
-        "has_json_logging_set",
-        new_callable=mocker.PropertyMock,
-        return_value=False,
-    )
-
-
 @pytest.mark.asyncio
-async def test_handle_async_with_shard_size(
-    copy_command, mocker, basic_schema, project
-):
-    """shard-size option is forwarded into retriever_overrides."""
-    option_values = {
-        "all": False,
-        "node": [],
-        "relationship": [],
-        "concurrency-limit": "1",
-        "batch-size": "1000",
-        "step-outbox-size": "10000",
-        "flush-concurrency": "1",
-        "connector-option": [],
-        "retriever-option": [],
-        "shard-size": "5000",
-        "node-only": False,
-        "reporting-frequency": "1000",
-        "metrics-interval-in-seconds": None,
-    }
-    _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
+async def test_handle_async_with_shard_size(copy_command, mocker, basic_schema, project):
+    opts = {**_DEFAULT_OPTIONS, "shard-size": "5000"}
+    _make_handle_async_setup(copy_command, mocker, project, basic_schema, opts)
     await copy_command.handle_async()
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
     assert run_copy_op.retriever_overrides.get("shard_size") == 5000
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_node_only(
-    copy_command, mocker, basic_schema, project
-):
-    """node_only=True is forwarded into retriever_overrides."""
-    option_values = {
-        "all": False,
-        "node": [],
-        "relationship": [],
-        "concurrency-limit": "1",
-        "batch-size": "1000",
-        "step-outbox-size": "10000",
-        "flush-concurrency": "1",
-        "connector-option": [],
-        "retriever-option": [],
-        "shard-size": None,
-        "node-only": True,
-        "reporting-frequency": "1000",
-        "metrics-interval-in-seconds": None,
-    }
-    _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
+async def test_handle_async_with_node_only(copy_command, mocker, basic_schema, project):
+    opts = {**_DEFAULT_OPTIONS, "node-only": True}
+    _make_handle_async_setup(copy_command, mocker, project, basic_schema, opts)
     await copy_command.handle_async()
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
     assert run_copy_op.retriever_overrides.get("node_only") is True
@@ -290,39 +224,16 @@ async def test_handle_async_with_node_only(
 async def test_handle_async_always_loads_schema(
     copy_command, mocker, basic_schema, project
 ):
-    """Schema is always loaded, even when explicit --node/--relationship are provided."""
-    option_values = {
-        "all": False,
-        "node": ["Person"],
-        "relationship": ["KNOWS"],
-        "concurrency-limit": "1",
-        "batch-size": "1000",
-        "step-outbox-size": "10000",
-        "flush-concurrency": "1",
-        "connector-option": [],
-        "retriever-option": [],
-        "shard-size": None,
-        "node-only": False,
-        "reporting-frequency": "1000",
-        "metrics-interval-in-seconds": None,
-    }
-    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.run_operation = mocker.AsyncMock(
-        side_effect=[None, None, project, None]
-    )
-    copy_command.get_taget_from_user = mocker.Mock(
-        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
-    )
-    copy_command.resolve_type_filter = mocker.Mock(side_effect=[["Person"], ["KNOWS"]])
-    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
-    mocker.patch.object(
-        type(copy_command),
-        "has_json_logging_set",
-        new_callable=mocker.PropertyMock,
-        return_value=False,
+    _make_handle_async_setup(
+        copy_command, mocker, project, basic_schema, _DEFAULT_OPTIONS
     )
     await copy_command.handle_async()
     project.make_schema_for_copy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# parse_key_value_options tests
+# ---------------------------------------------------------------------------
 
 
 def test_parse_key_value_options_int(copy_command, mocker):

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -175,7 +175,7 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
     assert run_copy_op.batch_size == 1000
     assert run_copy_op.flush_concurrency == 1
     assert run_copy_op.connector_overrides == {}
-    assert run_copy_op.retriever_overrides.get("concurrency_limit") == 1
+    assert run_copy_op.concurrency_limit == 1
 
 
 @pytest.mark.asyncio
@@ -196,7 +196,7 @@ async def test_handle_async_with_non_default_options(
     assert isinstance(run_copy_op, RunCopy)
     assert run_copy_op.flush_concurrency == 3
     assert run_copy_op.connector_overrides == {"uri": "bolt://remote:7687"}
-    assert run_copy_op.retriever_overrides.get("concurrency_limit") == 4
+    assert run_copy_op.concurrency_limit == 4
     assert run_copy_op.retriever_overrides.get("limit") == 500
     assert run_copy_op.retriever_overrides.get("sample_ratio") == 50
 

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -60,7 +60,7 @@ def test_apply_schema_filter_no_filters_returns_full_schema(
 ):
     copy_command.option = mocker.Mock(side_effect=lambda name: [] if name in ("node", "relationship") else None)
     result = copy_command.apply_schema_filter(basic_schema)
-    assert result is basic_schema
+    assert {n.name for n in result.nodes} == {n.name for n in basic_schema.nodes}
 
 
 def test_apply_schema_filter_node_filter(copy_command, mocker, basic_schema):

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -222,6 +222,124 @@ async def test_handle_async_with_non_default_options(
     assert any("Retriever Options" in s for s in printed)
 
 
+def _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values):
+    """Shared wiring for handle_async tests."""
+    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
+    copy_command.line = mocker.Mock()
+    copy_command.run_operation = mocker.AsyncMock(
+        side_effect=[None, None, project, None]
+    )
+    copy_command.get_taget_from_user = mocker.Mock(
+        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
+    )
+    copy_command.get_type_selection_from_user = mocker.Mock(
+        side_effect=[["Person"], ["BEST_FRIEND_OF"]]
+    )
+    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
+    mocker.patch.object(
+        type(copy_command),
+        "has_json_logging_set",
+        new_callable=mocker.PropertyMock,
+        return_value=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_async_with_shard_size(copy_command, mocker, basic_schema, project):
+    """shard-size option is forwarded into retriever_overrides and printed."""
+    option_values = {
+        "all": False,
+        "node": [],
+        "relationship": [],
+        "concurrency-limit": "1",
+        "batch-size": "1000",
+        "step-outbox-size": "10000",
+        "flush-concurrency": "1",
+        "connector-option": [],
+        "retriever-option": [],
+        "shard-size": "5000",
+        "relationships-only": False,
+        "reporting-frequency": "1000",
+        "metrics-interval-in-seconds": None,
+    }
+    _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
+    await copy_command.handle_async()
+    run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
+    assert run_copy_op.retriever_overrides.get("shard_size") == 5000
+    printed = [str(c) for c in copy_command.line.call_args_list]
+    assert any("Shard Size" in s for s in printed)
+
+
+@pytest.mark.asyncio
+async def test_handle_async_with_relationships_only(
+    copy_command, mocker, basic_schema, project
+):
+    """relationships_only=True prints the mode line and skips the node types line."""
+    option_values = {
+        "all": False,
+        "node": [],
+        "relationship": [],
+        "concurrency-limit": "1",
+        "batch-size": "1000",
+        "step-outbox-size": "10000",
+        "flush-concurrency": "1",
+        "connector-option": [],
+        "retriever-option": [],
+        "shard-size": None,
+        "relationships-only": True,
+        "reporting-frequency": "1000",
+        "metrics-interval-in-seconds": None,
+    }
+    _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
+    await copy_command.handle_async()
+    printed = [str(c) for c in copy_command.line.call_args_list]
+    assert any("relationships only" in s for s in printed)
+    assert not any("Node Types" in s for s in printed)
+
+
+@pytest.mark.asyncio
+async def test_handle_async_with_explicit_types_skips_schema(
+    copy_command, mocker, basic_schema, project
+):
+    """Providing explicit --node/--relationship without --all skips schema loading."""
+    option_values = {
+        "all": False,
+        "node": ["Person"],
+        "relationship": ["KNOWS"],
+        "concurrency-limit": "1",
+        "batch-size": "1000",
+        "step-outbox-size": "10000",
+        "flush-concurrency": "1",
+        "connector-option": [],
+        "retriever-option": [],
+        "shard-size": None,
+        "relationships-only": False,
+        "reporting-frequency": "1000",
+        "metrics-interval-in-seconds": None,
+    }
+    project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
+    copy_command.line = mocker.Mock()
+    copy_command.run_operation = mocker.AsyncMock(
+        side_effect=[None, None, project, None]
+    )
+    copy_command.get_taget_from_user = mocker.Mock(
+        side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
+    )
+    copy_command.get_type_selection_from_user = mocker.Mock(
+        side_effect=[["Person"], ["KNOWS"]]
+    )
+    copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
+    mocker.patch.object(
+        type(copy_command),
+        "has_json_logging_set",
+        new_callable=mocker.PropertyMock,
+        return_value=False,
+    )
+    await copy_command.handle_async()
+    # Schema was not loaded from project since explicit types were provided
+    project.make_schema_for_copy.assert_not_called()
+
+
 def test_parse_key_value_options_int(copy_command, mocker):
     copy_command.option = mocker.Mock(return_value=["limit=1000"])
     result = copy_command.parse_key_value_options("retriever-option")

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -222,7 +222,9 @@ async def test_handle_async_with_non_default_options(
     assert any("Retriever Options" in s for s in printed)
 
 
-def _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values):
+def _make_handle_async_setup(
+    copy_command, mocker, project, basic_schema, option_values
+):
     """Shared wiring for handle_async tests."""
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
     copy_command.line = mocker.Mock()
@@ -245,7 +247,9 @@ def _make_handle_async_setup(copy_command, mocker, project, basic_schema, option
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_shard_size(copy_command, mocker, basic_schema, project):
+async def test_handle_async_with_shard_size(
+    copy_command, mocker, basic_schema, project
+):
     """shard-size option is forwarded into retriever_overrides and printed."""
     option_values = {
         "all": False,

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -130,6 +130,7 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
         "flush-concurrency": "1",
         "connector-option": [],
         "retriever-option": [],
+        "shard-size": None,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }
@@ -184,6 +185,7 @@ async def test_handle_async_with_non_default_options(
         "flush-concurrency": "3",
         "connector-option": ["uri=bolt://remote:7687"],
         "retriever-option": ["limit=500", "sample_ratio=50"],
+        "shard-size": None,
         "reporting-frequency": "1000",
         "metrics-interval-in-seconds": None,
     }

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -75,34 +75,33 @@ def test_apply_schema_filter_node_filter(copy_command, mocker, basic_schema):
     assert "Person" in node_names
 
 
-def test_apply_schema_filter_unknown_node_raises(copy_command, mocker, basic_schema):
-    copy_command.line_error = mocker.Mock()
-
+def test_apply_schema_filter_unknown_node_skipped(copy_command, mocker, basic_schema):
     def opt(name):
         if name == "node":
             return ["UnknownType"]
         return []
 
     copy_command.option = mocker.Mock(side_effect=opt)
-    with pytest.raises(UnknownTargetError):
-        copy_command.apply_schema_filter(basic_schema)
-    copy_command.line_error.assert_called_once()
+    # Should not raise — unknown types are warned and skipped.
+    result = copy_command.apply_schema_filter(basic_schema)
+    # No unknown nodes survive into the filtered schema.
+    node_names = {n.name for n in result.nodes}
+    assert "UnknownType" not in node_names
 
 
-def test_apply_schema_filter_unknown_relationship_raises(
+def test_apply_schema_filter_unknown_relationship_skipped(
     copy_command, mocker, basic_schema
 ):
-    copy_command.line_error = mocker.Mock()
-
     def opt(name):
         if name == "relationship":
             return ["NONEXISTENT"]
         return []
 
     copy_command.option = mocker.Mock(side_effect=opt)
-    with pytest.raises(UnknownTargetError):
-        copy_command.apply_schema_filter(basic_schema)
-    copy_command.line_error.assert_called_once()
+    # Should not raise — unknown types are warned and skipped.
+    result = copy_command.apply_schema_filter(basic_schema)
+    rel_names = {r.name for r in result.relationships}
+    assert "NONEXISTENT" not in rel_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -58,7 +58,9 @@ def test_get_target_from_user_from_option_unknown_target(copy_command, project, 
 def test_apply_schema_filter_no_filters_returns_full_schema(
     copy_command, mocker, basic_schema
 ):
-    copy_command.option = mocker.Mock(side_effect=lambda name: [] if name in ("node", "relationship") else None)
+    copy_command.option = mocker.Mock(
+        side_effect=lambda name: [] if name in ("node", "relationship") else None
+    )
     result = copy_command.apply_schema_filter(basic_schema)
     assert {n.name for n in result.nodes} == {n.name for n in basic_schema.nodes}
 
@@ -109,7 +111,9 @@ def test_apply_schema_filter_unknown_relationship_skipped(
 # ---------------------------------------------------------------------------
 
 
-def _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values):
+def _make_handle_async_setup(
+    copy_command, mocker, project, basic_schema, option_values
+):
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
@@ -202,7 +206,9 @@ async def test_handle_async_with_non_default_options(
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_shard_size(copy_command, mocker, basic_schema, project):
+async def test_handle_async_with_shard_size(
+    copy_command, mocker, basic_schema, project
+):
     opts = {**_DEFAULT_OPTIONS, "shard-size": "5000"}
     _make_handle_async_setup(copy_command, mocker, project, basic_schema, opts)
     await copy_command.handle_async()

--- a/tests/unit/cli/commands/test_copy.py
+++ b/tests/unit/cli/commands/test_copy.py
@@ -50,17 +50,17 @@ def test_get_target_from_user_from_option_unknown_target(copy_command, project, 
     copy_command.line_error.assert_called_once_with("Unknown target: unknown")
 
 
-def test_get_type_selection_from_user_from_option(copy_command, mocker, basic_schema):
+def test_resolve_type_filter_from_option(copy_command, mocker, basic_schema):
     copy_command.option = mocker.Mock(side_effect=[False, ["Person"]])
-    types = copy_command.get_type_selection_from_user(basic_schema.nodes, "node")
+    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
     assert_that(types, equal_to(["Person"]))
     copy_command.option.assert_called_with("node")
 
 
-def test_get_type_selection_from_user_from_prompt(copy_command, mocker, basic_schema):
+def test_resolve_type_filter_from_prompt(copy_command, mocker, basic_schema):
     copy_command.option = mocker.Mock(side_effect=[False, None])
     copy_command.choice = mocker.Mock(return_value=["Person"])
-    types = copy_command.get_type_selection_from_user(basic_schema.nodes, "node")
+    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
     assert_that(types, equal_to(["Person"]))
     copy_command.option.assert_called_with("node")
     copy_command.choice.assert_called_with(
@@ -70,22 +70,20 @@ def test_get_type_selection_from_user_from_prompt(copy_command, mocker, basic_sc
     )
 
 
-def test_get_type_selection_from_user_from_all_flag(copy_command, mocker, basic_schema):
+def test_resolve_type_filter_from_all_flag(copy_command, mocker, basic_schema):
     copy_command.option = mocker.Mock(return_value=True)
-    types = copy_command.get_type_selection_from_user(basic_schema.nodes, "node")
+    types = copy_command.resolve_type_filter(basic_schema.nodes, "node")
     assert_that(types, equal_to(["Person", "Organization"]))
     copy_command.option.assert_called_once_with("all")
 
 
-def test_get_type_selection_from_user_from_option_unknown_type(
-    copy_command, mocker, basic_schema
-):
+def test_resolve_type_filter_unknown_type(copy_command, mocker, basic_schema):
     copy_command.line_error = mocker.Mock()
     with pytest.raises(UnknownTargetError):
         copy_command.option = mocker.Mock(side_effect=[False, ["Unknown"]])
-        copy_command.get_type_selection_from_user(basic_schema.nodes, "node")
+        copy_command.resolve_type_filter(basic_schema.nodes, "node")
     copy_command.line_error.assert_called_once_with(
-        "Unknown node type: Unknown. Valid options are: Person, Organization"
+        "Unknown node type(s): Unknown. Valid options are: Person, Organization"
     )
 
 
@@ -112,14 +110,13 @@ async def test_handle_async_unknown_target_error(copy_command, mocker):
 @pytest.mark.asyncio
 async def test_handle_async(copy_command, mocker, basic_schema, project):
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
     )
     copy_command.get_taget_from_user = mocker.Mock(
         side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
     )
-    copy_command.get_type_selection_from_user = mocker.Mock(
+    copy_command.resolve_type_filter = mocker.Mock(
         side_effect=[["Person", "Organization"], ["BEST_FRIEND_OF", "HAS_EMPLOYEE"]]
     )
 
@@ -168,16 +165,15 @@ async def test_handle_async(copy_command, mocker, basic_schema, project):
 async def test_handle_async_with_non_default_options(
     copy_command, mocker, basic_schema, project
 ):
-    """Conditional output lines should fire when concurrency/overrides are non-default."""
+    """Non-default concurrency/overrides are forwarded into the RunCopy operation."""
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
     )
     copy_command.get_taget_from_user = mocker.Mock(
         side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
     )
-    copy_command.get_type_selection_from_user = mocker.Mock(
+    copy_command.resolve_type_filter = mocker.Mock(
         side_effect=[["Person", "Organization"], ["BEST_FRIEND_OF"]]
     )
 
@@ -214,27 +210,19 @@ async def test_handle_async_with_non_default_options(
     assert run_copy_op.retriever_overrides.get("limit") == 500
     assert run_copy_op.retriever_overrides.get("sample_ratio") == 50
 
-    # Verify the conditional output lines were printed.
-    printed = [str(c) for c in copy_command.line.call_args_list]
-    assert any("Concurrency Limit" in s for s in printed)
-    assert any("Flush Concurrency" in s for s in printed)
-    assert any("Connector Overrides" in s for s in printed)
-    assert any("Retriever Options" in s for s in printed)
-
 
 def _make_handle_async_setup(
     copy_command, mocker, project, basic_schema, option_values
 ):
     """Shared wiring for handle_async tests."""
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
     )
     copy_command.get_taget_from_user = mocker.Mock(
         side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
     )
-    copy_command.get_type_selection_from_user = mocker.Mock(
+    copy_command.resolve_type_filter = mocker.Mock(
         side_effect=[["Person"], ["BEST_FRIEND_OF"]]
     )
     copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
@@ -250,7 +238,7 @@ def _make_handle_async_setup(
 async def test_handle_async_with_shard_size(
     copy_command, mocker, basic_schema, project
 ):
-    """shard-size option is forwarded into retriever_overrides and printed."""
+    """shard-size option is forwarded into retriever_overrides."""
     option_values = {
         "all": False,
         "node": [],
@@ -270,15 +258,13 @@ async def test_handle_async_with_shard_size(
     await copy_command.handle_async()
     run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
     assert run_copy_op.retriever_overrides.get("shard_size") == 5000
-    printed = [str(c) for c in copy_command.line.call_args_list]
-    assert any("Shard Size" in s for s in printed)
 
 
 @pytest.mark.asyncio
 async def test_handle_async_with_relationships_only(
     copy_command, mocker, basic_schema, project
 ):
-    """relationships_only=True prints the mode line and skips the node types line."""
+    """relationships_only=True is forwarded into retriever_overrides."""
     option_values = {
         "all": False,
         "node": [],
@@ -296,16 +282,15 @@ async def test_handle_async_with_relationships_only(
     }
     _make_handle_async_setup(copy_command, mocker, project, basic_schema, option_values)
     await copy_command.handle_async()
-    printed = [str(c) for c in copy_command.line.call_args_list]
-    assert any("relationships only" in s for s in printed)
-    assert not any("Node Types" in s for s in printed)
+    run_copy_op = copy_command.run_operation.call_args_list[-1].args[0]
+    assert run_copy_op.retriever_overrides.get("relationships_only") is True
 
 
 @pytest.mark.asyncio
-async def test_handle_async_with_explicit_types_skips_schema(
+async def test_handle_async_always_loads_schema(
     copy_command, mocker, basic_schema, project
 ):
-    """Providing explicit --node/--relationship without --all skips schema loading."""
+    """Schema is always loaded, even when explicit --node/--relationship are provided."""
     option_values = {
         "all": False,
         "node": ["Person"],
@@ -322,16 +307,13 @@ async def test_handle_async_with_explicit_types_skips_schema(
         "metrics-interval-in-seconds": None,
     }
     project.make_schema_for_copy = mocker.Mock(return_value=basic_schema)
-    copy_command.line = mocker.Mock()
     copy_command.run_operation = mocker.AsyncMock(
         side_effect=[None, None, project, None]
     )
     copy_command.get_taget_from_user = mocker.Mock(
         side_effect=[project.targets_by_name["test"], project.targets_by_name["test2"]]
     )
-    copy_command.get_type_selection_from_user = mocker.Mock(
-        side_effect=[["Person"], ["KNOWS"]]
-    )
+    copy_command.resolve_type_filter = mocker.Mock(side_effect=[["Person"], ["KNOWS"]])
     copy_command.option = mocker.Mock(side_effect=lambda name: option_values[name])
     mocker.patch.object(
         type(copy_command),
@@ -340,8 +322,7 @@ async def test_handle_async_with_explicit_types_skips_schema(
         return_value=False,
     )
     await copy_command.handle_async()
-    # Schema was not loaded from project since explicit types were provided
-    project.make_schema_for_copy.assert_not_called()
+    project.make_schema_for_copy.assert_called_once()
 
 
 def test_parse_key_value_options_int(copy_command, mocker):

--- a/tests/unit/cli/operations/test_run_copy.py
+++ b/tests/unit/cli/operations/test_run_copy.py
@@ -22,16 +22,13 @@ def subject(mocker, basic_schema):
 
 def test_build_writer(subject):
     result = subject.build_writer()
-    # Verify that the result is the writer returned by the target.
     assert result is subject.to_target.make_writer.return_value
 
 
-@pytest.mark.asyncio
-async def test_build_copier(subject):
-    result = await subject.build_copier()
-    # node_types and relationship_types are always forwarded; everything else
-    # flows through retriever_overrides.
+def test_build_copier(subject):
+    result = subject.build_copier()
     call_kwargs = subject.from_target.make_type_retriever.call_args[1]
+    assert_that(call_kwargs["schema"], equal_to(subject.schema))
     assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
     assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
     from nodestream.databases.copy import Copier
@@ -39,11 +36,10 @@ async def test_build_copier(subject):
     assert type(result) is Copier
 
 
-@pytest.mark.asyncio
-async def test_build_pipeline(subject, mocker):
-    subject.build_copier = mocker.AsyncMock()
+def test_build_pipeline(subject, mocker):
+    subject.build_copier = mocker.Mock()
     subject.build_writer = mocker.Mock()
-    result = await subject.build_pipeline()
+    result = subject.build_pipeline()
     assert_that(
         result.steps,
         equal_to(
@@ -52,9 +48,8 @@ async def test_build_pipeline(subject, mocker):
     )
 
 
-@pytest.mark.asyncio
-async def test_build_copier_relationships_only(mocker, basic_schema):
-    """relationships_only passed via retriever_overrides is forwarded to make_type_retriever."""
+def test_build_copier_node_only(mocker, basic_schema):
+    """node_only passed via retriever_overrides is forwarded to make_type_retriever."""
     from_target = mocker.Mock()
     from_target.name = "source"
     to_target = mocker.Mock()
@@ -65,46 +60,19 @@ async def test_build_copier_relationships_only(mocker, basic_schema):
         schema=basic_schema,
         node_types=["Person", "Movie"],
         relationship_types=["ACTED_IN"],
-        retriever_overrides={"relationships_only": True},
+        retriever_overrides={"node_only": True},
     )
-    await op.build_copier()
+    op.build_copier()
     call_kwargs = from_target.make_type_retriever.call_args[1]
     assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
     assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
-    assert_that(call_kwargs["relationships_only"], equal_to(True))
+    assert_that(call_kwargs["node_only"], equal_to(True))
 
 
 @pytest.mark.asyncio
 async def test_perform(subject, mocker):
     pipeline = mocker.AsyncMock()
-    subject.build_pipeline = mocker.AsyncMock(return_value=pipeline)
+    subject.build_pipeline = mocker.Mock(return_value=pipeline)
     await subject.perform(mocker.Mock())
-    # Verify run was awaited with a proper progress reporter.
     reporter_arg = pipeline.run.await_args[1]["reporter"]
     assert isinstance(reporter_arg, PipelineProgressReporter)
-
-
-@pytest.mark.asyncio
-async def test_build_copier_uses_build_schema_from_db_when_schema_has_no_nodes(
-    mocker, basic_schema
-):
-    """When schema has no node types, build_schema_from_db is called on the retriever."""
-    from nodestream.schema.state import Schema
-
-    from_target = mocker.Mock()
-    to_target = mocker.Mock()
-    empty_schema = Schema()
-
-    retriever = mocker.Mock()
-    retriever.build_schema_from_db = mocker.AsyncMock(return_value=basic_schema)
-    from_target.make_type_retriever.return_value = retriever
-
-    op = RunCopy(
-        from_target=from_target,
-        to_target=to_target,
-        schema=empty_schema,
-        node_types=["Person"],
-        relationship_types=["KNOWS"],
-    )
-    await op.build_copier()
-    retriever.build_schema_from_db.assert_called_once_with(["Person"], ["KNOWS"])

--- a/tests/unit/cli/operations/test_run_copy.py
+++ b/tests/unit/cli/operations/test_run_copy.py
@@ -44,8 +44,8 @@ def test_build_pipeline(subject, mocker):
     )
 
 
-def test_build_copier_node_only(mocker, basic_schema):
-    """node_only passed via retriever_overrides is forwarded to make_type_retriever."""
+def test_build_copier_preload_nodes(mocker, basic_schema):
+    """preload_nodes passed via retriever_overrides is forwarded to make_type_retriever."""
     from_target = mocker.Mock()
     from_target.name = "source"
     to_target = mocker.Mock()
@@ -54,11 +54,11 @@ def test_build_copier_node_only(mocker, basic_schema):
         from_target=from_target,
         to_target=to_target,
         schema=basic_schema,
-        retriever_overrides={"node_only": True},
+        retriever_overrides={"preload_nodes": True},
     )
     op.build_copier()
     call_kwargs = from_target.make_type_retriever.call_args[1]
-    assert_that(call_kwargs["node_only"], equal_to(True))
+    assert_that(call_kwargs["preload_nodes"], equal_to(True))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/operations/test_run_copy.py
+++ b/tests/unit/cli/operations/test_run_copy.py
@@ -82,3 +82,29 @@ async def test_perform(subject, mocker):
     # Verify run was awaited with a proper progress reporter.
     reporter_arg = pipeline.run.await_args[1]["reporter"]
     assert isinstance(reporter_arg, PipelineProgressReporter)
+
+
+@pytest.mark.asyncio
+async def test_build_copier_uses_build_schema_from_db_when_schema_has_no_nodes(
+    mocker, basic_schema
+):
+    """When schema has no node types, build_schema_from_db is called on the retriever."""
+    from nodestream.schema.state import Schema
+
+    from_target = mocker.Mock()
+    to_target = mocker.Mock()
+    empty_schema = Schema()
+
+    retriever = mocker.Mock()
+    retriever.build_schema_from_db = mocker.AsyncMock(return_value=basic_schema)
+    from_target.make_type_retriever.return_value = retriever
+
+    op = RunCopy(
+        from_target=from_target,
+        to_target=to_target,
+        schema=empty_schema,
+        node_types=["Person"],
+        relationship_types=["KNOWS"],
+    )
+    await op.build_copier()
+    retriever.build_schema_from_db.assert_called_once_with(["Person"], ["KNOWS"])

--- a/tests/unit/cli/operations/test_run_copy.py
+++ b/tests/unit/cli/operations/test_run_copy.py
@@ -26,21 +26,24 @@ def test_build_writer(subject):
     assert result is subject.to_target.make_writer.return_value
 
 
-def test_build_copier(subject):
-    result = subject.build_copier()
-    # Verify the copier has the correct configuration from the RunCopy operation.
-    assert_that(result.node_types, equal_to(["Person", "Movie"]))
-    assert_that(result.relationship_types, equal_to(["ACTED_IN"]))
-    # With concurrency_limit=1 (default), we get a base Copier, not ConcurrentCopier.
+@pytest.mark.asyncio
+async def test_build_copier(subject):
+    result = await subject.build_copier()
+    # node_types and relationship_types are always forwarded; everything else
+    # flows through retriever_overrides.
+    call_kwargs = subject.from_target.make_type_retriever.call_args[1]
+    assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
+    assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
     from nodestream.databases.copy import Copier
 
     assert type(result) is Copier
 
 
-def test_build_pipeline(subject, mocker):
-    subject.build_copier = mocker.Mock()
+@pytest.mark.asyncio
+async def test_build_pipeline(subject, mocker):
+    subject.build_copier = mocker.AsyncMock()
     subject.build_writer = mocker.Mock()
-    result = subject.build_pipeline()
+    result = await subject.build_pipeline()
     assert_that(
         result.steps,
         equal_to(
@@ -50,9 +53,31 @@ def test_build_pipeline(subject, mocker):
 
 
 @pytest.mark.asyncio
+async def test_build_copier_relationships_only(mocker, basic_schema):
+    """relationships_only passed via retriever_overrides is forwarded to make_type_retriever."""
+    from_target = mocker.Mock()
+    from_target.name = "source"
+    to_target = mocker.Mock()
+    to_target.name = "destination"
+    op = RunCopy(
+        from_target=from_target,
+        to_target=to_target,
+        schema=basic_schema,
+        node_types=["Person", "Movie"],
+        relationship_types=["ACTED_IN"],
+        retriever_overrides={"relationships_only": True},
+    )
+    await op.build_copier()
+    call_kwargs = from_target.make_type_retriever.call_args[1]
+    assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
+    assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
+    assert_that(call_kwargs["relationships_only"], equal_to(True))
+
+
+@pytest.mark.asyncio
 async def test_perform(subject, mocker):
     pipeline = mocker.AsyncMock()
-    subject.build_pipeline = mocker.Mock(return_value=pipeline)
+    subject.build_pipeline = mocker.AsyncMock(return_value=pipeline)
     await subject.perform(mocker.Mock())
     # Verify run was awaited with a proper progress reporter.
     reporter_arg = pipeline.run.await_args[1]["reporter"]

--- a/tests/unit/cli/operations/test_run_copy.py
+++ b/tests/unit/cli/operations/test_run_copy.py
@@ -15,8 +15,6 @@ def subject(mocker, basic_schema):
         from_target=from_target,
         to_target=to_target,
         schema=basic_schema,
-        node_types=["Person", "Movie"],
-        relationship_types=["ACTED_IN"],
     )
 
 
@@ -29,8 +27,6 @@ def test_build_copier(subject):
     result = subject.build_copier()
     call_kwargs = subject.from_target.make_type_retriever.call_args[1]
     assert_that(call_kwargs["schema"], equal_to(subject.schema))
-    assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
-    assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
     from nodestream.databases.copy import Copier
 
     assert type(result) is Copier
@@ -58,14 +54,10 @@ def test_build_copier_node_only(mocker, basic_schema):
         from_target=from_target,
         to_target=to_target,
         schema=basic_schema,
-        node_types=["Person", "Movie"],
-        relationship_types=["ACTED_IN"],
         retriever_overrides={"node_only": True},
     )
     op.build_copier()
     call_kwargs = from_target.make_type_retriever.call_args[1]
-    assert_that(call_kwargs["node_types"], equal_to(["Person", "Movie"]))
-    assert_that(call_kwargs["relationship_types"], equal_to(["ACTED_IN"]))
     assert_that(call_kwargs["node_only"], equal_to(True))
 
 

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from nodestream.databases.copy import (
-    ConcurrentCopier,
     Copier,
     TypeHistogram,
     TypeRetriever,
@@ -208,9 +207,6 @@ async def test_copier_propagates_extractor_error(mocker, basic_schema):
         async for _ in copier.extract_records():
             pass
 
-
-def test_copier_and_concurrent_copier_are_same_class():
-    assert ConcurrentCopier is Copier
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -19,7 +19,6 @@ from nodestream.schema import Adjacency, AdjacencyCardinality, Cardinality
 
 
 def _build_schema_with_adjacencies(basic_schema):
-    """Helper to build a schema with KNOWS (self-ref) and LIVES_AT adjacencies."""
     schema = deepcopy(basic_schema)
     schema.add_adjacency(
         Adjacency("Person", "Person", "KNOWS"),
@@ -32,13 +31,7 @@ def _build_schema_with_adjacencies(basic_schema):
     return schema
 
 
-async def _empty_async_gen():
-    return
-    yield  # pragma: no cover
-
-
 def _make_extractor(*records):
-    """Build a mock Extractor that yields the given records."""
     extractor = MagicMock(spec=Extractor)
 
     async def _extract():
@@ -49,25 +42,15 @@ def _make_extractor(*records):
     return extractor
 
 
-def _make_mock_retriever(
-    mocker, basic_schema=None, node_extractors=(), rel_extractors=(), concurrency_limit=1
-):
-    """Build a mock TypeRetriever with fetchNodeExtractors/fetchRelationshipExtractors."""
+def _make_mock_retriever(mocker, basic_schema=None, extractors=()):
     retriever = mocker.Mock()
 
-    async def _node_extractors():
-        for e in node_extractors:
+    async def _fetchExtractors():
+        for e in extractors:
             yield e
 
-    async def _rel_extractors():
-        for e in rel_extractors:
-            yield e
-
-    retriever.fetchNodeExtractors = _node_extractors
-    retriever.fetchRelationshipExtractors = _rel_extractors
+    retriever.fetchExtractors = _fetchExtractors
     retriever.build_histogram = AsyncMock(return_value=TypeHistogram())
-    retriever.concurrency_limit = concurrency_limit
-    retriever.orchestrator_queue_size = 0
     retriever.schema = basic_schema
     return retriever
 
@@ -77,11 +60,6 @@ def subject(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(mocker, basic_schema=schema)
     return Copier(retriever)
-
-
-async def async_generator(*items):
-    for item in items:
-        yield item
 
 
 def _make_step_context():
@@ -124,14 +102,11 @@ def test_histogram_log(mocker):
 
 @pytest.mark.asyncio
 async def test_start_delegates_histogram_to_retriever(subject):
-    """start() should call build_histogram on the retriever and log it."""
     histogram = TypeHistogram(
         {"Person": 50, "Address": 200}, {"KNOWS": 10, "LIVES_AT": 30}
     )
     subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
-
     await subject.start(_make_step_context())
-
     subject.type_retriever.build_histogram.assert_called_once_with()
 
 
@@ -142,15 +117,12 @@ async def test_start_logs_histogram(subject, mocker):
     )
     subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
     mock_logger = mocker.patch.object(subject, "logger")
-
     await subject.start(_make_step_context())
-
     rendered = []
     for call in mock_logger.info.call_args_list:
         fmt = call.args[0]
         args = call.args[1:]
         rendered.append(fmt % args if args else fmt)
-
     assert any("Node type histogram" in msg for msg in rendered)
     assert any("Relationship type histogram" in msg for msg in rendered)
     assert any("Address" in msg and "200" in msg for msg in rendered)
@@ -164,18 +136,14 @@ async def test_start_logs_histogram(subject, mocker):
 
 
 @pytest.mark.asyncio
-async def test_extract_records_yields_node_then_rel_extractor_records(mocker, basic_schema):
+async def test_extract_records_yields_extractor_records(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
-    nodeExtractor = _make_extractor("node-a", "node-b")
-    relExtractor = _make_extractor("rel-x")
-    retriever = _make_mock_retriever(
-        mocker, basic_schema=schema,
-        node_extractors=[nodeExtractor],
-        rel_extractors=[relExtractor],
-    )
+    e1 = _make_extractor("a", "b")
+    e2 = _make_extractor("c")
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[e1, e2])
     copier = Copier(retriever)
     records = [r async for r in copier.extract_records()]
-    assert set(records) == {"node-a", "node-b", "rel-x"}
+    assert set(records) == {"a", "b", "c"}
 
 
 @pytest.mark.asyncio
@@ -196,7 +164,7 @@ async def test_extract_records_propagates_extractor_error(mocker, basic_schema):
 
     badExtractor = MagicMock(spec=Extractor)
     badExtractor.extract_records = _failing_extract
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, node_extractors=[badExtractor])
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[badExtractor])
     copier = Copier(retriever)
     with pytest.raises(RuntimeError, match="database went away"):
         async for _ in copier.extract_records():
@@ -238,50 +206,40 @@ def test_convert_relationship_to_ingest(subject):
 
 
 # ---------------------------------------------------------------------------
-# Concurrent / concurrency_limit tests
+# Concurrency tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_runs_multiple_extractors(mocker, basic_schema):
-    """Copier runs all extractors and collects their records."""
+async def test_copier_runs_multiple_extractors_concurrently(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
     e1 = _make_extractor("a", "b")
     e2 = _make_extractor("c")
     e3 = _make_extractor("d", "e")
-    retriever = _make_mock_retriever(
-        mocker, basic_schema=schema,
-        node_extractors=[e1, e2],
-        rel_extractors=[e3],
-        concurrency_limit=4,
-    )
-    copier = Copier(retriever)
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[e1, e2, e3])
+    copier = Copier(retriever, concurrency_limit=4)
     records = [r async for r in copier.extract_records()]
     assert set(records) == {"a", "b", "c", "d", "e"}
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_propagates_error(mocker, basic_schema):
-    """Error inside an extractor propagates out of extract_records."""
+async def test_copier_propagates_extractor_error(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
 
     async def _fail():
-        raise RuntimeError("rel fetch failed")
+        raise RuntimeError("fetch failed")
         yield  # pragma: no cover
 
     badExtractor = MagicMock(spec=Extractor)
     badExtractor.extract_records = _fail
-    retriever = _make_mock_retriever(
-        mocker, basic_schema=schema, rel_extractors=[badExtractor], concurrency_limit=2
-    )
-    copier = Copier(retriever)
-    with pytest.raises(RuntimeError, match="rel fetch failed"):
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[badExtractor])
+    copier = Copier(retriever, concurrency_limit=2)
+    with pytest.raises(RuntimeError, match="fetch failed"):
         async for _ in copier.extract_records():
             pass
 
 
 def test_copier_and_concurrent_copier_are_same_class():
-    """ConcurrentCopier is just an alias for Copier."""
     assert ConcurrentCopier is Copier
 
 
@@ -302,15 +260,9 @@ def test_type_histogram_default():
 
 
 @pytest.mark.asyncio
-async def test_type_retriever_build_histogram_default(mocker, basic_schema):
-    """Default build_histogram returns an empty TypeHistogram."""
-
+async def test_type_retriever_build_histogram_default(basic_schema):
     class MinimalRetriever(TypeRetriever):
-        async def fetchNodeExtractors(self):
-            return
-            yield  # pragma: no cover
-
-        async def fetchRelationshipExtractors(self):
+        async def fetchExtractors(self):
             return
             yield  # pragma: no cover
 

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -36,7 +36,7 @@ async def _empty_async_gen():
 
 
 def _make_mock_retriever(
-    mocker, node_types=None, relationship_types=None, concurrency_limit=1
+    mocker, basic_schema=None, node_types=None, relationship_types=None, concurrency_limit=1
 ):
     """Build a mock TypeRetriever with the new ABC interface wired up."""
     retriever = mocker.Mock()
@@ -49,7 +49,8 @@ def _make_mock_retriever(
     retriever.fetchRelationships = MagicMock(return_value=_empty_async_gen())
     retriever.concurrency_limit = concurrency_limit
     retriever.orchestrator_queue_size = 0
-    retriever.relationships_only = False
+    retriever.node_only = False
+    retriever.schema = basic_schema
     return retriever
 
 
@@ -58,10 +59,11 @@ def subject(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
         mocker,
+        basic_schema=schema,
         node_types=["Person", "Address"],
         relationship_types=["KNOWS", "LIVES_AT"],
     )
-    return Copier(retriever, schema)
+    return Copier(retriever)
 
 
 async def async_generator(*items):
@@ -117,7 +119,7 @@ async def test_start_delegates_histogram_to_retriever(subject):
 
     await subject.start(_make_step_context())
 
-    subject.type_retriever.build_histogram.assert_called_once_with(subject.schema)
+    subject.type_retriever.build_histogram.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -171,13 +173,13 @@ async def test_extract_records(subject, mocker):
         ),
     )
 
-    async def mockFetchNodes(schema):
+    async def mockFetchNodes():
         async for n in people:
             yield n
         async for n in addresses:
             yield n
 
-    async def mockFetchRelationships(schema):
+    async def mockFetchRelationships():
         async for r in knows_rels:
             yield r
 
@@ -243,11 +245,12 @@ def concurrent_subject(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
         mocker,
+        basic_schema=schema,
         node_types=["Person", "Address"],
         relationship_types=["KNOWS", "LIVES_AT"],
         concurrency_limit=10,
     )
-    return Copier(retriever, schema)
+    return Copier(retriever)
 
 
 @pytest.mark.asyncio
@@ -255,12 +258,12 @@ async def test_concurrent_copier_nodes_before_relationships(concurrent_subject, 
     """Nodes are fully drained before relationships start in the concurrent path."""
     order = []
 
-    async def node_gen(schema):
+    async def node_gen():
         order.append("nodes")
         return
         yield  # pragma: no cover
 
-    async def rel_gen(schema):
+    async def rel_gen():
         order.append("rels")
         return
         yield  # pragma: no cover
@@ -277,9 +280,8 @@ async def test_concurrent_copier_nodes_before_relationships(concurrent_subject, 
 @pytest.mark.asyncio
 async def test_concurrent_copier_no_types(mocker, basic_schema):
     """Concurrent path handles empty generators gracefully."""
-    schema = deepcopy(basic_schema)
-    retriever = _make_mock_retriever(mocker, concurrency_limit=5)
-    copier = Copier(retriever, schema)
+    retriever = _make_mock_retriever(mocker, basic_schema=basic_schema, concurrency_limit=5)
+    copier = Copier(retriever)
     records = [record async for record in copier.extract_records()]
     assert records == []
 
@@ -288,15 +290,15 @@ async def test_concurrent_copier_no_types(mocker, basic_schema):
 async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema):
     """If fetch_nodes raises, the error propagates out of extract_records."""
     schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(mocker, node_types=["Person"], concurrency_limit=2)
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=2)
 
-    async def failing_nodes(schema):
+    async def failing_nodes():
         raise RuntimeError("database went away")
         yield  # pragma: no cover
 
     retriever.fetchNodes = failing_nodes
 
-    copier = Copier(retriever, schema)
+    copier = Copier(retriever)
     with pytest.raises(RuntimeError, match="database went away"):
         async for _ in copier.extract_records():
             pass
@@ -319,70 +321,61 @@ async def test_type_retriever_build_histogram_default(mocker, basic_schema):
     from nodestream.databases.copy import TypeRetriever
 
     class MinimalRetriever(TypeRetriever):
-        async def fetchNodes(self, schema):
+        async def fetchNodes(self):
             return
             yield  # pragma: no cover
 
-        async def fetchRelationships(self, schema):
+        async def fetchRelationships(self):
             return
             yield  # pragma: no cover
 
-    retriever = MinimalRetriever()
-    histogram = await retriever.build_histogram(basic_schema)
+    retriever = MinimalRetriever(schema=basic_schema)
+    histogram = await retriever.build_histogram()
     assert isinstance(histogram, TypeHistogram)
     assert histogram.node_counts == {}
     assert histogram.relationship_counts == {}
 
 
 @pytest.mark.asyncio
-async def test_extract_sequential_relationships_only(mocker, basic_schema):
-    """_extract_sequential skips nodes when relationships_only=True."""
+async def test_extract_node_only_sequential(mocker, basic_schema):
+    """Sequential path yields only nodes when node_only=True."""
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
-        mocker, relationship_types=["KNOWS"], concurrency_limit=1
+        mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=1
     )
-    retriever.relationships_only = True
+    retriever.node_only = True
 
-    rel = RelationshipWithNodes(
-        Node("Person", {"name": "A"}),
-        Node("Person", {"name": "B"}),
-        Relationship("KNOWS", {}),
-    )
+    node = Node("Person", {"name": "A"})
 
-    async def rel_gen(schema):
-        yield rel
+    async def node_gen():
+        yield node
 
-    retriever.fetchRelationships = rel_gen
-    copier = Copier(retriever, schema)
+    retriever.fetchNodes = node_gen
+    copier = Copier(retriever)
     records = [r async for r in copier.extract_records()]
-    # Only relationship records, no nodes
     assert len(records) == 1
-    retriever.fetchNodes.assert_not_called()
+    retriever.fetchRelationships.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_relationships_only(mocker, basic_schema):
-    """Concurrent path skips node queue entirely when relationships_only=True."""
+async def test_node_only_concurrent(mocker, basic_schema):
+    """Concurrent path yields only nodes when node_only=True."""
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
-        mocker, relationship_types=["KNOWS"], concurrency_limit=4
+        mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=4
     )
-    retriever.relationships_only = True
+    retriever.node_only = True
 
-    rel = RelationshipWithNodes(
-        Node("Person", {"name": "A"}),
-        Node("Person", {"name": "B"}),
-        Relationship("KNOWS", {}),
-    )
+    node = Node("Person", {"name": "A"})
 
-    async def rel_gen(schema):
-        yield rel
+    async def node_gen():
+        yield node
 
-    retriever.fetchRelationships = rel_gen
-    copier = Copier(retriever, schema)
+    retriever.fetchNodes = node_gen
+    copier = Copier(retriever)
     records = [r async for r in copier.extract_records()]
     assert len(records) == 1
-    retriever.fetchNodes.assert_not_called()
+    retriever.fetchRelationships.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -391,6 +384,7 @@ async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
         mocker,
+        basic_schema=schema,
         node_types=["Person"],
         relationship_types=["KNOWS"],
         concurrency_limit=4,
@@ -403,15 +397,15 @@ async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
         Relationship("KNOWS", {}),
     )
 
-    async def node_gen(schema):
+    async def node_gen():
         yield node
 
-    async def rel_gen(schema):
+    async def rel_gen():
         yield rel
 
     retriever.fetchNodes = node_gen
     retriever.fetchRelationships = rel_gen
-    copier = Copier(retriever, schema)
+    copier = Copier(retriever)
     copier.convert_node_to_ingest = lambda n: ("node", n.type)
     copier.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
     records = [r async for r in copier.extract_records()]
@@ -423,15 +417,14 @@ async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
 async def test_concurrent_copier_propagates_rel_producer_error(mocker, basic_schema):
     """If fetch_relationships raises, the error propagates out of extract_records."""
     schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(mocker, concurrency_limit=2)
-    retriever.relationships_only = True
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, concurrency_limit=2)
 
-    async def failing_rels(schema):
+    async def failing_rels():
         raise RuntimeError("rel fetch failed")
         yield  # pragma: no cover
 
     retriever.fetchRelationships = failing_rels
-    copier = Copier(retriever, schema)
+    copier = Copier(retriever)
     with pytest.raises(RuntimeError, match="rel fetch failed"):
         async for _ in copier.extract_records():
             pass

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -305,3 +305,133 @@ async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema)
 def test_copier_is_single_class(mocker, basic_schema):
     """Copier and ConcurrentCopier are the same class; mode is retriever-driven."""
     assert ConcurrentCopier is Copier
+
+
+def test_type_histogram_empty():
+    h = TypeHistogram.empty()
+    assert h.node_counts == {}
+    assert h.relationship_counts == {}
+
+
+@pytest.mark.asyncio
+async def test_type_retriever_build_histogram_default(mocker, basic_schema):
+    """Default build_histogram returns an empty TypeHistogram."""
+    from nodestream.databases.copy import TypeRetriever
+
+    class MinimalRetriever(TypeRetriever):
+        async def fetch_nodes(self, schema):
+            return
+            yield  # pragma: no cover
+
+        async def fetch_relationships(self, schema):
+            return
+            yield  # pragma: no cover
+
+    retriever = MinimalRetriever()
+    histogram = await retriever.build_histogram(basic_schema)
+    assert isinstance(histogram, TypeHistogram)
+    assert histogram.node_counts == {}
+    assert histogram.relationship_counts == {}
+
+
+@pytest.mark.asyncio
+async def test_extract_sequential_relationships_only(mocker, basic_schema):
+    """_extract_sequential skips nodes when relationships_only=True."""
+    schema = _build_schema_with_adjacencies(basic_schema)
+    retriever = _make_mock_retriever(
+        mocker, relationship_types=["KNOWS"], concurrency_limit=1
+    )
+    retriever.relationships_only = True
+
+    rel = RelationshipWithNodes(
+        Node("Person", {"name": "A"}),
+        Node("Person", {"name": "B"}),
+        Relationship("KNOWS", {}),
+    )
+
+    async def rel_gen(schema):
+        yield rel
+
+    retriever.fetch_relationships = rel_gen
+    copier = Copier(retriever, schema)
+    records = [r async for r in copier.extract_records()]
+    # Only relationship records, no nodes
+    assert len(records) == 1
+    retriever.fetch_nodes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_copier_relationships_only(mocker, basic_schema):
+    """Concurrent path skips node queue entirely when relationships_only=True."""
+    schema = _build_schema_with_adjacencies(basic_schema)
+    retriever = _make_mock_retriever(
+        mocker, relationship_types=["KNOWS"], concurrency_limit=4
+    )
+    retriever.relationships_only = True
+
+    rel = RelationshipWithNodes(
+        Node("Person", {"name": "A"}),
+        Node("Person", {"name": "B"}),
+        Relationship("KNOWS", {}),
+    )
+
+    async def rel_gen(schema):
+        yield rel
+
+    retriever.fetch_relationships = rel_gen
+    copier = Copier(retriever, schema)
+    records = [r async for r in copier.extract_records()]
+    assert len(records) == 1
+    retriever.fetch_nodes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
+    """Concurrent path yields both node and relationship records."""
+    schema = _build_schema_with_adjacencies(basic_schema)
+    retriever = _make_mock_retriever(
+        mocker,
+        node_types=["Person"],
+        relationship_types=["KNOWS"],
+        concurrency_limit=4,
+    )
+
+    node = Node("Person", {"name": "Alice"})
+    rel = RelationshipWithNodes(
+        Node("Person", {"name": "A"}),
+        Node("Person", {"name": "B"}),
+        Relationship("KNOWS", {}),
+    )
+
+    async def node_gen(schema):
+        yield node
+
+    async def rel_gen(schema):
+        yield rel
+
+    retriever.fetch_nodes = node_gen
+    retriever.fetch_relationships = rel_gen
+    copier = Copier(retriever, schema)
+    copier.convert_node_to_ingest = lambda n: ("node", n.type)
+    copier.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
+    records = [r async for r in copier.extract_records()]
+    assert ("node", "Person") in records
+    assert ("rel", "KNOWS") in records
+
+
+@pytest.mark.asyncio
+async def test_concurrent_copier_propagates_rel_producer_error(mocker, basic_schema):
+    """If fetch_relationships raises, the error propagates out of extract_records."""
+    schema = _build_schema_with_adjacencies(basic_schema)
+    retriever = _make_mock_retriever(mocker, concurrency_limit=2)
+    retriever.relationships_only = True
+
+    async def failing_rels(schema):
+        raise RuntimeError("rel fetch failed")
+        yield  # pragma: no cover
+
+    retriever.fetch_relationships = failing_rels
+    copier = Copier(retriever, schema)
+    with pytest.raises(RuntimeError, match="rel fetch failed"):
+        async for _ in copier.extract_records():
+            pass

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -8,8 +8,10 @@ from nodestream.databases.copy import (
     ConcurrentCopier,
     Copier,
     TypeHistogram,
+    TypeRetriever,
 )
 from nodestream.model import Node, Relationship, RelationshipWithNodes
+from nodestream.pipeline import Extractor
 from nodestream.pipeline.object_storage import ObjectStore
 from nodestream.pipeline.progress_reporter import PipelineProgressReporter
 from nodestream.pipeline.step import StepContext
@@ -35,21 +37,37 @@ async def _empty_async_gen():
     yield  # pragma: no cover
 
 
+def _make_extractor(*records):
+    """Build a mock Extractor that yields the given records."""
+    extractor = MagicMock(spec=Extractor)
+
+    async def _extract():
+        for r in records:
+            yield r
+
+    extractor.extract_records = _extract
+    return extractor
+
+
 def _make_mock_retriever(
-    mocker, basic_schema=None, node_types=None, relationship_types=None, concurrency_limit=1
+    mocker, basic_schema=None, node_extractors=(), rel_extractors=(), concurrency_limit=1
 ):
-    """Build a mock TypeRetriever with the new ABC interface wired up."""
+    """Build a mock TypeRetriever with fetchNodeExtractors/fetchRelationshipExtractors."""
     retriever = mocker.Mock()
-    histogram = TypeHistogram(
-        node_counts={t: 0 for t in (node_types or [])},
-        relationship_counts={t: 0 for t in (relationship_types or [])},
-    )
-    retriever.build_histogram = AsyncMock(return_value=histogram)
-    retriever.fetchNodes = MagicMock(return_value=_empty_async_gen())
-    retriever.fetchRelationships = MagicMock(return_value=_empty_async_gen())
+
+    async def _node_extractors():
+        for e in node_extractors:
+            yield e
+
+    async def _rel_extractors():
+        for e in rel_extractors:
+            yield e
+
+    retriever.fetchNodeExtractors = _node_extractors
+    retriever.fetchRelationshipExtractors = _rel_extractors
+    retriever.build_histogram = AsyncMock(return_value=TypeHistogram())
     retriever.concurrency_limit = concurrency_limit
     retriever.orchestrator_queue_size = 0
-    retriever.node_only = False
     retriever.schema = basic_schema
     return retriever
 
@@ -57,12 +75,7 @@ def _make_mock_retriever(
 @pytest.fixture
 def subject(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(
-        mocker,
-        basic_schema=schema,
-        node_types=["Person", "Address"],
-        relationship_types=["KNOWS", "LIVES_AT"],
-    )
+    retriever = _make_mock_retriever(mocker, basic_schema=schema)
     return Copier(retriever)
 
 
@@ -151,54 +164,47 @@ async def test_start_logs_histogram(subject, mocker):
 
 
 @pytest.mark.asyncio
-async def test_extract_records(subject, mocker):
-    people = async_generator(
-        Node("Person", {"name": "Bob"}),
-        Node("Person", {"name": "Alice"}),
+async def test_extract_records_yields_node_then_rel_extractor_records(mocker, basic_schema):
+    schema = _build_schema_with_adjacencies(basic_schema)
+    nodeExtractor = _make_extractor("node-a", "node-b")
+    relExtractor = _make_extractor("rel-x")
+    retriever = _make_mock_retriever(
+        mocker, basic_schema=schema,
+        node_extractors=[nodeExtractor],
+        rel_extractors=[relExtractor],
     )
-    addresses = async_generator(
-        Node("Address", {"street": "123 Main St"}),
-        Node("Address", {"street": "456 Main St"}),
-    )
-    knows_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Person", {"name": "Alice"}),
-            Relationship("KNOWS", {"since": 2010}),
-        ),
-        RelationshipWithNodes(
-            Node("Person", {"name": "Alice"}),
-            Node("Person", {"name": "Bob"}),
-            Relationship("KNOWS", {"since": 2015}),
-        ),
-    )
+    copier = Copier(retriever)
+    records = [r async for r in copier.extract_records()]
+    assert set(records) == {"node-a", "node-b", "rel-x"}
 
-    async def mockFetchNodes():
-        async for n in people:
-            yield n
-        async for n in addresses:
-            yield n
 
-    async def mockFetchRelationships():
-        async for r in knows_rels:
-            yield r
+@pytest.mark.asyncio
+async def test_extract_records_empty(mocker, basic_schema):
+    retriever = _make_mock_retriever(mocker, basic_schema=basic_schema)
+    copier = Copier(retriever)
+    records = [r async for r in copier.extract_records()]
+    assert records == []
 
-    subject.type_retriever.fetchNodes = mockFetchNodes
-    subject.type_retriever.fetchRelationships = mockFetchRelationships
-    subject.convert_node_to_ingest = mocker.Mock(side_effect=lambda n: ("node", n.type))
-    subject.convert_relationship_to_ingest = mocker.Mock(
-        side_effect=lambda r: ("rel", r.relationship.type)
-    )
 
-    records = [record async for record in subject.extract_records()]
+@pytest.mark.asyncio
+async def test_extract_records_propagates_extractor_error(mocker, basic_schema):
+    schema = _build_schema_with_adjacencies(basic_schema)
 
-    assert_that(records, has_length(2))
-    assert records[0] == ("rel", "KNOWS")
-    assert records[1] == ("rel", "KNOWS")
+    async def _failing_extract():
+        raise RuntimeError("database went away")
+        yield  # pragma: no cover
+
+    badExtractor = MagicMock(spec=Extractor)
+    badExtractor.extract_records = _failing_extract
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, node_extractors=[badExtractor])
+    copier = Copier(retriever)
+    with pytest.raises(RuntimeError, match="database went away"):
+        async for _ in copier.extract_records():
+            pass
 
 
 # ---------------------------------------------------------------------------
-# convert helpers
+# convert helpers (still on Copier for key reorganization)
 # ---------------------------------------------------------------------------
 
 
@@ -232,73 +238,56 @@ def test_convert_relationship_to_ingest(subject):
 
 
 # ---------------------------------------------------------------------------
-# Concurrent path tests (retriever.concurrency_limit > 1)
+# Concurrent / concurrency_limit tests
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def concurrent_subject(mocker, basic_schema):
+@pytest.mark.asyncio
+async def test_concurrent_copier_runs_multiple_extractors(mocker, basic_schema):
+    """Copier runs all extractors and collects their records."""
     schema = _build_schema_with_adjacencies(basic_schema)
+    e1 = _make_extractor("a", "b")
+    e2 = _make_extractor("c")
+    e3 = _make_extractor("d", "e")
     retriever = _make_mock_retriever(
-        mocker,
-        basic_schema=schema,
-        node_types=["Person", "Address"],
-        relationship_types=["KNOWS", "LIVES_AT"],
-        concurrency_limit=10,
+        mocker, basic_schema=schema,
+        node_extractors=[e1, e2],
+        rel_extractors=[e3],
+        concurrency_limit=4,
     )
-    return Copier(retriever)
-
-
-@pytest.mark.asyncio
-async def test_concurrent_copier_relationships_yielded(concurrent_subject, mocker):
-    """Concurrent path yields relationship records."""
-    rel = RelationshipWithNodes(
-        Node("Person", {"name": "A"}),
-        Node("Person", {"name": "B"}),
-        Relationship("KNOWS", {}),
-    )
-
-    async def rel_gen():
-        yield rel
-
-    concurrent_subject.type_retriever.fetchRelationships = rel_gen
-    concurrent_subject.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
-
-    records = [r async for r in concurrent_subject.extract_records()]
-
-    assert ("rel", "KNOWS") in records
-
-
-@pytest.mark.asyncio
-async def test_concurrent_copier_no_types(mocker, basic_schema):
-    """Concurrent path handles empty generators gracefully."""
-    retriever = _make_mock_retriever(mocker, basic_schema=basic_schema, concurrency_limit=5)
     copier = Copier(retriever)
-    records = [record async for record in copier.extract_records()]
-    assert records == []
+    records = [r async for r in copier.extract_records()]
+    assert set(records) == {"a", "b", "c", "d", "e"}
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema):
-    """If fetchRelationships raises, the error propagates out of extract_records."""
+async def test_concurrent_copier_propagates_error(mocker, basic_schema):
+    """Error inside an extractor propagates out of extract_records."""
     schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, relationship_types=["KNOWS"], concurrency_limit=2)
 
-    async def failing_rels():
-        raise RuntimeError("database went away")
+    async def _fail():
+        raise RuntimeError("rel fetch failed")
         yield  # pragma: no cover
 
-    retriever.fetchRelationships = failing_rels
-
+    badExtractor = MagicMock(spec=Extractor)
+    badExtractor.extract_records = _fail
+    retriever = _make_mock_retriever(
+        mocker, basic_schema=schema, rel_extractors=[badExtractor], concurrency_limit=2
+    )
     copier = Copier(retriever)
-    with pytest.raises(RuntimeError, match="database went away"):
+    with pytest.raises(RuntimeError, match="rel fetch failed"):
         async for _ in copier.extract_records():
             pass
 
 
-def test_copier_is_single_class(mocker, basic_schema):
-    """Copier and ConcurrentCopier are the same class; mode is retriever-driven."""
+def test_copier_and_concurrent_copier_are_same_class():
+    """ConcurrentCopier is just an alias for Copier."""
     assert ConcurrentCopier is Copier
+
+
+# ---------------------------------------------------------------------------
+# TypeHistogram default
+# ---------------------------------------------------------------------------
 
 
 def test_type_histogram_default():
@@ -307,17 +296,21 @@ def test_type_histogram_default():
     assert h.relationship_counts == {}
 
 
+# ---------------------------------------------------------------------------
+# TypeRetriever.build_histogram default
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_type_retriever_build_histogram_default(mocker, basic_schema):
     """Default build_histogram returns an empty TypeHistogram."""
-    from nodestream.databases.copy import TypeRetriever
 
     class MinimalRetriever(TypeRetriever):
-        async def fetchNodes(self):
+        async def fetchNodeExtractors(self):
             return
             yield  # pragma: no cover
 
-        async def fetchRelationships(self):
+        async def fetchRelationshipExtractors(self):
             return
             yield  # pragma: no cover
 
@@ -326,89 +319,3 @@ async def test_type_retriever_build_histogram_default(mocker, basic_schema):
     assert isinstance(histogram, TypeHistogram)
     assert histogram.node_counts == {}
     assert histogram.relationship_counts == {}
-
-
-@pytest.mark.asyncio
-async def test_extract_node_only_sequential(mocker, basic_schema):
-    """Sequential path yields only nodes when node_only=True."""
-    schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(
-        mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=1
-    )
-    retriever.node_only = True
-
-    node = Node("Person", {"name": "A"})
-
-    async def node_gen():
-        yield node
-
-    retriever.fetchNodes = node_gen
-    copier = Copier(retriever)
-    records = [r async for r in copier.extract_records()]
-    assert len(records) == 1
-    retriever.fetchRelationships.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_node_only_concurrent(mocker, basic_schema):
-    """Concurrent path yields only nodes when node_only=True."""
-    schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(
-        mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=4
-    )
-    retriever.node_only = True
-
-    node = Node("Person", {"name": "A"})
-
-    async def node_gen():
-        yield node
-
-    retriever.fetchNodes = node_gen
-    copier = Copier(retriever)
-    records = [r async for r in copier.extract_records()]
-    assert len(records) == 1
-    retriever.fetchRelationships.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_concurrent_copier_yields_rels(mocker, basic_schema):
-    """Concurrent path yields relationship records."""
-    schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(
-        mocker,
-        basic_schema=schema,
-        relationship_types=["KNOWS"],
-        concurrency_limit=4,
-    )
-
-    rel = RelationshipWithNodes(
-        Node("Person", {"name": "A"}),
-        Node("Person", {"name": "B"}),
-        Relationship("KNOWS", {}),
-    )
-
-    async def rel_gen():
-        yield rel
-
-    retriever.fetchRelationships = rel_gen
-    copier = Copier(retriever)
-    copier.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
-    records = [r async for r in copier.extract_records()]
-    assert ("rel", "KNOWS") in records
-
-
-@pytest.mark.asyncio
-async def test_concurrent_copier_propagates_rel_producer_error(mocker, basic_schema):
-    """If fetch_relationships raises, the error propagates out of extract_records."""
-    schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, concurrency_limit=2)
-
-    async def failing_rels():
-        raise RuntimeError("rel fetch failed")
-        yield  # pragma: no cover
-
-    retriever.fetchRelationships = failing_rels
-    copier = Copier(retriever)
-    with pytest.raises(RuntimeError, match="rel fetch failed"):
-        async for _ in copier.extract_records():
-            pass

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -208,7 +208,6 @@ async def test_copier_propagates_extractor_error(mocker, basic_schema):
             pass
 
 
-
 # ---------------------------------------------------------------------------
 # TypeHistogram default
 # ---------------------------------------------------------------------------

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -192,13 +192,9 @@ async def test_extract_records(subject, mocker):
 
     records = [record async for record in subject.extract_records()]
 
-    assert_that(records, has_length(6))
-    assert records[0] == ("node", "Person")
-    assert records[1] == ("node", "Person")
-    assert records[2] == ("node", "Address")
-    assert records[3] == ("node", "Address")
-    assert records[4] == ("rel", "KNOWS")
-    assert records[5] == ("rel", "KNOWS")
+    assert_that(records, has_length(2))
+    assert records[0] == ("rel", "KNOWS")
+    assert records[1] == ("rel", "KNOWS")
 
 
 # ---------------------------------------------------------------------------
@@ -254,27 +250,23 @@ def concurrent_subject(mocker, basic_schema):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_nodes_before_relationships(concurrent_subject, mocker):
-    """Nodes are fully drained before relationships start in the concurrent path."""
-    order = []
-
-    async def node_gen():
-        order.append("nodes")
-        return
-        yield  # pragma: no cover
+async def test_concurrent_copier_relationships_yielded(concurrent_subject, mocker):
+    """Concurrent path yields relationship records."""
+    rel = RelationshipWithNodes(
+        Node("Person", {"name": "A"}),
+        Node("Person", {"name": "B"}),
+        Relationship("KNOWS", {}),
+    )
 
     async def rel_gen():
-        order.append("rels")
-        return
-        yield  # pragma: no cover
+        yield rel
 
-    concurrent_subject.type_retriever.fetchNodes = node_gen
     concurrent_subject.type_retriever.fetchRelationships = rel_gen
+    concurrent_subject.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
 
-    async for _ in concurrent_subject.extract_records():
-        pass
+    records = [r async for r in concurrent_subject.extract_records()]
 
-    assert order == ["nodes", "rels"]
+    assert ("rel", "KNOWS") in records
 
 
 @pytest.mark.asyncio
@@ -288,15 +280,15 @@ async def test_concurrent_copier_no_types(mocker, basic_schema):
 
 @pytest.mark.asyncio
 async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema):
-    """If fetch_nodes raises, the error propagates out of extract_records."""
+    """If fetchRelationships raises, the error propagates out of extract_records."""
     schema = _build_schema_with_adjacencies(basic_schema)
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, node_types=["Person"], concurrency_limit=2)
+    retriever = _make_mock_retriever(mocker, basic_schema=schema, relationship_types=["KNOWS"], concurrency_limit=2)
 
-    async def failing_nodes():
+    async def failing_rels():
         raise RuntimeError("database went away")
         yield  # pragma: no cover
 
-    retriever.fetchNodes = failing_nodes
+    retriever.fetchRelationships = failing_rels
 
     copier = Copier(retriever)
     with pytest.raises(RuntimeError, match="database went away"):
@@ -309,8 +301,8 @@ def test_copier_is_single_class(mocker, basic_schema):
     assert ConcurrentCopier is Copier
 
 
-def test_type_histogram_empty():
-    h = TypeHistogram.empty()
+def test_type_histogram_default():
+    h = TypeHistogram()
     assert h.node_counts == {}
     assert h.relationship_counts == {}
 
@@ -379,37 +371,29 @@ async def test_node_only_concurrent(mocker, basic_schema):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
-    """Concurrent path yields both node and relationship records."""
+async def test_concurrent_copier_yields_rels(mocker, basic_schema):
+    """Concurrent path yields relationship records."""
     schema = _build_schema_with_adjacencies(basic_schema)
     retriever = _make_mock_retriever(
         mocker,
         basic_schema=schema,
-        node_types=["Person"],
         relationship_types=["KNOWS"],
         concurrency_limit=4,
     )
 
-    node = Node("Person", {"name": "Alice"})
     rel = RelationshipWithNodes(
         Node("Person", {"name": "A"}),
         Node("Person", {"name": "B"}),
         Relationship("KNOWS", {}),
     )
 
-    async def node_gen():
-        yield node
-
     async def rel_gen():
         yield rel
 
-    retriever.fetchNodes = node_gen
     retriever.fetchRelationships = rel_gen
     copier = Copier(retriever)
-    copier.convert_node_to_ingest = lambda n: ("node", n.type)
     copier.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
     records = [r async for r in copier.extract_records()]
-    assert ("node", "Person") in records
     assert ("rel", "KNOWS") in records
 
 

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -71,12 +71,12 @@ def _make_step_context():
 
 def test_histogram_sorted_node_types():
     h = TypeHistogram({"Person": 10, "Address": 200, "Device": 5})
-    assert h.sorted_node_types() == ["Address", "Person", "Device"]
+    assert h.sorted_types_by_count(h.node_counts) == ["Address", "Person", "Device"]
 
 
 def test_histogram_sorted_relationship_types():
     h = TypeHistogram(relationship_counts={"KNOWS": 5, "LIVES_AT": 100})
-    assert h.sorted_relationship_types() == ["LIVES_AT", "KNOWS"]
+    assert h.sorted_types_by_count(h.relationship_counts) == ["LIVES_AT", "KNOWS"]
 
 
 def test_histogram_log(mocker):

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -9,7 +9,6 @@ from nodestream.databases.copy import (
     TypeHistogram,
     TypeRetriever,
 )
-from nodestream.model import Node, Relationship, RelationshipWithNodes
 from nodestream.pipeline import Extractor
 from nodestream.pipeline.object_storage import ObjectStore
 from nodestream.pipeline.progress_reporter import PipelineProgressReporter
@@ -173,40 +172,6 @@ async def test_extract_records_propagates_extractor_error(mocker, basic_schema):
 
 
 # ---------------------------------------------------------------------------
-# convert helpers (still on Copier for key reorganization)
-# ---------------------------------------------------------------------------
-
-
-def test_convert_node_to_ingest(subject):
-    input_node = Node("Person", properties={"name": "bob", "age": 30})
-    output_node = Node("Person", key_values={"name": "bob"}, properties={"age": 30})
-    ingest = subject.convert_node_to_ingest(input_node)
-    assert ingest == output_node.into_ingest()
-
-
-def test_convert_node_to_ingest_with_unknown_type_does_not_error(subject):
-    input_node = Node("UnknownType", properties={"name": "bob"})
-    ingest = subject.convert_node_to_ingest(input_node)
-    assert ingest.source.key_values == {}
-
-
-def test_convert_node_to_ingest_with_none_type_does_not_error(subject):
-    input_node = Node(type=None, properties={"name": "bob"})
-    ingest = subject.convert_node_to_ingest(input_node)
-    assert ingest.source.key_values == {}
-
-
-def test_convert_relationship_to_ingest(subject):
-    rel = RelationshipWithNodes(
-        Node("Person", properties={"name": "Bob"}),
-        Node("Person", properties={"name": "Alice"}),
-        Relationship("KNOWS", {"since": 2010}),
-    )
-    ingest = subject.convert_relationship_to_ingest(rel)
-    assert ingest == rel.into_ingest()
-
-
-# ---------------------------------------------------------------------------
 # Concurrency tests
 # ---------------------------------------------------------------------------
 
@@ -260,13 +225,18 @@ def test_type_histogram_default():
 
 
 # ---------------------------------------------------------------------------
-# TypeRetriever.build_histogram default
+# TypeRetriever.build_histogram abstract
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_type_retriever_build_histogram_default(basic_schema):
+async def test_type_retriever_build_histogram_is_abstract(basic_schema):
+    """TypeRetriever.build_histogram is abstract — subclasses must implement it."""
+
     class MinimalRetriever(TypeRetriever):
+        async def build_histogram(self) -> TypeHistogram:
+            return TypeHistogram()
+
         async def fetch_extractors(self):
             return
             yield  # pragma: no cover

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -45,8 +45,8 @@ def _make_mock_retriever(
         relationship_counts={t: 0 for t in (relationship_types or [])},
     )
     retriever.build_histogram = AsyncMock(return_value=histogram)
-    retriever.fetch_nodes = MagicMock(return_value=_empty_async_gen())
-    retriever.fetch_relationships = MagicMock(return_value=_empty_async_gen())
+    retriever.fetchNodes = MagicMock(return_value=_empty_async_gen())
+    retriever.fetchRelationships = MagicMock(return_value=_empty_async_gen())
     retriever.concurrency_limit = concurrency_limit
     retriever.orchestrator_queue_size = 0
     retriever.relationships_only = False
@@ -171,18 +171,18 @@ async def test_extract_records(subject, mocker):
         ),
     )
 
-    async def mock_fetch_nodes(schema):
+    async def mockFetchNodes(schema):
         async for n in people:
             yield n
         async for n in addresses:
             yield n
 
-    async def mock_fetch_relationships(schema):
+    async def mockFetchRelationships(schema):
         async for r in knows_rels:
             yield r
 
-    subject.type_retriever.fetch_nodes = mock_fetch_nodes
-    subject.type_retriever.fetch_relationships = mock_fetch_relationships
+    subject.type_retriever.fetchNodes = mockFetchNodes
+    subject.type_retriever.fetchRelationships = mockFetchRelationships
     subject.convert_node_to_ingest = mocker.Mock(side_effect=lambda n: ("node", n.type))
     subject.convert_relationship_to_ingest = mocker.Mock(
         side_effect=lambda r: ("rel", r.relationship.type)
@@ -265,8 +265,8 @@ async def test_concurrent_copier_nodes_before_relationships(concurrent_subject, 
         return
         yield  # pragma: no cover
 
-    concurrent_subject.type_retriever.fetch_nodes = node_gen
-    concurrent_subject.type_retriever.fetch_relationships = rel_gen
+    concurrent_subject.type_retriever.fetchNodes = node_gen
+    concurrent_subject.type_retriever.fetchRelationships = rel_gen
 
     async for _ in concurrent_subject.extract_records():
         pass
@@ -294,7 +294,7 @@ async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema)
         raise RuntimeError("database went away")
         yield  # pragma: no cover
 
-    retriever.fetch_nodes = failing_nodes
+    retriever.fetchNodes = failing_nodes
 
     copier = Copier(retriever, schema)
     with pytest.raises(RuntimeError, match="database went away"):
@@ -319,11 +319,11 @@ async def test_type_retriever_build_histogram_default(mocker, basic_schema):
     from nodestream.databases.copy import TypeRetriever
 
     class MinimalRetriever(TypeRetriever):
-        async def fetch_nodes(self, schema):
+        async def fetchNodes(self, schema):
             return
             yield  # pragma: no cover
 
-        async def fetch_relationships(self, schema):
+        async def fetchRelationships(self, schema):
             return
             yield  # pragma: no cover
 
@@ -352,12 +352,12 @@ async def test_extract_sequential_relationships_only(mocker, basic_schema):
     async def rel_gen(schema):
         yield rel
 
-    retriever.fetch_relationships = rel_gen
+    retriever.fetchRelationships = rel_gen
     copier = Copier(retriever, schema)
     records = [r async for r in copier.extract_records()]
     # Only relationship records, no nodes
     assert len(records) == 1
-    retriever.fetch_nodes.assert_not_called()
+    retriever.fetchNodes.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -378,11 +378,11 @@ async def test_concurrent_copier_relationships_only(mocker, basic_schema):
     async def rel_gen(schema):
         yield rel
 
-    retriever.fetch_relationships = rel_gen
+    retriever.fetchRelationships = rel_gen
     copier = Copier(retriever, schema)
     records = [r async for r in copier.extract_records()]
     assert len(records) == 1
-    retriever.fetch_nodes.assert_not_called()
+    retriever.fetchNodes.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -409,8 +409,8 @@ async def test_concurrent_copier_yields_nodes_and_rels(mocker, basic_schema):
     async def rel_gen(schema):
         yield rel
 
-    retriever.fetch_nodes = node_gen
-    retriever.fetch_relationships = rel_gen
+    retriever.fetchNodes = node_gen
+    retriever.fetchRelationships = rel_gen
     copier = Copier(retriever, schema)
     copier.convert_node_to_ingest = lambda n: ("node", n.type)
     copier.convert_relationship_to_ingest = lambda r: ("rel", r.relationship.type)
@@ -430,7 +430,7 @@ async def test_concurrent_copier_propagates_rel_producer_error(mocker, basic_sch
         raise RuntimeError("rel fetch failed")
         yield  # pragma: no cover
 
-    retriever.fetch_relationships = failing_rels
+    retriever.fetchRelationships = failing_rels
     copier = Copier(retriever, schema)
     with pytest.raises(RuntimeError, match="rel fetch failed"):
         async for _ in copier.extract_records():

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from hamcrest import assert_that, equal_to, has_length
@@ -7,6 +7,7 @@ from hamcrest import assert_that, equal_to, has_length
 from nodestream.databases.copy import (
     ConcurrentCopier,
     Copier,
+    TypeHistogram,
 )
 from nodestream.model import Node, Relationship, RelationshipWithNodes
 from nodestream.pipeline.object_storage import ObjectStore
@@ -29,12 +30,36 @@ def _build_schema_with_adjacencies(basic_schema):
     return schema
 
 
+async def _empty_async_gen():
+    return
+    yield  # pragma: no cover
+
+
+def _make_mock_retriever(mocker, node_types=None, relationship_types=None, concurrency_limit=1):
+    """Build a mock TypeRetriever with the new ABC interface wired up."""
+    retriever = mocker.Mock()
+    histogram = TypeHistogram(
+        node_counts={t: 0 for t in (node_types or [])},
+        relationship_counts={t: 0 for t in (relationship_types or [])},
+    )
+    retriever.build_histogram = AsyncMock(return_value=histogram)
+    retriever.fetch_nodes = MagicMock(return_value=_empty_async_gen())
+    retriever.fetch_relationships = MagicMock(return_value=_empty_async_gen())
+    retriever.concurrency_limit = concurrency_limit
+    retriever.orchestrator_queue_size = 0
+    retriever.relationships_only = False
+    return retriever
+
+
 @pytest.fixture
 def subject(mocker, basic_schema):
-    # Use a schema that declares the adjacencies we expect to copy so that the
-    # copier always exercises the schema-driven relationship path.
     schema = _build_schema_with_adjacencies(basic_schema)
-    return Copier(mocker.Mock(), schema, ["Person", "Address"], ["KNOWS", "LIVES_AT"])
+    retriever = _make_mock_retriever(
+        mocker,
+        node_types=["Person", "Address"],
+        relationship_types=["KNOWS", "LIVES_AT"],
+    )
+    return Copier(retriever, schema)
 
 
 async def async_generator(*items):
@@ -43,139 +68,82 @@ async def async_generator(*items):
 
 
 def _make_step_context():
-    """Build a lightweight StepContext backed by a null ObjectStore."""
     return StepContext("test", 0, PipelineProgressReporter(), ObjectStore.null())
 
 
+# ---------------------------------------------------------------------------
+# TypeHistogram tests
+# ---------------------------------------------------------------------------
+
+
+def test_histogram_sorted_node_types():
+    h = TypeHistogram({"Person": 10, "Address": 200, "Device": 5})
+    assert h.sorted_node_types() == ["Address", "Person", "Device"]
+
+
+def test_histogram_sorted_relationship_types():
+    h = TypeHistogram(relationship_counts={"KNOWS": 5, "LIVES_AT": 100})
+    assert h.sorted_relationship_types() == ["LIVES_AT", "KNOWS"]
+
+
+def test_histogram_log(mocker):
+    h = TypeHistogram({"Person": 10, "Address": 200}, {"KNOWS": 5, "LIVES_AT": 100})
+    logger = mocker.Mock()
+    h.log(logger)
+    rendered = []
+    for call in logger.info.call_args_list:
+        fmt = call.args[0]
+        args = call.args[1:]
+        rendered.append(fmt % args if args else fmt)
+    assert any("Address" in msg and "200" in msg for msg in rendered)
+    assert any("Total nodes: 210" in msg for msg in rendered)
+    assert any("Total relationships: 105" in msg for msg in rendered)
+
+
+# ---------------------------------------------------------------------------
+# Copier.start tests
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_start_sorts_node_types_descending_by_count(subject):
-    """start() should reorder node_types so the largest types come first."""
-    subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 50, "Address": 200}[t]
-    )
-    subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 10, "LIVES_AT": 30}[t]
-    )
+async def test_start_delegates_histogram_to_retriever(subject):
+    """start() should call build_histogram on the retriever and log it."""
+    histogram = TypeHistogram({"Person": 50, "Address": 200}, {"KNOWS": 10, "LIVES_AT": 30})
+    subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
 
     await subject.start(_make_step_context())
 
-    assert_that(subject.node_types, equal_to(["Address", "Person"]))
-    assert_that(subject.relationship_types, equal_to(["LIVES_AT", "KNOWS"]))
-
-
-@pytest.mark.asyncio
-async def test_start_persists_counts_for_logging(subject):
-    """start() should store preview counts as instance state."""
-    subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 100, "Address": 50}[t]
-    )
-    subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 75, "LIVES_AT": 25}[t]
-    )
-
-    await subject.start(_make_step_context())
-
-    assert subject._node_counts == {"Person": 100, "Address": 50}
-    assert subject._relationship_counts == {"KNOWS": 75, "LIVES_AT": 25}
+    subject.type_retriever.build_histogram.assert_called_once_with(subject.schema)
 
 
 @pytest.mark.asyncio
 async def test_start_logs_histogram(subject, mocker):
-    """start() should log a histogram of type counts in sorted order."""
-    subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 10, "Address": 200}[t]
-    )
-    subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 5, "LIVES_AT": 100}[t]
-    )
+    histogram = TypeHistogram({"Person": 10, "Address": 200}, {"KNOWS": 5, "LIVES_AT": 100})
+    subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
     mock_logger = mocker.patch.object(subject, "logger")
 
     await subject.start(_make_step_context())
 
-    # Build the rendered log messages by applying %-formatting to each call.
     rendered = []
     for call in mock_logger.info.call_args_list:
         fmt = call.args[0]
         args = call.args[1:]
         rendered.append(fmt % args if args else fmt)
 
-    # Verify the histogram section headers.
     assert any("Node type histogram" in msg for msg in rendered)
     assert any("Relationship type histogram" in msg for msg in rendered)
-
-    # Verify individual type counts appear (sorted: Address before Person).
     assert any("Address" in msg and "200" in msg for msg in rendered)
-    assert any("Person" in msg and "10" in msg for msg in rendered)
-    assert any("LIVES_AT" in msg and "100" in msg for msg in rendered)
-    assert any("KNOWS" in msg and "5" in msg for msg in rendered)
-
-    # Verify totals.
     assert any("Total nodes: 210" in msg for msg in rendered)
     assert any("Total relationships: 105" in msg for msg in rendered)
 
 
-@pytest.mark.asyncio
-async def test_extract_records_respects_start_sort_order(subject, mocker):
-    """extract_records should iterate types in the order established by start()."""
-    # Make Address larger so it sorts first after start().
-    subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 10, "Address": 500}[t]
-    )
-    subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 5, "LIVES_AT": 100}[t]
-    )
-    await subject.start(_make_step_context())
-
-    # Now set up the generators in the *sorted* order (Address first, Person second).
-    addresses = async_generator(Node("Address", {"street": "123 Main St"}))
-    people = async_generator(Node("Person", {"name": "Bob"}))
-    lives_at_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Address", {"street": "123 Main St"}),
-            Relationship("LIVES_AT", {"since": 2010}),
-        ),
-    )
-    knows_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Person", {"name": "Alice"}),
-            Relationship("KNOWS", {"since": 2010}),
-        ),
-    )
-
-    subject.convert_node_to_ingest = mocker.Mock(side_effect=lambda n: ("node", n.type))
-    subject.convert_relationship_to_ingest = mocker.Mock(
-        side_effect=lambda r: ("rel", r.relationship.type)
-    )
-    # Side effects are consumed in call order — Address first, then Person.
-    subject.type_retriever.get_nodes_of_type.side_effect = [addresses, people]
-    subject.type_retriever.get_relationships_of_type_between.side_effect = [
-        lives_at_rels,
-        knows_rels,
-    ]
-
-    records = [record async for record in subject.extract_records()]
-
-    assert_that(records, has_length(4))
-    # Verify the ordering: Address nodes come before Person nodes.
-    assert records[0] == ("node", "Address")
-    assert records[1] == ("node", "Person")
-    assert records[2] == ("rel", "LIVES_AT")
-    assert records[3] == ("rel", "KNOWS")
+# ---------------------------------------------------------------------------
+# Copier.extract_records tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_extract_records(subject, mocker):
-    # Initialize via start() so sorting and histogram logging are exercised.
-    subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 2, "Address": 2}[t]
-    )
-    subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 2, "LIVES_AT": 2}[t]
-    )
-    await subject.start(_make_step_context())
-
     people = async_generator(
         Node("Person", {"name": "Bob"}),
         Node("Person", {"name": "Alice"}),
@@ -196,46 +164,38 @@ async def test_extract_records(subject, mocker):
             Relationship("KNOWS", {"since": 2015}),
         ),
     )
-    lives_at_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Address", {"street": "123 Main St"}),
-            Relationship("LIVES_AT", {"since": 2010}),
-        ),
-        RelationshipWithNodes(
-            Node("Person", {"name": "Alice"}),
-            Node("Address", {"street": "456 Main St"}),
-            Relationship("LIVES_AT", {"since": 2015}),
-        ),
-    )
 
-    # Tagging lambdas: convert_* returns a tagged tuple carrying the actual data,
-    # so we can assert on real content rather than mock call counts.
+    async def mock_fetch_nodes(schema):
+        async for n in people:
+            yield n
+        async for n in addresses:
+            yield n
+
+    async def mock_fetch_relationships(schema):
+        async for r in knows_rels:
+            yield r
+
+    subject.type_retriever.fetch_nodes = mock_fetch_nodes
+    subject.type_retriever.fetch_relationships = mock_fetch_relationships
     subject.convert_node_to_ingest = mocker.Mock(side_effect=lambda n: ("node", n.type))
     subject.convert_relationship_to_ingest = mocker.Mock(
         side_effect=lambda r: ("rel", r.relationship.type)
     )
-    # After start() with equal counts, order is stable (Person before Address,
-    # KNOWS before LIVES_AT — the original insertion order).
-    subject.type_retriever.get_nodes_of_type.side_effect = [people, addresses]
-    subject.type_retriever.get_relationships_of_type_between.side_effect = [
-        knows_rels,
-        lives_at_rels,
-    ]
 
     records = [record async for record in subject.extract_records()]
 
-    # 4 nodes + 4 relationships = 8 tagged records.
-    assert_that(records, has_length(8))
-    # Verify actual content: nodes come first (by type), then relationships.
+    assert_that(records, has_length(6))
     assert records[0] == ("node", "Person")
     assert records[1] == ("node", "Person")
     assert records[2] == ("node", "Address")
     assert records[3] == ("node", "Address")
     assert records[4] == ("rel", "KNOWS")
     assert records[5] == ("rel", "KNOWS")
-    assert records[6] == ("rel", "LIVES_AT")
-    assert records[7] == ("rel", "LIVES_AT")
+
+
+# ---------------------------------------------------------------------------
+# convert helpers
+# ---------------------------------------------------------------------------
 
 
 def test_convert_node_to_ingest(subject):
@@ -246,19 +206,14 @@ def test_convert_node_to_ingest(subject):
 
 
 def test_convert_node_to_ingest_with_unknown_type_does_not_error(subject):
-    """reorganize_node_key_properties should be a no-op when the type is unknown."""
-    # Use a node type that is not present in the basic_schema fixture.
     input_node = Node("UnknownType", properties={"name": "bob"})
-    # This should not raise, and key_values should remain empty.
     ingest = subject.convert_node_to_ingest(input_node)
     assert ingest.source.key_values == {}
 
 
 def test_convert_node_to_ingest_with_none_type_does_not_error(subject):
-    """reorganize_node_key_properties should be a no-op when the node type is None."""
     input_node = Node(type=None, properties={"name": "bob"})
     ingest = subject.convert_node_to_ingest(input_node)
-    # When type is None, get_node_type_by_name returns None and the method returns early.
     assert ingest.source.key_values == {}
 
 
@@ -273,130 +228,74 @@ def test_convert_relationship_to_ingest(subject):
 
 
 # ---------------------------------------------------------------------------
-# ConcurrentCopier tests
+# Concurrent path tests (retriever.concurrency_limit > 1)
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
 def concurrent_subject(mocker, basic_schema):
     schema = _build_schema_with_adjacencies(basic_schema)
-    return ConcurrentCopier(
-        mocker.Mock(),
-        schema,
-        ["Person", "Address"],
-        ["KNOWS", "LIVES_AT"],
+    retriever = _make_mock_retriever(
+        mocker,
+        node_types=["Person", "Address"],
+        relationship_types=["KNOWS", "LIVES_AT"],
         concurrency_limit=10,
     )
+    return Copier(retriever, schema)
 
 
 @pytest.mark.asyncio
-async def test_concurrent_copier_extract_records(concurrent_subject, mocker):
-    """All node types are fetched first, then all relationship types."""
-    # Initialize via start() so sorting and histogram logging are exercised.
-    concurrent_subject.type_retriever.preview_node_count = AsyncMock(
-        side_effect=lambda t: {"Person": 2, "Address": 2}[t]
-    )
-    concurrent_subject.type_retriever.preview_relationship_count = AsyncMock(
-        side_effect=lambda t: {"KNOWS": 1, "LIVES_AT": 1}[t]
-    )
-    await concurrent_subject.start(_make_step_context())
+async def test_concurrent_copier_nodes_before_relationships(concurrent_subject, mocker):
+    """Nodes are fully drained before relationships start in the concurrent path."""
+    order = []
 
-    people = async_generator(
-        Node("Person", {"name": "Bob"}),
-        Node("Person", {"name": "Alice"}),
-    )
-    addresses = async_generator(
-        Node("Address", {"street": "123 Main St"}),
-        Node("Address", {"street": "456 Main St"}),
-    )
-    knows_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Person", {"name": "Alice"}),
-            Relationship("KNOWS", {"since": 2010}),
-        ),
-    )
-    lives_at_rels = async_generator(
-        RelationshipWithNodes(
-            Node("Person", {"name": "Bob"}),
-            Node("Address", {"street": "123 Main St"}),
-            Relationship("LIVES_AT", {"since": 2010}),
-        ),
-    )
+    async def node_gen(schema):
+        order.append("nodes")
+        return
+        yield  # pragma: no cover
 
-    # Tagging lambdas to carry actual data through the pipeline.
-    concurrent_subject.convert_node_to_ingest = mocker.Mock(
-        side_effect=lambda n: ("node", n.type)
-    )
-    concurrent_subject.convert_relationship_to_ingest = mocker.Mock(
-        side_effect=lambda r: ("rel", r.relationship.type)
-    )
-    concurrent_subject.type_retriever.get_nodes_of_type.side_effect = [
-        people,
-        addresses,
-    ]
-    concurrent_subject.type_retriever.get_relationships_of_type_between.side_effect = [
-        knows_rels,
-        lives_at_rels,
-    ]
+    async def rel_gen(schema):
+        order.append("rels")
+        return
+        yield  # pragma: no cover
 
-    records = [record async for record in concurrent_subject.extract_records()]
+    concurrent_subject.type_retriever.fetch_nodes = node_gen
+    concurrent_subject.type_retriever.fetch_relationships = rel_gen
 
-    # 4 nodes + 2 relationships = 6 tagged records.
-    assert_that(records, has_length(6))
-    # Nodes come first (4), then relationships (2) — order within a group may
-    # vary due to concurrency, so use sets for the group checks.
-    node_records = [r for r in records if r[0] == "node"]
-    rel_records = [r for r in records if r[0] == "rel"]
-    assert len(node_records) == 4
-    assert {r[1] for r in node_records} == {"Person", "Address"}
-    assert len(rel_records) == 2
-    assert {r[1] for r in rel_records} == {"KNOWS", "LIVES_AT"}
+    async for _ in concurrent_subject.extract_records():
+        pass
+
+    assert order == ["nodes", "rels"]
 
 
 @pytest.mark.asyncio
 async def test_concurrent_copier_no_types(mocker, basic_schema):
-    """ConcurrentCopier should handle empty type lists gracefully."""
+    """Concurrent path handles empty generators gracefully."""
     schema = deepcopy(basic_schema)
-    copier = ConcurrentCopier(mocker.Mock(), schema, [], [], concurrency_limit=5)
+    retriever = _make_mock_retriever(mocker, concurrency_limit=5)
+    copier = Copier(retriever, schema)
     records = [record async for record in copier.extract_records()]
     assert records == []
 
 
 @pytest.mark.asyncio
 async def test_concurrent_copier_propagates_producer_error(mocker, basic_schema):
-    """If a producer raises, the error should propagate instead of hanging."""
+    """If fetch_nodes raises, the error propagates out of extract_records."""
     schema = _build_schema_with_adjacencies(basic_schema)
-    copier = ConcurrentCopier(
-        mocker.Mock(), schema, ["Person"], [], concurrency_limit=2
-    )
+    retriever = _make_mock_retriever(mocker, node_types=["Person"], concurrency_limit=2)
 
-    async def failing_generator(*_):
-        yield Node("Person", {"name": "Bob"})
+    async def failing_nodes(schema):
         raise RuntimeError("database went away")
+        yield  # pragma: no cover
 
-    copier.convert_node_to_ingest = mocker.Mock()
-    copier.type_retriever.get_nodes_of_type.side_effect = [failing_generator()]
+    retriever.fetch_nodes = failing_nodes
 
+    copier = Copier(retriever, schema)
     with pytest.raises(RuntimeError, match="database went away"):
         async for _ in copier.extract_records():
             pass
 
 
-def test_copier_create_sequential(mocker, basic_schema):
-    """Copier.create returns a plain Copier when concurrency_limit is 1."""
-    copier = Copier.create(mocker.Mock(), basic_schema, ["Person"], ["KNOWS"])
-    assert type(copier) is Copier
-
-
-def test_copier_create_concurrent(mocker, basic_schema):
-    """Copier.create returns a ConcurrentCopier when concurrency_limit > 1."""
-    copier = Copier.create(
-        mocker.Mock(),
-        basic_schema,
-        ["Person"],
-        ["KNOWS"],
-        concurrency_limit=5,
-    )
-    assert isinstance(copier, ConcurrentCopier)
-    assert copier.concurrency_limit == 5
+def test_copier_is_single_class(mocker, basic_schema):
+    """Copier and ConcurrentCopier are the same class; mode is retriever-driven."""
+    assert ConcurrentCopier is Copier

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from hamcrest import assert_that, has_length
 
 from nodestream.databases.copy import (
     ConcurrentCopier,
@@ -164,7 +163,9 @@ async def test_extract_records_propagates_extractor_error(mocker, basic_schema):
 
     badExtractor = MagicMock(spec=Extractor)
     badExtractor.extract_records = _failing_extract
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[badExtractor])
+    retriever = _make_mock_retriever(
+        mocker, basic_schema=schema, extractors=[badExtractor]
+    )
     copier = Copier(retriever)
     with pytest.raises(RuntimeError, match="database went away"):
         async for _ in copier.extract_records():
@@ -216,7 +217,9 @@ async def test_copier_runs_multiple_extractors_concurrently(mocker, basic_schema
     e1 = _make_extractor("a", "b")
     e2 = _make_extractor("c")
     e3 = _make_extractor("d", "e")
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[e1, e2, e3])
+    retriever = _make_mock_retriever(
+        mocker, basic_schema=schema, extractors=[e1, e2, e3]
+    )
     copier = Copier(retriever, concurrency_limit=4)
     records = [r async for r in copier.extract_records()]
     assert set(records) == {"a", "b", "c", "d", "e"}
@@ -232,7 +235,9 @@ async def test_copier_propagates_extractor_error(mocker, basic_schema):
 
     badExtractor = MagicMock(spec=Extractor)
     badExtractor.extract_records = _fail
-    retriever = _make_mock_retriever(mocker, basic_schema=schema, extractors=[badExtractor])
+    retriever = _make_mock_retriever(
+        mocker, basic_schema=schema, extractors=[badExtractor]
+    )
     copier = Copier(retriever, concurrency_limit=2)
     with pytest.raises(RuntimeError, match="fetch failed"):
         async for _ in copier.extract_records():

--- a/tests/unit/databases/test_copy.py
+++ b/tests/unit/databases/test_copy.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from hamcrest import assert_that, equal_to, has_length
+from hamcrest import assert_that, has_length
 
 from nodestream.databases.copy import (
     ConcurrentCopier,
@@ -35,7 +35,9 @@ async def _empty_async_gen():
     yield  # pragma: no cover
 
 
-def _make_mock_retriever(mocker, node_types=None, relationship_types=None, concurrency_limit=1):
+def _make_mock_retriever(
+    mocker, node_types=None, relationship_types=None, concurrency_limit=1
+):
     """Build a mock TypeRetriever with the new ABC interface wired up."""
     retriever = mocker.Mock()
     histogram = TypeHistogram(
@@ -108,7 +110,9 @@ def test_histogram_log(mocker):
 @pytest.mark.asyncio
 async def test_start_delegates_histogram_to_retriever(subject):
     """start() should call build_histogram on the retriever and log it."""
-    histogram = TypeHistogram({"Person": 50, "Address": 200}, {"KNOWS": 10, "LIVES_AT": 30})
+    histogram = TypeHistogram(
+        {"Person": 50, "Address": 200}, {"KNOWS": 10, "LIVES_AT": 30}
+    )
     subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
 
     await subject.start(_make_step_context())
@@ -118,7 +122,9 @@ async def test_start_delegates_histogram_to_retriever(subject):
 
 @pytest.mark.asyncio
 async def test_start_logs_histogram(subject, mocker):
-    histogram = TypeHistogram({"Person": 10, "Address": 200}, {"KNOWS": 5, "LIVES_AT": 100})
+    histogram = TypeHistogram(
+        {"Person": 10, "Address": 200}, {"KNOWS": 5, "LIVES_AT": 100}
+    )
     subject.type_retriever.build_histogram = AsyncMock(return_value=histogram)
     mock_logger = mocker.patch.object(subject, "logger")
 

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -32,14 +32,8 @@ def test_make_retriever(connector):
 
 
 @pytest.mark.asyncio
-async def test_retriever_fetch_node_extractors(retriver):
-    results = [r async for r in retriver.fetchNodeExtractors()]
-    assert_that(results, empty())
-
-
-@pytest.mark.asyncio
-async def test_retriever_fetch_relationship_extractors(retriver):
-    results = [r async for r in retriver.fetchRelationshipExtractors()]
+async def test_retriever_fetch_extractors(retriver):
+    results = [r async for r in retriver.fetchExtractors()]
     assert_that(results, empty())
 
 

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -32,14 +32,14 @@ def test_make_retriever(connector):
 
 
 @pytest.mark.asyncio
-async def test_retriever_fetch_nodes(retriver):
-    results = [r async for r in retriver.fetchNodes()]
+async def test_retriever_fetch_node_extractors(retriver):
+    results = [r async for r in retriver.fetchNodeExtractors()]
     assert_that(results, empty())
 
 
 @pytest.mark.asyncio
-async def test_retriever_fetch_relationships(retriver):
-    results = [r async for r in retriver.fetchRelationships()]
+async def test_retriever_fetch_relationship_extractors(retriver):
+    results = [r async for r in retriver.fetchRelationshipExtractors()]
     assert_that(results, empty())
 
 

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -5,7 +5,7 @@ from nodestream.databases.null import (
     NullConnector,
     NullMigrator,
     NullQueryExecutor,
-    NullRetriver,
+    NullRetriever,
 )
 
 
@@ -15,8 +15,8 @@ def connector():
 
 
 @pytest.fixture
-def retriver():
-    return NullRetriver()
+def retriever():
+    return NullRetriever()
 
 
 def test_make_migrator(connector):
@@ -28,22 +28,22 @@ def test_make_executor(connector):
 
 
 def test_make_retriever(connector):
-    assert_that(connector.make_type_retriever(), instance_of(NullRetriver))
+    assert_that(connector.make_type_retriever(), instance_of(NullRetriever))
 
 
 @pytest.mark.asyncio
-async def test_retriever_fetch_extractors(retriver):
-    results = [r async for r in retriver.fetch_extractors()]
+async def test_retriever_fetch_extractors(retriever):
+    results = [result async for result in retriever.fetch_extractors()]
     assert_that(results, empty())
 
 
 def test_make_type_retriever_accepts_kwargs(connector):
     """make_type_retriever should accept and ignore arbitrary kwargs."""
     retriever = connector.make_type_retriever(limit=500, sample_ratio=50)
-    assert_that(retriever, instance_of(NullRetriver))
+    assert_that(retriever, instance_of(NullRetriever))
 
 
 def test_connector_get_type_retriever_forwards_kwargs(connector):
     """get_type_retriever should forward kwargs to make_type_retriever."""
     retriever = connector.get_type_retriever(limit=100, extra_param="value")
-    assert_that(retriever, instance_of(NullRetriver))
+    assert_that(retriever, instance_of(NullRetriever))

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -33,13 +33,13 @@ def test_make_retriever(connector):
 
 @pytest.mark.asyncio
 async def test_retriever_fetch_nodes(retriver):
-    results = [r async for r in retriver.fetch_nodes(None)]
+    results = [r async for r in retriver.fetchNodes()]
     assert_that(results, empty())
 
 
 @pytest.mark.asyncio
 async def test_retriever_fetch_relationships(retriver):
-    results = [r async for r in retriver.fetch_relationships(None)]
+    results = [r async for r in retriver.fetchRelationships()]
     assert_that(results, empty())
 
 

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -32,32 +32,15 @@ def test_make_retriever(connector):
 
 
 @pytest.mark.asyncio
-async def test_retriever_get_nodes_of_type(retriver):
-    results = [r async for r in retriver.get_nodes_of_type("Foo")]
+async def test_retriever_fetch_nodes(retriver):
+    results = [r async for r in retriver.fetch_nodes(None)]
     assert_that(results, empty())
 
 
 @pytest.mark.asyncio
-async def test_retriever_get_relationships_of_type(retriver):
-    results = [
-        r
-        async for r in retriver.get_relationships_of_type_between(
-            "Person", "Person", "KNOWS"
-        )
-    ]
+async def test_retriever_fetch_relationships(retriver):
+    results = [r async for r in retriver.fetch_relationships(None)]
     assert_that(results, empty())
-
-
-@pytest.mark.asyncio
-async def test_retriever_preview_node_count(retriver):
-    count = await retriver.preview_node_count("Person")
-    assert count == 0
-
-
-@pytest.mark.asyncio
-async def test_retriever_preview_relationship_count(retriver):
-    count = await retriver.preview_relationship_count("KNOWS")
-    assert count == 0
 
 
 def test_make_type_retriever_accepts_kwargs(connector):

--- a/tests/unit/databases/test_null.py
+++ b/tests/unit/databases/test_null.py
@@ -1,6 +1,7 @@
 import pytest
 from hamcrest import assert_that, empty, instance_of
 
+from nodestream.databases.copy import TypeHistogram
 from nodestream.databases.null import (
     NullConnector,
     NullMigrator,
@@ -35,6 +36,14 @@ def test_make_retriever(connector):
 async def test_retriever_fetch_extractors(retriever):
     results = [result async for result in retriever.fetch_extractors()]
     assert_that(results, empty())
+
+
+@pytest.mark.asyncio
+async def test_retriever_build_histogram_returns_empty(retriever):
+    histogram = await retriever.build_histogram()
+    assert_that(histogram, instance_of(TypeHistogram))
+    assert histogram.node_counts == {}
+    assert histogram.relationship_counts == {}
 
 
 def test_make_type_retriever_accepts_kwargs(connector):

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -26,8 +26,10 @@ def test_node_into_ingest():
 def test_relationship_into_ingest_defaults():
     """into_ingest() respects the creation rule fields on RelationshipWithNodes.
 
-    Default construction uses EAGER on both sides; the retriever is responsible
-    for setting MATCH_ONLY when performing a copy operation.
+    Default construction uses MATCH_ONLY on both node sides to preserve safe
+    semantics for the normal ingest pipeline — endpoint nodes are matched, not
+    created. The copy extractor explicitly sets EAGER on both sides when it
+    constructs RelationshipWithNodes so that missing destination nodes are created.
     """
     relationship = Relationship("KNOWS", {"since": 2010})
     from_node = Node("Person", {"name": "John"})
@@ -39,14 +41,14 @@ def test_relationship_into_ingest_defaults():
     assert_that(ingest.source, equal_to(from_node))
     assert_that(ingest.relationships[0].from_node, equal_to(from_node))
     assert_that(ingest.relationships[0].to_node, equal_to(to_node))
-    # Defaults: both sides EAGER (no hardcoding in into_ingest anymore).
+    # Defaults: MATCH_ONLY — safe for normal ingest, copy sets EAGER explicitly.
     assert_that(
         ingest.relationships[0].from_side_node_creation_rule,
-        equal_to(NodeCreationRule.EAGER),
+        equal_to(NodeCreationRule.MATCH_ONLY),
     )
     assert_that(
         ingest.relationships[0].to_side_node_creation_rule,
-        equal_to(NodeCreationRule.EAGER),
+        equal_to(NodeCreationRule.MATCH_ONLY),
     )
     assert_that(
         ingest.relationships[0].relationship_creation_rule,

--- a/tests/unit/model/test_graph_objects.py
+++ b/tests/unit/model/test_graph_objects.py
@@ -23,7 +23,12 @@ def test_node_into_ingest():
     assert_that(ingest.relationships, equal_to([]))
 
 
-def test_relationship_into_ingest():
+def test_relationship_into_ingest_defaults():
+    """into_ingest() respects the creation rule fields on RelationshipWithNodes.
+
+    Default construction uses EAGER on both sides; the retriever is responsible
+    for setting MATCH_ONLY when performing a copy operation.
+    """
     relationship = Relationship("KNOWS", {"since": 2010})
     from_node = Node("Person", {"name": "John"})
     to_node = Node("Person", {"name": "Mary"})
@@ -34,20 +39,41 @@ def test_relationship_into_ingest():
     assert_that(ingest.source, equal_to(from_node))
     assert_that(ingest.relationships[0].from_node, equal_to(from_node))
     assert_that(ingest.relationships[0].to_node, equal_to(to_node))
+    # Defaults: both sides EAGER (no hardcoding in into_ingest anymore).
     assert_that(
         ingest.relationships[0].from_side_node_creation_rule,
         equal_to(NodeCreationRule.EAGER),
     )
     assert_that(
         ingest.relationships[0].to_side_node_creation_rule,
-        equal_to(NodeCreationRule.MATCH_ONLY),
+        equal_to(NodeCreationRule.EAGER),
     )
-    # The current default behavior uses EAGER for relationship creation; this
-    # assertion codifies that behavior rather than forcing a specific rule
-    # value into the model.
     assert_that(
         ingest.relationships[0].relationship_creation_rule,
         equal_to(RelationshipCreationRule.EAGER),
+    )
+
+
+def test_relationship_into_ingest_match_only():
+    """into_ingest() uses MATCH_ONLY when explicitly set — as the copy retriever does."""
+    relationship = Relationship("KNOWS", {"since": 2010})
+    from_node = Node("Person", {"name": "John"})
+    to_node = Node("Person", {"name": "Mary"})
+    relationship_with_nodes = RelationshipWithNodes(
+        from_node=from_node,
+        to_node=to_node,
+        relationship=relationship,
+        from_side_node_creation_rule=NodeCreationRule.MATCH_ONLY,
+        to_side_node_creation_rule=NodeCreationRule.MATCH_ONLY,
+    )
+    ingest = relationship_with_nodes.into_ingest()
+    assert_that(
+        ingest.relationships[0].from_side_node_creation_rule,
+        equal_to(NodeCreationRule.MATCH_ONLY),
+    )
+    assert_that(
+        ingest.relationships[0].to_side_node_creation_rule,
+        equal_to(NodeCreationRule.MATCH_ONLY),
     )
 
 

--- a/tests/unit/pipeline/fixtures/mixed_pipeline.yaml
+++ b/tests/unit/pipeline/fixtures/mixed_pipeline.yaml
@@ -1,0 +1,10 @@
+- implementation: nodestream.pipeline.step:PassStep
+  arguments:
+    name: extractor-that-needs-credentials
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    interpretations:
+      - type: source_node
+        node_type: TestNode
+        key:
+          id: !jmespath id

--- a/tests/unit/pipeline/test_pipeline_file.py
+++ b/tests/unit/pipeline/test_pipeline_file.py
@@ -197,3 +197,58 @@ def test_load_pipeline_for_schema_collection():
     # simple_pipeline has no ExpandsSchema steps — should load 0 steps
     pipeline = file_loader.load_pipeline_for_schema_collection()
     assert_that(pipeline.steps, has_length(0))
+
+
+def test_schema_only_silently_skips_failed_step_load():
+    """When schema_only=True and a step fails to load, the error is swallowed."""
+    from unittest.mock import patch
+
+    from nodestream.pipeline.pipeline_file_loader import (
+        PipelineFileContents,
+        PipelineInitializationArguments,
+        StepDefinition,
+    )
+
+    defn = StepDefinition(
+        implementation_path="nodestream.interpreting:Interpreter",
+        annotations=set(),
+        arguments={},
+    )
+    contents = PipelineFileContents([defn])
+    init_args = PipelineInitializationArguments.for_schema_collection()
+
+    with (
+        patch.object(StepDefinition, "expands_schema", return_value=True),
+        patch.object(
+            StepDefinition, "load_step", side_effect=RuntimeError("load failed")
+        ),
+    ):
+        pipeline = contents.initialize_with_arguments(init_args)
+
+    # Error is swallowed in schema_only mode — pipeline has no steps
+    assert_that(pipeline.steps, has_length(0))
+
+
+def test_non_schema_only_reraises_failed_step_load():
+    """When schema_only=False and a step fails to load, the error is re-raised."""
+    from unittest.mock import patch
+
+    from nodestream.pipeline.pipeline_file_loader import (
+        PipelineFileContents,
+        PipelineInitializationArguments,
+        StepDefinition,
+    )
+
+    defn = StepDefinition(
+        implementation_path="nodestream.interpreting:Interpreter",
+        annotations=set(),
+        arguments={},
+    )
+    contents = PipelineFileContents([defn])
+    init_args = PipelineInitializationArguments(annotations=[], schema_only=False)
+
+    with patch.object(
+        StepDefinition, "load_step", side_effect=RuntimeError("load failed")
+    ):
+        with pytest.raises(RuntimeError, match="load failed"):
+            contents.initialize_with_arguments(init_args)

--- a/tests/unit/pipeline/test_pipeline_file.py
+++ b/tests/unit/pipeline/test_pipeline_file.py
@@ -14,7 +14,6 @@ from nodestream.pipeline.pipeline_file_loader import (
     StepDefinition,
 )
 from nodestream.pipeline.step import PassStep
-from nodestream.schema import ExpandsSchema
 
 
 def test_basic_file_load():
@@ -132,9 +131,9 @@ def test_load_pipeline_for_introspection_only_loads_schema_steps():
         pipeline = file_loader.load_pipeline_for_introspection()
 
     # Only the Interpreter should have been instantiated
-    assert loaded_impls == ["nodestream.interpreting:Interpreter"], (
-        f"Expected only Interpreter to be loaded, got: {loaded_impls}"
-    )
+    assert loaded_impls == [
+        "nodestream.interpreting:Interpreter"
+    ], f"Expected only Interpreter to be loaded, got: {loaded_impls}"
     assert_that(pipeline.steps, has_length(1))
     assert_that(pipeline.steps[0], instance_of(Interpreter))
 

--- a/tests/unit/pipeline/test_pipeline_file.py
+++ b/tests/unit/pipeline/test_pipeline_file.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from hamcrest import assert_that, contains_string, equal_to, has_length, instance_of
 
 from nodestream.file_io import LazyLoadedArgument
+from nodestream.interpreting import Interpreter
 from nodestream.pipeline.pipeline_file_loader import (
     PipelineFile,
     PipelineFileContents,
@@ -12,6 +14,7 @@ from nodestream.pipeline.pipeline_file_loader import (
     StepDefinition,
 )
 from nodestream.pipeline.step import PassStep
+from nodestream.schema import ExpandsSchema
 
 
 def test_basic_file_load():
@@ -107,4 +110,53 @@ def test_load_pipeline_for_introspection():
     file_path = Path("tests/unit/pipeline/fixtures/simple_pipeline.yaml")
     file_loader = PipelineFile(file_path)
     pipeline = file_loader.load_pipeline_for_introspection()
+    # schema_only=True: only ExpandsSchema steps are loaded; PassStep doesn't expand schema
+    assert_that(pipeline.steps, has_length(0))
+
+
+def test_load_pipeline_for_introspection_only_loads_schema_steps():
+    """Mixed pipeline: PassStep (non-schema) and Interpreter (ExpandsSchema).
+    Introspection must only load the Interpreter — PassStep must never be instantiated.
+    """
+    file_path = Path("tests/unit/pipeline/fixtures/mixed_pipeline.yaml")
+    file_loader = PipelineFile(file_path)
+
+    original_load = StepDefinition.load_step
+    loaded_impls = []
+
+    def tracking_load(self):
+        loaded_impls.append(self.implementation_path)
+        return original_load(self)
+
+    with patch.object(StepDefinition, "load_step", tracking_load):
+        pipeline = file_loader.load_pipeline_for_introspection()
+
+    # Only the Interpreter should have been instantiated
+    assert loaded_impls == ["nodestream.interpreting:Interpreter"], (
+        f"Expected only Interpreter to be loaded, got: {loaded_impls}"
+    )
+    assert_that(pipeline.steps, has_length(1))
+    assert_that(pipeline.steps[0], instance_of(Interpreter))
+
+
+def test_expands_schema_returns_true_for_schema_step():
+    defn = StepDefinition(implementation_path="nodestream.interpreting:Interpreter")
+    assert defn.expands_schema() is True
+
+
+def test_expands_schema_returns_false_for_non_schema_step():
+    defn = StepDefinition(implementation_path="nodestream.pipeline.step:PassStep")
+    assert defn.expands_schema() is False
+
+
+def test_expands_schema_returns_false_for_bad_path():
+    defn = StepDefinition(implementation_path="nonexistent.module:FakeClass")
+    assert defn.expands_schema() is False
+
+
+def test_schema_only_flag_does_not_affect_normal_load():
+    """Normal (non-introspection) load must still instantiate all steps."""
+    file_path = Path("tests/unit/pipeline/fixtures/mixed_pipeline.yaml")
+    file_loader = PipelineFile(file_path)
+    pipeline = file_loader.load_pipeline()
     assert_that(pipeline.steps, has_length(2))

--- a/tests/unit/project/test_pipeline_definition.py
+++ b/tests/unit/project/test_pipeline_definition.py
@@ -258,3 +258,43 @@ def test_effective_annotation_prioritizes_self():
         "key": "value",
         "other_key": "arbitrary_value",
     }
+
+
+def test_expand_schema_for_copy_logs_warning_on_failure(mocker):
+    """expand_schema_for_copy swallows exceptions and logs a warning."""
+    coordinator = mocker.Mock()
+    subject = PipelineDefinition(
+        "test", "tests/unit/project/fixtures/simple_pipeline.yaml"
+    )
+    subject.initialize_for_schema_collection = mocker.Mock(
+        side_effect=RuntimeError("collection failed")
+    )
+    mock_logger = mocker.Mock()
+    mocker.patch("nodestream.project.pipeline_definition.logger", mock_logger)
+    subject.expand_schema_for_copy(coordinator)
+    mock_logger.warning.assert_called_once()
+    assert "test" in mock_logger.warning.call_args[0][1]
+
+
+def test_expand_schema_for_copy_happy_path(mocker):
+    """expand_schema_for_copy calls initialize_for_schema_collection and expand_schema."""
+    coordinator = mocker.MagicMock()
+    subject = PipelineDefinition(
+        "test", "tests/unit/project/fixtures/simple_pipeline.yaml"
+    )
+    mock_pipeline = mocker.Mock()
+    subject.initialize_for_schema_collection = mocker.Mock(return_value=mock_pipeline)
+    subject.expand_schema_for_copy(coordinator)
+    mock_pipeline.expand_schema.assert_called_once_with(coordinator)
+
+
+def test_expand_schema_calls_initialize_for_schema_collection(mocker):
+    """expand_schema calls initialize_for_schema_collection and expand_schema."""
+    coordinator = mocker.MagicMock()
+    subject = PipelineDefinition(
+        "test", "tests/unit/project/fixtures/simple_pipeline.yaml"
+    )
+    mock_pipeline = mocker.Mock()
+    subject.initialize_for_schema_collection = mocker.Mock(return_value=mock_pipeline)
+    subject.expand_schema(coordinator)
+    mock_pipeline.expand_schema.assert_called_once_with(coordinator)

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -669,3 +669,17 @@ def test_dig_for_step_of_type_yields_matching_steps(project, mocker):
     assert_that(pl2, same_instance(pipeline2))
     assert_that(idx2, equal_to(1))
     assert isinstance(step2, DummyStep)
+
+
+def test_make_schema_for_copy_returns_schema(project, mocker):
+    """make_schema_for_copy collects schema from all pipelines and returns it."""
+    for scope in project.scopes_by_name.values():
+        for pipeline in scope.pipelines_by_name.values():
+            pipeline.expand_schema_for_copy = mocker.Mock()
+
+    schema = project.make_schema_for_copy()
+
+    assert isinstance(schema, Schema)
+    for scope in project.scopes_by_name.values():
+        for pipeline in scope.pipelines_by_name.values():
+            pipeline.expand_schema_for_copy.assert_called_once()

--- a/tests/unit/schema/migrations/test_auto_detector.py
+++ b/tests/unit/schema/migrations/test_auto_detector.py
@@ -795,3 +795,47 @@ async def test_auto_change_detections_with_permutations(
     # Compare the detected changes to the expected changes.
     for scenario in scenario_instances:
         scenario.compare_to_expected_detections(detections)
+
+
+@pytest.mark.asyncio
+async def test_detect_node_key_changes_raises_when_key_deleted():
+    """detect_node_key_changes raises NotImplementedError when a node key is removed."""
+    memory_migrator = InMemoryMigrator()
+    input = ScenarioMigratorInput()
+
+    # Start with a node type that has two keys.
+    await memory_migrator.execute_operation(
+        CreateNodeType(name="Person", keys={"id", "email"}, properties=set())
+    )
+    from_state = StaticStateProvider(deepcopy(memory_migrator.schema))
+
+    # Build "to" state where one key is demoted to a regular property.
+    to_schema = deepcopy(memory_migrator.schema)
+    person = next(n for n in to_schema.nodes if n.name == "Person")
+    person.properties["email"].is_key = False
+    to_state = StaticStateProvider(to_schema)
+
+    detector = AutoChangeDetector(input, from_state, to_state)
+    with pytest.raises(NotImplementedError):
+        await detector.detect_changes()
+
+
+@pytest.mark.asyncio
+async def test_detect_relationship_key_changes_raises_when_key_deleted():
+    """detect_relationship_key_changes raises NotImplementedError when a key is removed."""
+    memory_migrator = InMemoryMigrator()
+    input = ScenarioMigratorInput()
+
+    await memory_migrator.execute_operation(
+        CreateRelationshipType(name="KNOWS", keys={"since", "weight"}, properties=set())
+    )
+    from_state = StaticStateProvider(deepcopy(memory_migrator.schema))
+
+    to_schema = deepcopy(memory_migrator.schema)
+    rel = next(r for r in to_schema.relationships if r.name == "KNOWS")
+    rel.properties["weight"].is_key = False
+    to_state = StaticStateProvider(to_schema)
+
+    detector = AutoChangeDetector(input, from_state, to_state)
+    with pytest.raises(NotImplementedError):
+        await detector.detect_changes()

--- a/tests/unit/schema/test_state.py
+++ b/tests/unit/schema/test_state.py
@@ -360,3 +360,47 @@ def test_pipeline_context_restores_on_exception():
     except ValueError:
         pass
     assert coordinator._current_pipeline is None
+
+
+# -- Schema.filtered() -------------------------------------------------------
+
+
+def test_filtered_no_filters_returns_all_types(basic_schema):
+    result = basic_schema.filtered()
+    assert {n.name for n in result.nodes} == {"Person", "Organization"}
+    assert {r.name for r in result.relationships} == {"BEST_FRIEND_OF", "HAS_EMPLOYEE"}
+
+
+def test_filtered_node_filter_includes_adjacency_endpoints(basic_schema):
+    # Filter to Person only; HAS_EMPLOYEE connects Organization→Person,
+    # so Organization should be pulled in as an endpoint.
+    result = basic_schema.filtered(node_filter=["Person"])
+    node_names = {n.name for n in result.nodes}
+    assert "Person" in node_names
+    assert "Organization" in node_names  # endpoint of HAS_EMPLOYEE
+
+
+def test_filtered_relationship_filter_excludes_unmatched_rel_type(basic_schema):
+    # Line 717: adjacency whose rel type is not in included_rels → continue
+    result = basic_schema.filtered(relationship_filter=["BEST_FRIEND_OF"])
+    rel_names = {r.name for r in result.relationships}
+    assert "BEST_FRIEND_OF" in rel_names
+    assert "HAS_EMPLOYEE" not in rel_names
+
+
+def test_filtered_node_filter_excludes_adjacency_with_no_matching_endpoint(
+    basic_schema,
+):
+    # Line 723: adjacency where neither endpoint touches included_nodes → continue
+    # Filter to Organization only; BEST_FRIEND_OF connects Person→Person,
+    # neither endpoint is Organization, so it should be excluded.
+    result = basic_schema.filtered(node_filter=["Organization"])
+    rel_names = {r.name for r in result.relationships}
+    assert "BEST_FRIEND_OF" not in rel_names
+    assert "HAS_EMPLOYEE" in rel_names  # Organization→Person survives
+
+
+def test_filtered_empty_lists_treated_as_no_filter(basic_schema):
+    result = basic_schema.filtered(node_filter=[], relationship_filter=[])
+    assert {n.name for n in result.nodes} == {"Person", "Organization"}
+    assert {r.name for r in result.relationships} == {"BEST_FRIEND_OF", "HAS_EMPLOYEE"}

--- a/tests/unit/test_file_io.py
+++ b/tests/unit/test_file_io.py
@@ -74,3 +74,31 @@ def test_delayed_value_resolution(mocker):
         loaded["delayed"].get_value(), LazyLoadedArgument("env", "USERNAME_FROM_ENV")
     )
     assert_that(loaded["delayed"].get_value().get_value(), equal_to("bob"))
+
+
+def test_wrap_unloaded_tag_mapping_node():
+    mapping_yaml = "config: !custom\n  key: value\n  nested: data\n"
+    LazyLoadedTagSafeLoader.add_constructor(
+        "!custom",
+        lambda loader, node: __import__(
+            "nodestream.file_io", fromlist=["wrap_unloaded_tag"]
+        ).wrap_unloaded_tag(loader, node),
+    )
+    loaded = yaml.load(mapping_yaml, Loader=LazyLoadedTagSafeLoader)
+    arg = loaded["config"]
+    assert isinstance(arg, LazyLoadedArgument)
+    assert arg.value == {"key": "value", "nested": "data"}
+
+
+def test_wrap_unloaded_tag_sequence_node():
+    sequence_yaml = "items: !custom\n  - alpha\n  - beta\n"
+    LazyLoadedTagSafeLoader.add_constructor(
+        "!custom",
+        lambda loader, node: __import__(
+            "nodestream.file_io", fromlist=["wrap_unloaded_tag"]
+        ).wrap_unloaded_tag(loader, node),
+    )
+    loaded = yaml.load(sequence_yaml, Loader=LazyLoadedTagSafeLoader)
+    arg = loaded["items"]
+    assert isinstance(arg, LazyLoadedArgument)
+    assert arg.value == ["alpha", "beta"]


### PR DESCRIPTION
## Summary

Refactors the `nodestream copy` pipeline to support plugin-driven concurrent copying with histogram-guided sharding and a clean retriever contract.

### What changed

**New `TypeRetriever` ABC** (`nodestream/databases/copy.py`)

Introduces a `TypeRetriever` abstract base class that plugins implement to own all type decomposition, shard splitting, histogram computation, and concurrency strategy. The `Copier` only sees two async generators — `fetch_nodes(schema)` and `fetch_relationships(schema)` — and drives them through a producer/consumer queue when `concurrency_limit > 1`. Plugin internals are completely invisible to core.

**Histogram-driven sharding**

At startup, `Copier` calls `build_histogram(schema)` to get record counts per type. When `shard_size` is set, each type is split into fixed-size shards that run as independent concurrent coroutines. This means:
- All 40 concurrency slots stay busy — when a large type's last shard finishes, the next type's shards fill in immediately
- No single large type can starve smaller ones
- Types without a schema key field fall back to `elementId`-based sharding automatically

**Flat retriever contract** (`nodestream/cli/commands/copy.py`, `nodestream/cli/operations/run_copy.py`)

CLI-level flags (`--retriever-option key=value`) are merged into a single flat dict passed to `make_type_retriever`. Core no longer forwards plugin-specific kwargs explicitly — each plugin pops what it understands and ignores the rest. Neptune and future plugins are unaffected.

**`expand_schema_for_copy` error visibility** (`nodestream/project/pipeline_definition.py`)

Replaced a bare `except Exception: pass` with `logger.warning(..., exc_info=True)` so silent schema expansion failures are now visible in logs.

### New CLI options

| Flag | Description |
|---|---|
| `--retriever-option key=value` | Pass arbitrary key/value options to the plugin's `TypeRetriever` (repeatable) |
| `--flush-concurrency N` | Number of parallel write lanes in the writer |
| `--step-outbox-size N` | Buffer size between pipeline steps |

### Performance

Benchmarked on a production Neo4j graph (~135M relationships, `sample_ratio=50`, `latest_hours=24`):

| | Before | After |
|---|---|---|
| Avg throughput | ~400 r/s | ~1,000–1,200 r/s |
| Histogram build | ~22 min (sequential COUNTs) | ~1 min (`asyncio.gather`) |
| Concurrency utilisation | Low (single coroutine per type) | High (40 shards in flight) |

### Test plan

- [ ] `poetry run pytest tests/unit/databases/test_copy.py` — Copier, TypeHistogram, concurrent path
- [ ] `poetry run pytest tests/unit/cli/operations/test_run_copy.py` — CLI wiring
- [ ] `poetry run pytest tests/unit/pipeline/test_pipeline_file.py` — schema-only load path
- [ ] `poetry run ruff check . && poetry run black --check . && poetry run isort --check-only .` — lint clean
