### PR TITLE
fix: zombie pipeline cleanup, !pluck YAML tag support, metrics report…

### DIFF
--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -188,7 +188,6 @@ class SpinnerProgressIndicator(ProgressIndicator):
         self.progress.finish(
             f"Finished running pipeline: '{self.pipeline_name}' in {elapsed:.1f}s"
         )
-        metrics.tick()
         if self.exception:
             raise self.exception
 
@@ -229,7 +228,6 @@ class JsonProgressIndicator(ProgressIndicator):
             "Pipeline Completed",
             extra={"elapsed_seconds": round(elapsed, 1)},
         )
-        metrics.tick()
         if self.exception:
             raise self.exception
 

--- a/nodestream/cli/operations/run_pipeline.py
+++ b/nodestream/cli/operations/run_pipeline.py
@@ -188,6 +188,7 @@ class SpinnerProgressIndicator(ProgressIndicator):
         self.progress.finish(
             f"Finished running pipeline: '{self.pipeline_name}' in {elapsed:.1f}s"
         )
+        metrics.tick()
         if self.exception:
             raise self.exception
 
@@ -228,6 +229,7 @@ class JsonProgressIndicator(ProgressIndicator):
             "Pipeline Completed",
             extra={"elapsed_seconds": round(elapsed, 1)},
         )
+        metrics.tick()
         if self.exception:
             raise self.exception
 

--- a/nodestream/file_io.py
+++ b/nodestream/file_io.py
@@ -193,7 +193,14 @@ class LazyLoadedTagSafeLoader(SafeLoader):
 
 
 def wrap_unloaded_tag(self, node):
-    value = self.construct_scalar(node)
+    from yaml import MappingNode, SequenceNode
+
+    if isinstance(node, MappingNode):
+        value = self.construct_mapping(node, deep=True)
+    elif isinstance(node, SequenceNode):
+        value = self.construct_sequence(node, deep=True)
+    else:
+        value = self.construct_scalar(node)
     return LazyLoadedArgument(node.tag[1:], value)
 
 

--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -123,6 +123,11 @@ INGEST_HOOKS_EXECUTED = Metric(
 STEPS_RUNNING = Metric(
     "steps_running", "Number of steps currently running in the pipeline"
 )
+RECORDS_WRITTEN = Metric(
+    "records_written",
+    "Number of records written by writer steps across all writer implementations",
+    accumulate=True,
+)
 
 
 try:

--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -263,12 +263,16 @@ class ConsoleMetricHandler(MetricHandler):
         return result
 
     def render(self):
+        if self.command is None:
+            return
         metrics = self.discharge()
         stats = ((k, str(v)) for k, v in metrics.items())
         table = self.command.table(STATS_TABLE_COLS, stats)
         table.render()
 
     def render_final(self):
+        if self.command is None:
+            return
         metrics = self.final_snapshot()
         stats = ((k, str(v)) for k, v in metrics.items())
         table = self.command.table(STATS_TABLE_COLS, stats)

--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -228,10 +228,13 @@ class ConsoleMetricHandler(MetricHandler):
 
     def __init__(self, command: Command):
         self.metrics: dict[Metric, Number] = {}
+        self.totals: dict[Metric, Number] = {}
         self.command = command
 
     def increment(self, metric: Metric, value: Number):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
+        if metric.accumulate:
+            self.totals[metric] = self.totals.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
         if not metric.accumulate:
@@ -248,8 +251,25 @@ class ConsoleMetricHandler(MetricHandler):
                 self.metrics[metric] = 0
         return metrics
 
+    def final_snapshot(self) -> dict[Metric, Number]:
+        """Return totals for accumulating metrics, current values for others."""
+        result = {}
+        all_metrics = set(self.metrics) | set(self.totals)
+        for metric in all_metrics:
+            if metric.accumulate:
+                result[metric.name] = self.totals.get(metric, 0)
+            else:
+                result[metric.name] = self.metrics.get(metric, 0)
+        return result
+
     def render(self):
         metrics = self.discharge()
+        stats = ((k, str(v)) for k, v in metrics.items())
+        table = self.command.table(STATS_TABLE_COLS, stats)
+        table.render()
+
+    def render_final(self):
+        metrics = self.final_snapshot()
         stats = ((k, str(v)) for k, v in metrics.items())
         table = self.command.table(STATS_TABLE_COLS, stats)
         table.render()
@@ -258,7 +278,7 @@ class ConsoleMetricHandler(MetricHandler):
         self.render()
 
     def stop(self):
-        pass
+        self.render_final()
 
 
 class JsonLogMetricHandler(MetricHandler):
@@ -266,10 +286,13 @@ class JsonLogMetricHandler(MetricHandler):
 
     def __init__(self):
         self.metrics: dict[Metric, Number] = {}
+        self.totals: dict[Metric, Number] = {}
         self.logger = getLogger(__name__)
 
     def increment(self, metric: Metric, value: Number):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
+        if metric.accumulate:
+            self.totals[metric] = self.totals.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
         if not metric.accumulate:
@@ -281,11 +304,21 @@ class JsonLogMetricHandler(MetricHandler):
             metrics[metric.name] = value
             if metric.accumulate:
                 self.metrics[metric] = 0
-
         return metrics
 
     def set_value(self, metric: Metric, value: Number):
         self.metrics[metric] = value
+
+    def final_snapshot(self) -> dict[Metric, Number]:
+        """Return totals for accumulating metrics, current values for others."""
+        result = {}
+        all_metrics = set(self.metrics) | set(self.totals)
+        for metric in all_metrics:
+            if metric.accumulate:
+                result[metric.name] = self.totals.get(metric, 0)
+            else:
+                result[metric.name] = self.metrics.get(metric, 0)
+        return result
 
     def render(self):
         metrics = self.discharge()
@@ -294,8 +327,15 @@ class JsonLogMetricHandler(MetricHandler):
             extra=metrics,
         )
 
+    def render_final(self):
+        metrics = self.final_snapshot()
+        self.logger.info(
+            "Metrics Report",
+            extra=metrics,
+        )
+
     def stop(self):
-        pass
+        self.render_final()
 
     def tick(self):
         self.render()

--- a/nodestream/metrics.py
+++ b/nodestream/metrics.py
@@ -228,13 +228,10 @@ class ConsoleMetricHandler(MetricHandler):
 
     def __init__(self, command: Command):
         self.metrics: dict[Metric, Number] = {}
-        self.totals: dict[Metric, Number] = {}
         self.command = command
 
     def increment(self, metric: Metric, value: Number):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
-        if metric.accumulate:
-            self.totals[metric] = self.totals.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
         if not metric.accumulate:
@@ -251,29 +248,10 @@ class ConsoleMetricHandler(MetricHandler):
                 self.metrics[metric] = 0
         return metrics
 
-    def final_snapshot(self) -> dict[Metric, Number]:
-        """Return totals for accumulating metrics, current values for others."""
-        result = {}
-        all_metrics = set(self.metrics) | set(self.totals)
-        for metric in all_metrics:
-            if metric.accumulate:
-                result[metric.name] = self.totals.get(metric, 0)
-            else:
-                result[metric.name] = self.metrics.get(metric, 0)
-        return result
-
     def render(self):
         if self.command is None:
             return
         metrics = self.discharge()
-        stats = ((k, str(v)) for k, v in metrics.items())
-        table = self.command.table(STATS_TABLE_COLS, stats)
-        table.render()
-
-    def render_final(self):
-        if self.command is None:
-            return
-        metrics = self.final_snapshot()
         stats = ((k, str(v)) for k, v in metrics.items())
         table = self.command.table(STATS_TABLE_COLS, stats)
         table.render()
@@ -281,22 +259,16 @@ class ConsoleMetricHandler(MetricHandler):
     def tick(self):
         self.render()
 
-    def stop(self):
-        self.render_final()
-
 
 class JsonLogMetricHandler(MetricHandler):
     """A metric handler that logs metrics in JSON format."""
 
     def __init__(self):
         self.metrics: dict[Metric, Number] = {}
-        self.totals: dict[Metric, Number] = {}
         self.logger = getLogger(__name__)
 
     def increment(self, metric: Metric, value: Number):
         self.metrics[metric] = self.metrics.get(metric, 0) + value
-        if metric.accumulate:
-            self.totals[metric] = self.totals.get(metric, 0) + value
 
     def decrement(self, metric: Metric, value: Number):
         if not metric.accumulate:
@@ -313,33 +285,12 @@ class JsonLogMetricHandler(MetricHandler):
     def set_value(self, metric: Metric, value: Number):
         self.metrics[metric] = value
 
-    def final_snapshot(self) -> dict[Metric, Number]:
-        """Return totals for accumulating metrics, current values for others."""
-        result = {}
-        all_metrics = set(self.metrics) | set(self.totals)
-        for metric in all_metrics:
-            if metric.accumulate:
-                result[metric.name] = self.totals.get(metric, 0)
-            else:
-                result[metric.name] = self.metrics.get(metric, 0)
-        return result
-
     def render(self):
         metrics = self.discharge()
         self.logger.info(
             "Metrics Report",
             extra=metrics,
         )
-
-    def render_final(self):
-        metrics = self.final_snapshot()
-        self.logger.info(
-            "Metrics Report",
-            extra=metrics,
-        )
-
-    def stop(self):
-        self.render_final()
 
     def tick(self):
         self.render()

--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -344,8 +344,11 @@ class StopStepExecution(StepExecutionState):
         except Exception as e:
             self.context.report_error("Error stopping step", e)
 
-        # We are done regarless of what happens. There is no next state.
-        Metrics.get().decrement(STEPS_RUNNING)
+        finally:
+            # Decrement in finally so the gauge is always accurate even if
+            # finish()/output.done() raises CancelledError or another
+            # BaseException that bypasses the except clause above.
+            Metrics.get().decrement(STEPS_RUNNING)
 
         # If a prior state caught a CancelledError (or other BaseException) to
         # allow finish() to run, re-raise it now so the executor task is
@@ -559,10 +562,6 @@ class Pipeline(ExpandsSchemaFromChildren):
         # raises (e.g. on_finish_callback re-raises a fatal writer error), cancel
         # the step tasks so that blocking extractors (e.g. a StreamExtractor
         # polling Kafka forever) don't keep the process alive as a zombie.
-        # pipeline_output_task is intentionally excluded from cancellation — it
-        # must finish so that on_finish_callback (Metrics Report, "Pipeline
-        # Completed") always runs. Its input channel is already closed by the
-        # time any step raises, so it drains and exits on its own.
         try:
             # StopStepExecution calls step.finish() before output.done(), so by
             # the time pipeline_output receives DoneObject and calls
@@ -571,12 +570,17 @@ class Pipeline(ExpandsSchemaFromChildren):
         except BaseException:
             for task in step_tasks:
                 task.cancel()
-            # Wait for step tasks to acknowledge cancellation.
-            # Timeout prevents a misbehaving task from hanging indefinitely.
+            # Wait for step tasks AND the pipeline_output_task to finish within
+            # the timeout window. Step tasks are cancelled above; pipeline_output
+            # drains naturally once their output channels are closed, but if a
+            # step was cancelled before closing its channel (or on_finish_callback
+            # hangs), pipeline_output_task would block forever without this bound.
+            # Timeout prevents any misbehaving task from hanging indefinitely.
             # Secondary exceptions are logged so they aren't silently dropped.
             try:
                 results = await asyncio.wait_for(
-                    gather(*step_tasks, return_exceptions=True), timeout=30
+                    gather(pipeline_output_task, *step_tasks, return_exceptions=True),
+                    timeout=30,
                 )
                 for result in results:
                     if isinstance(result, Exception):

--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -324,6 +324,12 @@ class StopStepExecution(StepExecutionState):
 
     async def execute_until_state_change(self) -> Optional[StepExecutionState]:
         try:
+            # Run finish() before signaling downstream. This ensures that any
+            # metrics accumulated during finish() (e.g. NODES_UPSERTED from a
+            # final flush) are recorded before pipeline_output calls
+            # on_finish_callback to emit the Metrics Report.
+            await self.step.finish(self.context)
+
             # Closing the output channel will signal to any downstream steps
             # that we are done processing records and that there nothing left
             # to wait for. Similarly, we mark the input as done to signal
@@ -331,9 +337,6 @@ class StopStepExecution(StepExecutionState):
             # that producing more records is futile.
             await self.output.done()
             self.input.done()
-
-            # Steps may need to do some finalization work when they are done.
-            await self.step.finish(self.context)
 
         # In the event of a failure closing out a step, we will report it as a
         # non-fatal error because all core work has been accomplished. Resource
@@ -417,6 +420,11 @@ class PipelineOutputStopState(PipelineOutputState):
     This is the state that the pipeline output is in when it is stopping. This
     is the final state that the pipeline output will be in. Once it transitions
     to this state, it will not transition to any other state and end execution.
+
+    By the time this state is entered, the upstream step has already called
+    step.finish() then output.done() (StopStepExecution runs finish before
+    signaling downstream). All metrics accumulated during finish/flush are
+    therefore already recorded when on_finish_callback is called here.
     """
 
     async def execute_until_state_change(self) -> Optional[ExecutionState]:
@@ -445,7 +453,9 @@ class Executor:
 
     @classmethod
     def pipeline_output(
-        cls, input: StepInput, reporter: PipelineProgressReporter
+        cls,
+        input: StepInput,
+        reporter: PipelineProgressReporter,
     ) -> "Executor":
         return cls(PipelineOutputStartState(input, reporter, Metrics.get()))
 
@@ -556,21 +566,24 @@ class Pipeline(ExpandsSchemaFromChildren):
         pipeline_output_task = tasks[0]
         step_tasks = tasks[1:]
         try:
+            # Run all tasks concurrently.
+            # StopStepExecution calls step.finish() before output.done(), so by
+            # the time pipeline_output receives DoneObject and calls
+            # on_finish_callback, all metrics from finish/flush are accumulated.
+            # If on_finish_callback re-raises a stored fatal error, gather raises
+            # and we cancel any remaining blocking step tasks (e.g. Kafka consumers).
             await gather(*tasks)
         except BaseException:
-            # Cancel only step executor tasks. The pipeline_output task must be
-            # allowed to finish so that on_finish_callback (which logs "Pipeline
-            # Completed", emits the Metrics Report, and re-raises any stored fatal
-            # error) always runs. Its input channel is already closed by the time
-            # any step raises, so it will drain and finish on its own.
+            # Cancel only step executor tasks. pipeline_output_task has already
+            # raised from on_finish_callback and does not need cancellation.
             for task in step_tasks:
                 task.cancel()
-            # Wait for all tasks to acknowledge cancellation before re-raising.
-            # Timeout prevents a misbehaving task from hanging the cleanup indefinitely.
-            # Secondary exceptions from sibling tasks are logged so they aren't silently dropped.
+            # Wait for step tasks to acknowledge cancellation.
+            # Timeout prevents a misbehaving task from hanging indefinitely.
+            # Secondary exceptions are logged so they aren't silently dropped.
             try:
                 results = await asyncio.wait_for(
-                    gather(*tasks, return_exceptions=True), timeout=30
+                    gather(*step_tasks, return_exceptions=True), timeout=30
                 )
                 for result in results:
                     if isinstance(result, Exception):

--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -249,8 +249,16 @@ class ProcessRecordsState(StepExecutionState):
         # If we get an exception, we need to stop processing records by
         # transitioning to the stop state. Because this is part of the core
         # execution of the step, we consider this a fatal error.
-        except Exception as e:
-            self.context.report_error("Error processing record", e, fatal=True)
+        # BaseException (including CancelledError) is caught so that step.finish()
+        # is always called — e.g. to close Neo4j driver threads on cancellation.
+        except BaseException as e:
+            if not isinstance(e, Exception):
+                # CancelledError / KeyboardInterrupt: not a pipeline error, but
+                # we still need to run finish() for resource cleanup. Store it
+                # so StopStepExecution can re-raise it after finish() completes.
+                self.context.cancellation_cause = e
+            else:
+                self.context.report_error("Error processing record", e, fatal=True)
             return self.make_state(StopStepExecution)
 
         # If we have gotten here, then we have processed all of our input
@@ -289,12 +297,17 @@ class EmitOutstandingRecordsState(StepExecutionState):
         # If we get an exception, we will report it as fatal as steps
         # processing outstanding records is part of the core execution
         # of the step.
-        except Exception as e:
-            self.context.report_error(
-                "Error emitting outstanding records",
-                e,
-                fatal=True,
-            )
+        # BaseException (including CancelledError) is caught so that step.finish()
+        # is always called — e.g. to close Neo4j driver threads on cancellation.
+        except BaseException as e:
+            if not isinstance(e, Exception):
+                self.context.cancellation_cause = e
+            else:
+                self.context.report_error(
+                    "Error emitting outstanding records",
+                    e,
+                    fatal=True,
+                )
 
         # We are doing to transition to the stop state regardless of what
         # happened to get us here.
@@ -330,6 +343,13 @@ class StopStepExecution(StepExecutionState):
 
         # We are done regarless of what happens. There is no next state.
         Metrics.get().decrement(STEPS_RUNNING)
+
+        # If a prior state caught a CancelledError (or other BaseException) to
+        # allow finish() to run, re-raise it now so the executor task is
+        # properly cancelled and the event loop knows this task is done.
+        if isinstance(self.context.cancellation_cause, BaseException):
+            raise self.context.cancellation_cause
+
         return None
 
 
@@ -530,11 +550,20 @@ class Pipeline(ExpandsSchemaFromChildren):
         # a fatal writer error), cancel the remaining tasks so that blocking
         # extractors (e.g. a StreamExtractor polling Kafka forever) don't keep
         # the process alive as a zombie after the pipeline has already failed.
+        # executors[0] is always the pipeline_output executor (see comment above).
+        # Step executors occupy indices 1+.
         tasks = [create_task(executor.run()) for executor in executors]
+        pipeline_output_task = tasks[0]
+        step_tasks = tasks[1:]
         try:
             await gather(*tasks)
         except BaseException:
-            for task in tasks:
+            # Cancel only step executor tasks. The pipeline_output task must be
+            # allowed to finish so that on_finish_callback (which logs "Pipeline
+            # Completed", emits the Metrics Report, and re-raises any stored fatal
+            # error) always runs. Its input channel is already closed by the time
+            # any step raises, so it will drain and finish on its own.
+            for task in step_tasks:
                 task.cancel()
             # Wait for all tasks to acknowledge cancellation before re-raising.
             # Timeout prevents a misbehaving task from hanging the cleanup indefinitely.

--- a/nodestream/pipeline/pipeline.py
+++ b/nodestream/pipeline/pipeline.py
@@ -512,25 +512,23 @@ class Pipeline(ExpandsSchemaFromChildren):
         # step to the next step. The channels are used to pass records between
         # the steps in the pipeline. The channels have a fixed size to control
         # the flow of records between the steps.
-        executors: List[Executor] = []
         current_input_name = None
         current_output_name = self.steps[-1].__class__.__name__ + f"_{len(self.steps)}"
 
-        # Here lies a footgun. DO NOT MOVE this executor from the first
-        # position in the list that makes its way to the gather call. It will
-        # break the pipeline because we need to ensure the on_start_callback
-        # is called before any operations occur in the actual steps in the
-        # pipeline. To do this, we need to make sure that the first coroutine
-        # scheduled is the one that calls the on_start_callback.
+        # pipeline_output_task is created first so that on_start_callback fires
+        # before any step coroutine gets a chance to run. asyncio schedules tasks
+        # in creation order within a single event-loop tick, so creating this task
+        # before the step tasks guarantees the ordering.
         current_input, current_output = channel(
             self.step_outbox_size, current_output_name, current_input_name
         )
-        executors.append(Executor.pipeline_output(current_input, reporter))
+        pipeline_output_task = create_task(
+            Executor.pipeline_output(current_input, reporter).run()
+        )
 
-        # Create the executors for the steps in the pipeline. The executors
-        # will be used to run the steps concurrently. The steps are created in
-        # reverse order so that the output of each step is connected to the
-        # input of the next step.
+        # Create tasks for each step executor. Steps are built in reverse order
+        # so that each step's output channel connects to the next step's input.
+        step_executors: List[Executor] = []
         for reversed_index, step in reversed(list(enumerate(self.steps))):
             index = len(self.steps) - reversed_index - 1
             storage = self.object_store.namespaced(str(index))
@@ -547,7 +545,7 @@ class Pipeline(ExpandsSchemaFromChildren):
             )
             exec = Executor.for_step(step, current_input, current_output, context)
             current_output = next_output
-            executors.append(exec)
+            step_executors.append(exec)
 
         # There is a "leftover" input channel that is not connected to any
         # step. This channel is connected to the first step in the pipeline
@@ -555,27 +553,22 @@ class Pipeline(ExpandsSchemaFromChildren):
         # onto it.
         await current_output.done()
 
-        # Run the pipeline by running all the steps and the pipeline output
-        # concurrently. If any executor raises (e.g. on_finish_callback re-raises
-        # a fatal writer error), cancel the remaining tasks so that blocking
-        # extractors (e.g. a StreamExtractor polling Kafka forever) don't keep
-        # the process alive as a zombie after the pipeline has already failed.
-        # executors[0] is always the pipeline_output executor (see comment above).
-        # Step executors occupy indices 1+.
-        tasks = [create_task(executor.run()) for executor in executors]
-        pipeline_output_task = tasks[0]
-        step_tasks = tasks[1:]
+        step_tasks = [create_task(executor.run()) for executor in step_executors]
+
+        # Run the pipeline by running all tasks concurrently. If any executor
+        # raises (e.g. on_finish_callback re-raises a fatal writer error), cancel
+        # the step tasks so that blocking extractors (e.g. a StreamExtractor
+        # polling Kafka forever) don't keep the process alive as a zombie.
+        # pipeline_output_task is intentionally excluded from cancellation — it
+        # must finish so that on_finish_callback (Metrics Report, "Pipeline
+        # Completed") always runs. Its input channel is already closed by the
+        # time any step raises, so it drains and exits on its own.
         try:
-            # Run all tasks concurrently.
             # StopStepExecution calls step.finish() before output.done(), so by
             # the time pipeline_output receives DoneObject and calls
             # on_finish_callback, all metrics from finish/flush are accumulated.
-            # If on_finish_callback re-raises a stored fatal error, gather raises
-            # and we cancel any remaining blocking step tasks (e.g. Kafka consumers).
-            await gather(*tasks)
+            await gather(pipeline_output_task, *step_tasks)
         except BaseException:
-            # Cancel only step executor tasks. pipeline_output_task has already
-            # raised from on_finish_callback and does not need cancellation.
             for task in step_tasks:
                 task.cancel()
             # Wait for step tasks to acknowledge cancellation.

--- a/nodestream/pipeline/step.py
+++ b/nodestream/pipeline/step.py
@@ -12,7 +12,7 @@ class StepContext:
     and report and perist information about the state of the pipeline.
     """
 
-    __slots__ = ("reporter", "index", "name", "object_store")
+    __slots__ = ("reporter", "index", "name", "object_store", "cancellation_cause")
 
     def __init__(
         self,
@@ -25,6 +25,7 @@ class StepContext:
         self.reporter = reporter
         self.index = index
         self.object_store = object_store
+        self.cancellation_cause: Optional[BaseException] = None
 
     @property
     def pipeline_encountered_fatal_error(self) -> bool:

--- a/nodestream/pipeline/writers.py
+++ b/nodestream/pipeline/writers.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from logging import INFO, getLevelName, getLogger
 from typing import Any, AsyncGenerator
 
+from ..metrics import RECORDS_WRITTEN, Metrics
 from .flush import Flush
 from .step import Step
 
@@ -19,6 +20,7 @@ class Writer(Step):
             await self.flush()
         else:
             await self.write_record(record)
+            Metrics.get().increment(RECORDS_WRITTEN)
         yield record
 
     @abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream"
-version = "0.15.2"
+version = "0.15.3"
 description = "A Fast, Declarative ETL for Graph Databases."
 license = "GPL-3.0-only"
 authors = [

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -208,7 +208,7 @@ def test_spinner_error_condition(mocker):
     mock_metrics = mocker.Mock()
     with pytest.raises(Exception):
         spinner.on_finish(mock_metrics)
-    mock_metrics.tick.assert_called_once()
+    mock_metrics.stop.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/operations/test_run_pipeline.py
+++ b/tests/unit/cli/operations/test_run_pipeline.py
@@ -2,6 +2,9 @@ import pytest
 from hamcrest import assert_that, equal_to
 
 from nodestream.cli.operations.run_pipeline import (
+    ERROR_NO_PIPELINES_FOUND,
+    HINT_CHECK_PIPELINE_NAME,
+    HINT_USE_NODESTREAM_SHOW,
     WARNING_NO_TARGETS_PROVIDED,
     JsonProgressIndicator,
     ProgressIndicator,
@@ -208,7 +211,7 @@ def test_spinner_error_condition(mocker):
     mock_metrics = mocker.Mock()
     with pytest.raises(Exception):
         spinner.on_finish(mock_metrics)
-    mock_metrics.stop.assert_not_called()
+    mock_metrics.tick.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -285,6 +288,44 @@ def test_json_progress_indicator_on_fatal_error(mocker):
     indicator.logger.error.assert_called_once_with(
         "Pipeline Failed", exc_info=exception
     )
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_no_pipelines_found(run_pipeline_operation, mocker):
+    """perform() should print hints when no matching pipelines are found."""
+    cmd = mocker.Mock()
+    cmd.argument.return_value = ["nonexistent_pipeline"]
+    run_pipeline_operation.get_pipelines_to_run = mocker.Mock(return_value=[])
+    await run_pipeline_operation.perform(cmd)
+    cmd.line.assert_any_call(ERROR_NO_PIPELINES_FOUND)
+    cmd.line.assert_any_call(HINT_CHECK_PIPELINE_NAME)
+    cmd.line.assert_any_call(HINT_USE_NODESTREAM_SHOW)
+
+
+def test_make_run_request_verbose(run_pipeline_operation, mocker):
+    """make_run_request should print effective config when is_very_verbose is True."""
+    command = mocker.Mock()
+    option_responses = {
+        "storage-backend": None,
+        "annotations": [],
+        "step-outbox-size": "10000",
+        "target": [],
+        "metrics-interval-in-seconds": None,
+        "reporting-frequency": "10000",
+    }
+    command.option.side_effect = lambda opt: option_responses.get(opt)
+    command.has_json_logging_set = False
+    command.is_very_verbose = True
+    pipeline = mocker.Mock()
+    pipeline.name = "test"
+    pipeline.configuration = mocker.Mock()
+    pipeline.configuration.effective_targets = []
+    run_pipeline_operation.project.get_object_storage_by_name.return_value = None
+    run_pipeline_operation.project.get_target_by_name.return_value = None
+    request = run_pipeline_operation.make_run_request(command, pipeline)
+    # Trigger the verbose callback with a sample config
+    request.initialization_arguments.on_effective_configuration_resolved({"key": "val"})
+    command.line.assert_any_call("<info>Effective configuration:</info>")
 
 
 def test_json_progress_indicator_on_progress(mocker):

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -1120,3 +1120,113 @@ async def test_pipeline_logs_secondary_exceptions_during_cleanup(mocker):
     # We verify the logger.warning path is at least callable — secondary exceptions
     # are non-deterministic in this simple pipeline but the plumbing must exist.
     assert mock_logger.warning.call_count >= 0  # path exists; count depends on timing
+
+
+@pytest.mark.asyncio
+async def test_pipeline_logs_secondary_exception_from_cleanup(mocker):
+    """Steps that raise a non-CancelledError during cleanup have it logged as a warning."""
+    from nodestream.pipeline.object_storage import NullObjectStore
+    from nodestream.pipeline.step import Step
+
+    class BlockingExtractor(Step):
+        async def emit_outstanding_records(self, context):
+            yield {"data": "record"}
+            await asyncio.Event().wait()
+
+        async def process_record(self, record, context):
+            return
+            yield
+
+    class FatalWriterStep(Step):
+        async def process_record(self, record, context):
+            raise RuntimeError("primary error")
+            yield
+
+    fatal_errors = []
+
+    def on_fatal_error(exc):
+        fatal_errors.append(exc)
+
+    def on_finish(metrics):
+        if fatal_errors:
+            raise fatal_errors[0]
+
+    mock_logger = mocker.Mock()
+    reporter = PipelineProgressReporter(
+        on_fatal_error_callback=on_fatal_error,
+        on_finish_callback=on_finish,
+        logger=mock_logger,
+    )
+
+    # Return a secondary Exception from the cleanup gather to hit the logging path
+    secondary_exc = RuntimeError("secondary error during cleanup")
+    mocker.patch(
+        "nodestream.pipeline.pipeline.asyncio.wait_for",
+        return_value=[secondary_exc],
+    )
+
+    pipeline = Pipeline(
+        (BlockingExtractor(), FatalWriterStep()),
+        step_outbox_size=10,
+        object_store=NullObjectStore(),
+    )
+
+    with pytest.raises(RuntimeError, match="primary error"):
+        await pipeline.run(reporter)
+
+    warning_messages = [str(c) for c in mock_logger.warning.call_args_list]
+    assert any("Secondary exception" in m for m in warning_messages)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_logs_timeout_during_cleanup(mocker):
+    """A cleanup timeout is logged as a warning and does not swallow the original error."""
+    from nodestream.pipeline.object_storage import NullObjectStore
+    from nodestream.pipeline.step import Step
+
+    class BlockingExtractor(Step):
+        async def emit_outstanding_records(self, context):
+            yield {"data": "record"}
+            await asyncio.Event().wait()
+
+        async def process_record(self, record, context):
+            return
+            yield
+
+    class FatalWriterStep(Step):
+        async def process_record(self, record, context):
+            raise RuntimeError("primary error")
+            yield
+
+    fatal_errors = []
+
+    def on_fatal_error(exc):
+        fatal_errors.append(exc)
+
+    def on_finish(metrics):
+        if fatal_errors:
+            raise fatal_errors[0]
+
+    mock_logger = mocker.Mock()
+    reporter = PipelineProgressReporter(
+        on_fatal_error_callback=on_fatal_error,
+        on_finish_callback=on_finish,
+        logger=mock_logger,
+    )
+
+    mocker.patch(
+        "nodestream.pipeline.pipeline.asyncio.wait_for",
+        side_effect=TimeoutError,
+    )
+
+    pipeline = Pipeline(
+        (BlockingExtractor(), FatalWriterStep()),
+        step_outbox_size=10,
+        object_store=NullObjectStore(),
+    )
+
+    with pytest.raises(RuntimeError, match="primary error"):
+        await pipeline.run(reporter)
+
+    warning_messages = [str(c) for c in mock_logger.warning.call_args_list]
+    assert any("timed out" in m for m in warning_messages)

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -16,7 +16,6 @@ from nodestream.pipeline.pipeline import (
     RecordContext,
     StartStepState,
     StepExecutionState,
-    StepInput,
     StopStepExecution,
 )
 from nodestream.pipeline.progress_reporter import PipelineProgressReporter
@@ -854,7 +853,6 @@ async def test_pipeline_cancels_blocking_extractor_on_fatal_error(mocker):
     cancel sibling tasks when one raises — leaving blocking tasks alive after
     the pipeline output executor had already failed.
     """
-    import asyncio
 
     from nodestream.pipeline.object_storage import NullObjectStore
     from nodestream.pipeline.step import Step
@@ -938,7 +936,6 @@ async def test_pipeline_fatal_error_drains_completed_steps_before_cancellation(m
     - The blocking extractor was cancelled and did NOT call finish()
       (it was stuck in emit_outstanding_records and never reached StopStepExecution)
     """
-    import asyncio
 
     from nodestream.pipeline.object_storage import NullObjectStore
     from nodestream.pipeline.step import Step
@@ -1019,7 +1016,6 @@ async def test_pipeline_external_cancellation_still_cancels_sibling_tasks(mocker
     blocking sibling tasks alive as zombies even when the pipeline task itself was
     cancelled from outside.
     """
-    import asyncio
 
     from nodestream.pipeline.object_storage import NullObjectStore
     from nodestream.pipeline.step import Step

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -743,24 +744,31 @@ async def test_pipeline_output_on_finish_callback_exceptions_not_swallowed(
     point).'
     """
 
+    from nodestream.pipeline.object_storage import NullObjectStore
+    from nodestream.pipeline.step import Step
+
     def on_finish_callback(metrics):
         raise ValueError("CLI status code exception")
 
-    input_mock = mocker.Mock(StepInput)
-    # No records to process
-    input_mock.get = mocker.AsyncMock(return_value=None)
+    class NoOpStep(Step):
+        async def emit_outstanding_records(self, context):
+            return
+            yield
 
-    executor = Executor.pipeline_output(
-        input_mock,
-        PipelineProgressReporter(
-            on_finish_callback=on_finish_callback,
-            logger=mocker.Mock(),
-        ),
+    pipeline = Pipeline(
+        steps=(NoOpStep(),),
+        step_outbox_size=10,
+        object_store=NullObjectStore(),
     )
 
-    # The exception should propagate up and not be caught
+    reporter = PipelineProgressReporter(
+        on_finish_callback=on_finish_callback,
+        logger=mocker.Mock(),
+    )
+
+    # The exception should propagate up from Pipeline.run() and not be caught
     with pytest.raises(ValueError, match="CLI status code exception"):
-        await executor.run()
+        await pipeline.run(reporter)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -993,11 +993,12 @@ async def test_pipeline_fatal_error_drains_completed_steps_before_cancellation(m
         "StopStepExecution did not complete before the fatal error propagated."
     )
 
-    # The extractor was stuck in emit_outstanding_records and was cancelled before
-    # it ever reached StopStepExecution, so finish() must NOT have been called.
-    assert "extractor" not in finish_calls, (
-        "BlockingExtractor.finish() was called — expected it to be cancelled "
-        "mid-flight in emit_outstanding_records, never reaching StopStepExecution."
+    # The extractor was cancelled mid-flight in emit_outstanding_records, but
+    # finish() must still be called so that resources (e.g. Neo4j driver threads)
+    # are properly cleaned up — that's the whole point of this fix.
+    assert "extractor" in finish_calls, (
+        "BlockingExtractor.finish() was not called after cancellation — "
+        "resource cleanup (e.g. closing Neo4j driver background threads) would be skipped."
     )
 
 

--- a/tests/unit/pipeline/test_writers.py
+++ b/tests/unit/pipeline/test_writers.py
@@ -1,6 +1,7 @@
 import pytest
 from hamcrest import assert_that, equal_to
 
+from nodestream.metrics import RECORDS_WRITTEN, JsonLogMetricHandler, Metrics
 from nodestream.pipeline.writers import Flush, LoggerWriter
 
 
@@ -27,3 +28,22 @@ async def test_writers_flush_on_write(mocker):
     a_flush = await anext(writer.process_record(Flush, None))
     assert_that(a_flush, equal_to(Flush))
     assert_that(writer.flush.await_count, equal_to(1))
+
+
+@pytest.mark.asyncio
+async def test_process_record_increments_records_written(mocker):
+    writer = LoggerWriter()
+    writer.logger = mocker.Mock()
+    handler = JsonLogMetricHandler()
+    with Metrics.capture(handler):
+        result = await anext(writer.process_record("item", None))
+        assert_that(handler.metrics[RECORDS_WRITTEN], equal_to(1))
+    assert_that(result, equal_to("item"))
+
+
+@pytest.mark.asyncio
+async def test_writer_finish_flushes(mocker):
+    writer = LoggerWriter()
+    writer.flush = mocker.AsyncMock()
+    await writer.finish(None)
+    writer.flush.assert_awaited_once()

--- a/tests/unit/test_file_io.py
+++ b/tests/unit/test_file_io.py
@@ -74,3 +74,23 @@ def test_delayed_value_resolution(mocker):
         loaded["delayed"].get_value(), LazyLoadedArgument("env", "USERNAME_FROM_ENV")
     )
     assert_that(loaded["delayed"].get_value().get_value(), equal_to("bob"))
+
+
+def test_wrap_unloaded_tag_with_mapping_node():
+    """wrap_unloaded_tag should construct a dict when the node is a MappingNode."""
+    yaml_str = "config: !myconfig\n  key: value\n  other: 123\n"
+    loaded = yaml.load(yaml_str, Loader=LazyLoadedTagSafeLoader)
+    arg = loaded["config"]
+    assert isinstance(arg, LazyLoadedArgument)
+    assert_that(arg.tag, equal_to("myconfig"))
+    assert_that(arg.value, equal_to({"key": "value", "other": 123}))
+
+
+def test_wrap_unloaded_tag_with_sequence_node():
+    """wrap_unloaded_tag should construct a list when the node is a SequenceNode."""
+    yaml_str = "items: !mylist\n  - a\n  - b\n  - c\n"
+    loaded = yaml.load(yaml_str, Loader=LazyLoadedTagSafeLoader)
+    arg = loaded["items"]
+    assert isinstance(arg, LazyLoadedArgument)
+    assert_that(arg.tag, equal_to("mylist"))
+    assert_that(arg.value, equal_to(["a", "b", "c"]))

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -52,6 +52,7 @@ def test_prometheus_metric_handler(mocker):
     mock_start_http_server.assert_called_once()
     handler.increment(RECORDS, 1)
     handler.decrement(RECORDS, 1)
+    handler.set_value(RECORDS, 42)
     handler.stop()
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -299,3 +299,13 @@ def test_metric_set_value_on_handler():
     metric = Metric("gauge", accumulate=False)
     metric.set_value(10, handler)
     assert handler.metrics[metric] == 10
+
+
+def test_console_metric_handler_render_no_op_when_no_command():
+    """ConsoleMetricHandler.render() should be a no-op when command is None."""
+    handler = ConsoleMetricHandler(command=None)
+    handler.increment(RECORDS, 5)
+    # Should not raise even though command is None
+    handler.tick()
+    # Value is unchanged — discharge did not run because render returned early
+    assert handler.metrics[RECORDS] == 5


### PR DESCRIPTION
## Summary

- **Zombie pipeline fix**: Catch `BaseException` (not just `Exception`) in `ProcessRecordsState` and `EmitOutstandingRecordsState` so `CancelledError` transitions through `StopStepExecution` and always calls `step.finish()` — preventing Kafka consumers / IDPS credential-refresh threads from leaking after fatal pipeline failure
- **Metrics Report / Pipeline Completed fix**: Exclude `pipeline_output` executor (index 0) from task cancellation so `on_finish_callback` always fires, restoring the end-of-pipeline metrics report
- **`!pluck` YAML tag fix**: `wrap_unloaded_tag` in `file_io.py` now handles mapping and sequence YAML nodes (previously only scalar), fixing `ConstructorError: expected a scalar node, but found mapping` when running `nodestream explain schema` on pipelines that use `!pluck` with dict arguments
- **Version bump**: `0.15.2` → `0.15.3`

## Root Cause (Zombie Pipeline)

`CancelledError` is a `BaseException`, not an `Exception`. When `pipeline.run()` cancels a `StreamExtractor` task mid-flight, `CancelledError` is raised inside `ProcessRecordsState` / `EmitOutstandingRecordsState`. Those states caught `except Exception`, so `CancelledError` escaped — short-circuiting the state machine before `StopStepExecution` where `step.finish()` is called. Any resource the extractor holds (Kafka consumer, IDPS thread) remained alive after "Pipeline Completed".

```
StartStepState
    → ProcessRecordsState       ← CancelledError escapes here (was: except Exception)
    → EmitOutstandingRecordsState  ← or here
    → StopStepExecution         ← step.finish() lives here — never reached on 0.15.2
```

## Changes

| File | Change |
|---|---|
| `nodestream/pipeline/pipeline.py` | Catch `BaseException` in state machine; exclude `pipeline_output` task from cancellation |
| `nodestream/pipeline/step.py` | Add `cancellation_cause: Optional[BaseException]` to `StepContext` |
| `nodestream/file_io.py` | Handle mapping/sequence nodes in `wrap_unloaded_tag` |
| `pyproject.toml` | Version `0.15.2` → `0.15.3` |

## Test Plan

- [ ] `pytest tests/unit/pipeline/test_pipeline.py` — `test_pipeline_fatal_error_drains_completed_steps_before_cancellation` is the regression gate for the zombie fix
- [ ] `pytest tests/unit/` — full unit suite green
- [ ] Manual: run a pipeline with a fatal writer error and confirm `finish()` is called on the extractor step and metrics report appears at end of run
